### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,11 +1,16 @@
 ---
-title: 'Feature request'
-labels: feature
-about: Suggest an idea for this project.
+name: 'Bug report'
+about: Tell us about a problem you are experiencing.
+
 ---
 
-**Describe the solution you'd like**
-[A clear and concise description of what you want to happen.]
+/kind bug
+
+**What steps did you take and what happened:**
+[A clear and concise description of what the bug is.]
+
+
+**What did you expect to happen:**
 
 
 **Anything else you would like to add:**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,14 +1,13 @@
 ---
-title: 'Bug report'
-labels: bug
-about: Tell us about a problem you are experiencing.
+name: 'Feature request'
+about: Suggest an idea for this project.
+
 ---
 
-**What steps did you take and what happened:**
-[A clear and concise description of what the bug is.]
+/kind feature
 
-
-**What did you expect to happen:**
+**Describe the solution you'd like**
+[A clear and concise description of what you want to happen.]
 
 
 **Anything else you would like to add:**


### PR DESCRIPTION
These fixes are required for Github to register these markdown files as issue templates.