### PR TITLE
lint: Update golangci-lint and fix gocyclo issues reported by golangci- lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+linters-settings:
+  gocyclo:
+    min-complexity: 15
 linters:
   enable:
     - golint
@@ -22,3 +25,7 @@ linters:
 issue:
   max-same-issues: 0
 max-per-linter: 0
+
+run:
+  skip-dirs:
+    - build

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,8 +88,8 @@ go_repository(
     name = "com_github_golangci_golangci-lint",
     build_file_generation = "on",
     importpath = "github.com/golangci/golangci-lint",
-    strip_prefix = "golangci-lint-4570c043a9b56ccf0372cb6ba7a8b645d92b3357",
-    urls = ["https://github.com/golangci/golangci-lint/archive/4570c043a9b56ccf0372cb6ba7a8b645d92b3357.zip"],
+    strip_prefix = "golangci-lint-901cf25e20f86b7e9dc6f73eaba5afbd0cbdc257", #
+    urls = ["https://github.com/golangci/golangci-lint/archive/901cf25e20f86b7e9dc6f73eaba5afbd0cbdc257.zip"],
 )
 
 go_repository(

--- a/scripts/ci-bazel-lint.sh
+++ b/scripts/ci-bazel-lint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+cd $REPO_ROOT
+golangci-lint run


### PR DESCRIPTION
Fix golangci-lint  issues in the repo. Let's enforce some code quality :) !

```release-note
Update Golangci-lint version and fix linting issues reported by golangci-lint.
```

This PR includes the following changes

i) Add bazel CI script to run the linter.
ii) Add `gocyclo` settings to the GolangCI yaml.
iii) Fix the `gocyclo` failure in `virtualmachines.go`.
`Line 76: warning: cyclomatic complexity 18 of function (*Service).createVM() is high (> 15) (gocyclo)`