### PR TITLE
Update cluster-api dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1060,7 +1060,7 @@
   version = "v1.13.4"
 
 [[projects]]
-  digest = "1:a027ce065fff86c54a06cda8e6eb07e62f7d131c9f10dc0b69f68468bf64baf5"
+  digest = "1:85714ffbf80a9cd2a26951a7c5b75a6e2fea1b1d38e17abd36fa9c8f5c7ba6ef"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "cmd/clusterctl/clientcmd",
@@ -1088,7 +1088,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "b59602c29d9d9d045d52deebf351a91fed09a951"
+  revision = "af298a2a480fb7143786cf4f9990e741855f08e9"
 
 [[projects]]
   digest = "1:743eebdcc3e564ed574b3fa0c10c223f5edeba6ee2e3c625c345c1604432a8f1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,7 @@ required = [
 
 [[constraint]]
   name = "sigs.k8s.io/cluster-api"
-  revision = "b59602c29d9d9d045d52deebf351a91fed09a951"
+  revision = "af298a2a480fb7143786cf4f9990e741855f08e9"
 
 # TODO: It's currently necessary to pin this to kubernetes-1.13.1, instead of
 # kubernetes-1.13.4, due to some transitive dependencies upstream.

--- a/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/vendor/sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -388,17 +388,18 @@ func (c *client) GetMachinesForCluster(cluster *clusterv1.Cluster) ([]*clusterv1
 		return nil, errors.Wrapf(err, "error listing Machines for Cluster %s/%s", cluster.Namespace, cluster.Name)
 	}
 	var machines []*clusterv1.Machine
-	for _, m := range machineslist.Items {
+
+	for i := 0; i < len(machineslist.Items); i++ {
+		m := &machineslist.Items[i]
+
 		for _, or := range m.GetOwnerReferences() {
 			if or.Kind == cluster.Kind && or.Name == cluster.Name {
-				machines = append(machines, &m)
-				continue
+				machines = append(machines, m)
+				break
 			}
 		}
 	}
-	for i := 0; i < len(machineslist.Items); i++ {
-		machines = append(machines, &machineslist.Items[i])
-	}
+
 	return machines, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**What this PR does / why we need it**:
ref: kubernetes-sigs/cluster-api#816

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/milestone v1alpha1
/priority important-soon
/kind feature