### PR TITLE
Allow user userdata

### DIFF
--- a/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 )
@@ -41,6 +42,10 @@ type AzureMachineProviderSpec struct {
 	OSDisk        OSDisk        `json:"osDisk"`
 	SSHPublicKey  string        `json:"sshPublicKey"`
 	SSHPrivateKey string        `json:"sshPrivateKey"`
+	// UserDataSecret contains a local reference to a secret that contains the
+	// UserData to apply to the instance
+	// + optional
+	UserDataSecret *corev1.LocalObjectReference `json:"userDataSecret,omitempty"`
 }
 
 // KubeadmConfiguration holds the various configurations that kubeadm uses.

--- a/pkg/apis/azureprovider/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/azureprovider/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -114,6 +115,11 @@ func (in *AzureMachineProviderSpec) DeepCopyInto(out *AzureMachineProviderSpec) 
 	}
 	out.Image = in.Image
 	out.OSDisk = in.OSDisk
+	if in.UserDataSecret != nil {
+		in, out := &in.UserDataSecret, &out.UserDataSecret
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cloud/azure/actuators/BUILD.bazel
+++ b/pkg/cloud/azure/actuators/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1:go_default_library",

--- a/pkg/cloud/azure/actuators/machine_scope.go
+++ b/pkg/cloud/azure/actuators/machine_scope.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -30,9 +31,10 @@ import (
 // MachineScopeParams defines the input parameters used to create a new MachineScope.
 type MachineScopeParams struct {
 	AzureClients
-	Cluster *clusterv1.Cluster
-	Machine *clusterv1.Machine
-	Client  client.ClusterV1alpha1Interface
+	Cluster    *clusterv1.Cluster
+	Machine    *clusterv1.Machine
+	Client     client.ClusterV1alpha1Interface
+	CoreClient v1.CoreV1Interface
 }
 
 // NewMachineScope creates a new MachineScope from the supplied parameters.
@@ -58,12 +60,18 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 		machineClient = params.Client.Machines(params.Machine.Namespace)
 	}
 
+	var coreClient v1.CoreV1Interface
+	if params.Client != nil {
+		coreClient = params.CoreClient
+	}
+
 	return &MachineScope{
 		Scope:         scope,
 		Machine:       params.Machine,
 		MachineClient: machineClient,
 		MachineConfig: machineConfig,
 		MachineStatus: machineStatus,
+		CoreClient:    coreClient,
 	}, nil
 }
 
@@ -75,6 +83,7 @@ type MachineScope struct {
 	MachineClient client.MachineInterface
 	MachineConfig *v1alpha1.AzureMachineProviderSpec
 	MachineStatus *v1alpha1.AzureMachineProviderStatus
+	CoreClient    v1.CoreV1Interface
 }
 
 // Name returns the machine name.

--- a/pkg/cloud/azure/services/compute/BUILD.bazel
+++ b/pkg/cloud/azure/services/compute/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//vendor/github.com/Azure/go-autorest/autorest:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes tight coupling between machine resource and kubeadm while keeping the current behaviour pristine.
This allows flexibility for the API consumers to support broader use cases by injecting arbitrary userdata into a secret optionally referenced by the spec.
While being a fairly scoped change this would favour adoption of the project extremely.

Related:
https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/651
https://github.com/kubernetes-sigs/cluster-api/issues/721
https://docs.google.com/document/d/1pzXtwYWRsOzq5Ftu03O5FcFAlQE26nD3bjYBPenbhjg/edit#heading=h.etxqa0k5waej

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```