### PR TITLE
Remove hardcoded values from virtual machines, respect values from ma…

### DIFF
--- a/pkg/cloud/azure/actuators/machine/actuator.go
+++ b/pkg/cloud/azure/actuators/machine/actuator.go
@@ -191,7 +191,11 @@ func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machi
 		Name:       scope.Machine.Name,
 		NICName:    networkInterfaceSpec.Name,
 		SSHKeyData: string(decoded),
+		Size:       scope.MachineConfig.VMSize,
+		OSDisk:     scope.MachineConfig.OSDisk,
+		Image:      scope.MachineConfig.Image,
 	}
+
 	err = virtualmachines.NewService(scope.Scope).CreateOrUpdate(context.Background(), vmSpec)
 	if err != nil {
 		klog.Errorf("failed to create or get machine: %+v", err)

--- a/pkg/cloud/azure/defaults.go
+++ b/pkg/cloud/azure/defaults.go
@@ -17,6 +17,8 @@ limitations under the License.
 package azure
 
 const (
+	// DefaultUserName is the default username for created vm
+	DefaultUserName = "capi"
 	// DefaultVnetName is the default name for the cluster's virtual network.
 	DefaultVnetName = "ClusterAPIVnet"
 	// DefaultVnetCIDR is the default Vnet CIDR

--- a/pkg/cloud/azure/services/virtualmachines/BUILD.bazel
+++ b/pkg/cloud/azure/services/virtualmachines/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure/services/virtualmachines",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis/azureprovider/v1alpha1:go_default_library",
         "//pkg/cloud/azure:go_default_library",
         "//pkg/cloud/azure/actuators:go_default_library",
         "//pkg/cloud/azure/services/networkinterfaces:go_default_library",


### PR DESCRIPTION
…chineconfig instead

**What this PR does / why we need it**:
Previous PR had hardcoded certain VM specific values, this addresses the hardcoding to use values specified in machineconfig

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use VMSize, OSDisk and Image values specified in machineconfig
```