### PR TITLE
fix: Generate consistent names for Azure resources

### DIFF
--- a/config/crds/azureprovider_v1alpha1_azuremachineproviderspec.yaml
+++ b/config/crds/azureprovider_v1alpha1_azuremachineproviderspec.yaml
@@ -63,10 +63,6 @@ spec:
           - managedDisk
           - diskSizeGB
           type: object
-        roles:
-          items:
-            type: string
-          type: array
         sshPrivateKey:
           type: string
         sshPublicKey:

--- a/pkg/cloud/azure/actuators/clients.go
+++ b/pkg/cloud/azure/actuators/clients.go
@@ -19,7 +19,6 @@ package actuators
 import (
 	"fmt"
 	"hash/fnv"
-	"strings"
 
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/cloud/azure"
@@ -36,7 +35,8 @@ func CreateOrUpdateNetworkAPIServerIP(scope *Scope) {
 	if scope.Network().APIServerIP.Name == "" {
 		h := fnv.New32a()
 		h.Write([]byte(fmt.Sprintf("%s/%s/%s", scope.SubscriptionID, scope.ClusterConfig.ResourceGroup, scope.Cluster.Name)))
-		scope.Network().APIServerIP.Name = strings.ToLower(azure.DefaultPublicIPPrefix + fmt.Sprintf("%x", h.Sum32()))
+		scope.Network().APIServerIP.Name = azure.GeneratePublicIPName(scope.Cluster.Name, fmt.Sprintf("%x", h.Sum32()))
 	}
-	scope.Network().APIServerIP.DNSName = fmt.Sprintf("%s.%s.%s", strings.ToLower(scope.Network().APIServerIP.Name), strings.ToLower(scope.ClusterConfig.Location), azure.DefaultAzureDNSZone)
+
+	scope.Network().APIServerIP.DNSName = azure.GenerateFQDN(scope.Network().APIServerIP.Name, scope.ClusterConfig.Location)
 }

--- a/pkg/cloud/azure/actuators/cluster/actuator_test.go
+++ b/pkg/cloud/azure/actuators/cluster/actuator_test.go
@@ -154,29 +154,29 @@ func TestServicesCreatedCount(t *testing.T) {
 		t.Errorf("failed to reconcile cluster services: %+v", err)
 	}
 
-	if cache[azure.DefaultVnetName] != 1 {
-		t.Errorf("Expected 1 count of %s service", azure.DefaultVnetName)
+	if cache[azure.GenerateVnetName(fakeReconciler.scope.Cluster.Name)] != 1 {
+		t.Errorf("Expected 1 count of %s service", azure.GenerateVnetName(fakeReconciler.scope.Cluster.Name))
 	}
-	if cache[azure.DefaultControlPlaneSecurityGroupName] != 1 {
-		t.Errorf("Expected 1 count of %s service", azure.DefaultControlPlaneSecurityGroupName)
+	if cache[azure.GenerateControlPlaneSecurityGroupName(fakeReconciler.scope.Cluster.Name)] != 1 {
+		t.Errorf("Expected 1 count of %s service", azure.GenerateControlPlaneSecurityGroupName(fakeReconciler.scope.Cluster.Name))
 	}
-	if cache[azure.DefaultNodeSecurityGroupName] != 1 {
-		t.Errorf("Expected 1 count of %s service", azure.DefaultNodeSecurityGroupName)
+	if cache[azure.GenerateNodeSecurityGroupName(fakeReconciler.scope.Cluster.Name)] != 1 {
+		t.Errorf("Expected 1 count of %s service", azure.GenerateNodeSecurityGroupName(fakeReconciler.scope.Cluster.Name))
 	}
-	if cache[azure.DefaultNodeRouteTableName] != 1 {
-		t.Errorf("Expected 1 count of %s service", azure.DefaultNodeRouteTableName)
+	if cache[azure.GenerateNodeRouteTableName(fakeReconciler.scope.Cluster.Name)] != 1 {
+		t.Errorf("Expected 1 count of %s service", azure.GenerateNodeRouteTableName(fakeReconciler.scope.Cluster.Name))
 	}
-	if cache[azure.DefaultControlPlaneSubnetName] != 1 {
-		t.Errorf("Expected 1 count of %s service", azure.DefaultControlPlaneSubnetName)
+	if cache[azure.GenerateControlPlaneSubnetName(fakeReconciler.scope.Cluster.Name)] != 1 {
+		t.Errorf("Expected 1 count of %s service", azure.GenerateControlPlaneSubnetName(fakeReconciler.scope.Cluster.Name))
 	}
-	if cache[azure.DefaultNodeSubnetName] != 1 {
-		t.Errorf("Expected 1 count of %s service", azure.DefaultNodeSubnetName)
+	if cache[azure.GenerateNodeSubnetName(fakeReconciler.scope.Cluster.Name)] != 1 {
+		t.Errorf("Expected 1 count of %s service", azure.GenerateNodeSubnetName(fakeReconciler.scope.Cluster.Name))
 	}
-	if cache[azure.DefaultInternalLBName] != 1 {
-		t.Errorf("Expected 1 count of %s service", azure.DefaultInternalLBName)
+	if cache[azure.GenerateInternalLBName(fakeReconciler.scope.Cluster.Name)] != 1 {
+		t.Errorf("Expected 1 count of %s service", azure.GenerateInternalLBName(fakeReconciler.scope.Cluster.Name))
 	}
-	if cache[azure.DefaultPublicLBName] != 1 {
-		t.Errorf("Expected 1 count of %s service", azure.DefaultPublicLBName)
+	if cache[azure.GeneratePublicLBName(fakeReconciler.scope.Cluster.Name)] != 1 {
+		t.Errorf("Expected 1 count of %s service", azure.GeneratePublicLBName(fakeReconciler.scope.Cluster.Name))
 	}
 	if cache[fakeReconciler.scope.Network().APIServerIP.Name] != 1 {
 		t.Errorf("Expected 1 count of %s service", fakeReconciler.scope.Network().APIServerIP.Name)

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -74,15 +74,15 @@ func (s *Reconciler) Create(ctx context.Context) error {
 
 	networkInterfaceSpec := &networkinterfaces.Spec{
 		Name:     fmt.Sprintf("%s-nic", s.scope.Machine.Name),
-		VNETName: azure.DefaultVnetName,
+		VnetName: azure.GenerateVnetName(s.scope.Cluster.Name),
 	}
 	switch set := s.scope.Machine.ObjectMeta.Labels["set"]; set {
 	case v1alpha1.Node:
-		networkInterfaceSpec.SubnetName = azure.DefaultNodeSubnetName
+		networkInterfaceSpec.SubnetName = azure.GenerateNodeSubnetName(s.scope.Cluster.Name)
 	case v1alpha1.ControlPlane:
-		networkInterfaceSpec.SubnetName = azure.DefaultControlPlaneSubnetName
-		networkInterfaceSpec.PublicLoadBalancerName = azure.DefaultPublicLBName
-		networkInterfaceSpec.InternalLoadBalancerName = azure.DefaultInternalLBName
+		networkInterfaceSpec.SubnetName = azure.GenerateControlPlaneSubnetName(s.scope.Cluster.Name)
+		networkInterfaceSpec.PublicLoadBalancerName = azure.GeneratePublicLBName(s.scope.Cluster.Name)
+		networkInterfaceSpec.InternalLoadBalancerName = azure.GenerateInternalLBName(s.scope.Cluster.Name)
 		networkInterfaceSpec.NatRule = 0
 	default:
 		return errors.Errorf("Unknown value %s for label `set` on machine %s, skipping machine creation", set, s.scope.Machine.Name)
@@ -226,7 +226,7 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 
 	networkInterfaceSpec := &networkinterfaces.Spec{
 		Name:     fmt.Sprintf("%s-nic", s.scope.Machine.Name),
-		VNETName: azure.DefaultVnetName,
+		VnetName: azure.GenerateVnetName(s.scope.Cluster.Name),
 	}
 
 	err = s.networkInterfacesSvc.Delete(ctx, networkInterfaceSpec)

--- a/pkg/cloud/azure/defaults.go
+++ b/pkg/cloud/azure/defaults.go
@@ -16,35 +16,69 @@ limitations under the License.
 
 package azure
 
+import "fmt"
+
 const (
 	// DefaultUserName is the default username for created vm
 	DefaultUserName = "capi"
-	// DefaultVnetName is the default name for the cluster's virtual network.
-	DefaultVnetName = "ClusterAPIVnet"
 	// DefaultVnetCIDR is the default Vnet CIDR
 	DefaultVnetCIDR = "10.0.0.0/8"
-	// DefaultControlPlaneSecurityGroupName is the default name for the control plane security group.
-	DefaultControlPlaneSecurityGroupName = "ClusterAPIControlPlaneNSG"
-	// DefaultNodeSecurityGroupName is the default name for the Node's security group.
-	DefaultNodeSecurityGroupName = "ClusterAPINodeNSG"
-	// DefaultNodeRouteTableName is the default name for the Node's route table.
-	DefaultNodeRouteTableName = "ClusterAPINodeRouteTable"
-	// DefaultControlPlaneSubnetName is the default name for the Node's subnet.
-	DefaultControlPlaneSubnetName = "ClusterAPIControlPlaneSubnet"
 	// DefaultControlPlaneSubnetCIDR is the default Control Plane Subnet CIDR
 	DefaultControlPlaneSubnetCIDR = "10.0.0.0/16"
-	// DefaultNodeSubnetName is the default name for the Node's subnet.
-	DefaultNodeSubnetName = "ClusterAPINodeSubnet"
 	// DefaultNodeSubnetCIDR is the default Node Subnet CIDR
 	DefaultNodeSubnetCIDR = "10.1.0.0/16"
-	// DefaultInternalLBName is the default internal load balancer name
-	DefaultInternalLBName = "ClusterAPIInternalLB"
 	// DefaultInternalLBIPAddress is the default internal load balancer ip address
 	DefaultInternalLBIPAddress = "10.0.0.100"
-	// DefaultPublicLBName is the default public load balancer name
-	DefaultPublicLBName = "ClusterAPIPublicLB"
-	// DefaultPublicIPPrefix is the default publicip prefix
-	DefaultPublicIPPrefix = "ClusterAPI"
 	// DefaultAzureDNSZone is the default provided azure dns zone
 	DefaultAzureDNSZone = "cloudapp.azure.com"
 )
+
+// GenerateVnetName generates a virtual network name, based on the cluster name.
+func GenerateVnetName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, "vnet")
+}
+
+// GenerateControlPlaneSecurityGroupName generates a control plane security group name, based on the cluster name.
+func GenerateControlPlaneSecurityGroupName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, "controlplane-nsg")
+}
+
+// GenerateNodeSecurityGroupName generates a node security group name, based on the cluster name.
+func GenerateNodeSecurityGroupName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, "node-nsg")
+}
+
+// GenerateNodeRouteTableName generates a node route table name, based on the cluster name.
+func GenerateNodeRouteTableName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, "node-routetable")
+}
+
+// GenerateControlPlaneSubnetName generates a node subnet name, based on the cluster name.
+func GenerateControlPlaneSubnetName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, "controlplane-subnet")
+}
+
+// GenerateNodeSubnetName generates a node subnet name, based on the cluster name.
+func GenerateNodeSubnetName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, "node-subnet")
+}
+
+// GenerateInternalLBName generates a internal load balancer name, based on the cluster name.
+func GenerateInternalLBName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, "internal-lb")
+}
+
+// GeneratePublicLBName generates a public load balancer name, based on the cluster name.
+func GeneratePublicLBName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, "public-lb")
+}
+
+// GeneratePublicIPName generates a public IP name, based on the cluster name and a hash.
+func GeneratePublicIPName(clusterName, hash string) string {
+	return fmt.Sprintf("%s-%s", clusterName, hash)
+}
+
+// GenerateFQDN generates a fully qualified domain name, based on the public IP name and cluster location.
+func GenerateFQDN(publicIPName, location string) string {
+	return fmt.Sprintf("%s.%s.%s", publicIPName, location, DefaultAzureDNSZone)
+}

--- a/pkg/cloud/azure/services/config/startupscript.go
+++ b/pkg/cloud/azure/services/config/startupscript.go
@@ -172,9 +172,9 @@ func getAzureCloudProviderConfig(machine *actuators.MachineScope) string {
 		os.Getenv("AZURE_CLIENT_SECRET"),
 		machine.Scope.ClusterConfig.ResourceGroup,
 		machine.Scope.ClusterConfig.Location,
-		azure.DefaultNodeSubnetName,
-		azure.DefaultNodeSecurityGroupName,
-		azure.DefaultVnetName,
-		azure.DefaultNodeRouteTableName,
+		azure.GenerateNodeSubnetName(machine.Scope.Cluster.Name),
+		azure.GenerateNodeSecurityGroupName(machine.Scope.Cluster.Name),
+		azure.GenerateVnetName(machine.Scope.Cluster.Name),
+		azure.GenerateNodeRouteTableName(machine.Scope.Cluster.Name),
 	)
 }

--- a/pkg/cloud/azure/services/internalloadbalancers/internalloadbalancers.go
+++ b/pkg/cloud/azure/services/internalloadbalancers/internalloadbalancers.go
@@ -32,7 +32,7 @@ import (
 type Spec struct {
 	Name       string
 	SubnetName string
-	VNETName   string
+	VnetName   string
 	IPAddress  string
 }
 
@@ -66,7 +66,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 	lbName := internalLBSpec.Name
 
 	klog.V(2).Infof("getting subnet %s", internalLBSpec.SubnetName)
-	subnetInterface, err := subnets.NewService(s.Scope).Get(ctx, &subnets.Spec{Name: internalLBSpec.SubnetName, VNETName: internalLBSpec.VNETName})
+	subnetInterface, err := subnets.NewService(s.Scope).Get(ctx, &subnets.Spec{Name: internalLBSpec.SubnetName, VnetName: internalLBSpec.VnetName})
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
@@ -33,7 +33,7 @@ import (
 type Spec struct {
 	Name                     string
 	SubnetName               string
-	VNETName                 string
+	VnetName                 string
 	StaticIPAddress          string
 	PublicLoadBalancerName   string
 	InternalLoadBalancerName string
@@ -64,7 +64,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 
 	nicConfig := &network.InterfaceIPConfigurationPropertiesFormat{}
 
-	subnetInterface, err := subnets.NewService(s.Scope).Get(ctx, &subnets.Spec{Name: nicSpec.SubnetName, VNETName: nicSpec.VNETName})
+	subnetInterface, err := subnets.NewService(s.Scope).Get(ctx, &subnets.Spec{Name: nicSpec.SubnetName, VnetName: nicSpec.VnetName})
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/azure/services/subnets/subnets.go
+++ b/pkg/cloud/azure/services/subnets/subnets.go
@@ -32,7 +32,7 @@ import (
 type Spec struct {
 	Name              string
 	CIDR              string
-	VNETName          string
+	VnetName          string
 	RouteTableName    string
 	SecurityGroupName string
 }
@@ -43,7 +43,7 @@ func (s *Service) Get(ctx context.Context, spec azure.Spec) (interface{}, error)
 	if !ok {
 		return network.Subnet{}, errors.New("Invalid Subnet Specification")
 	}
-	subnet, err := s.Client.Get(ctx, s.Scope.ClusterConfig.ResourceGroup, subnetSpec.VNETName, subnetSpec.Name, "")
+	subnet, err := s.Client.Get(ctx, s.Scope.ClusterConfig.ResourceGroup, subnetSpec.VnetName, subnetSpec.Name, "")
 	if err != nil && azure.ResourceNotFound(err) {
 		return nil, errors.Wrapf(err, "subnet %s not found", subnetSpec.Name)
 	} else if err != nil {
@@ -87,11 +87,11 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 	klog.V(2).Infof("got nsg %s", subnetSpec.SecurityGroupName)
 	subnetProperties.NetworkSecurityGroup = &nsg
 
-	klog.V(2).Infof("creating subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VNETName)
+	klog.V(2).Infof("creating subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VnetName)
 	f, err := s.Client.CreateOrUpdate(
 		ctx,
 		s.Scope.ClusterConfig.ResourceGroup,
-		subnetSpec.VNETName,
+		subnetSpec.VnetName,
 		subnetSpec.Name,
 		network.Subnet{
 			Name:                   to.StringPtr(subnetSpec.Name),
@@ -111,7 +111,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 	if err != nil {
 		return errors.Wrap(err, "result error")
 	}
-	klog.V(2).Infof("successfully created subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VNETName)
+	klog.V(2).Infof("successfully created subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VnetName)
 	return err
 }
 
@@ -121,8 +121,8 @@ func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
 	if !ok {
 		return errors.New("Invalid Subnet Specification")
 	}
-	klog.V(2).Infof("deleting subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VNETName)
-	f, err := s.Client.Delete(ctx, s.Scope.ClusterConfig.ResourceGroup, subnetSpec.VNETName, subnetSpec.Name)
+	klog.V(2).Infof("deleting subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VnetName)
+	f, err := s.Client.Delete(ctx, s.Scope.ClusterConfig.ResourceGroup, subnetSpec.VnetName, subnetSpec.Name)
 	if err != nil && azure.ResourceNotFound(err) {
 		// already deleted
 		return nil
@@ -140,6 +140,6 @@ func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
 	if err != nil {
 		return errors.Wrap(err, "result error")
 	}
-	klog.V(2).Infof("successfully deleted subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VNETName)
+	klog.V(2).Infof("successfully deleted subnet %s in vnet %s", subnetSpec.Name, subnetSpec.VnetName)
 	return err
 }


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**What this PR does / why we need it**:
Generate consistent names for Azure resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #114

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```