### PR TITLE
fix: Increase mem limits, use Ubuntu 18.04, install kubernetes-cni 0.6.0

### DIFF
--- a/cmd/clusterctl/examples/azure/machines.yaml.template
+++ b/cmd/clusterctl/examples/azure/machines.yaml.template
@@ -23,7 +23,7 @@ items:
           image:
             publisher: "Canonical"
             offer: "UbuntuServer"
-            sku: "16.04-LTS"
+            sku: "18.04-LTS"
             version: "latest"
           osDisk:
             osType: "Linux"
@@ -53,7 +53,7 @@ items:
           image:
             publisher: "Canonical"
             offer: "UbuntuServer"
-            sku: "16.04-LTS"
+            sku: "18.04-LTS"
             version: "latest"
           osDisk:
             osType: "Linux"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,8 +61,8 @@ spec:
             - "-stderrthreshold=INFO"
           resources:
             limits:
-              cpu: 100m
-              memory: 30Mi
+              cpu: 200m
+              memory: 300Mi
             requests:
               cpu: 100m
               memory: 20Mi

--- a/pkg/cloud/azure/actuators/cluster/reconciler.go
+++ b/pkg/cloud/azure/actuators/cluster/reconciler.go
@@ -119,7 +119,7 @@ func (s *Reconciler) Reconcile() error {
 		Name:              azure.GenerateNodeSubnetName(s.scope.Cluster.Name),
 		CIDR:              azure.DefaultNodeSubnetCIDR,
 		VnetName:          azure.GenerateVnetName(s.scope.Cluster.Name),
-		SecurityGroupName: azure.GenerateControlPlaneSecurityGroupName(s.scope.Cluster.Name),
+		SecurityGroupName: azure.GenerateNodeSecurityGroupName(s.scope.Cluster.Name),
 		RouteTableName:    azure.GenerateNodeRouteTableName(s.scope.Cluster.Name),
 	}
 	if err := s.subnetsSvc.CreateOrUpdate(s.scope.Context, subnetSpec); err != nil {

--- a/pkg/cloud/azure/services/config/controlplane.go
+++ b/pkg/cloud/azure/services/config/controlplane.go
@@ -140,6 +140,7 @@ cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
 deb https://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
+apt-get install -y kubernetes-cni=0.6.0-00
 apt-get install -y kubelet="{{.KubernetesVersion}}-00" kubeadm="{{.KubernetesVersion}}-00" kubectl="{{.KubernetesVersion}}-00"
 apt-mark hold kubelet kubeadm kubectl
 
@@ -231,6 +232,7 @@ cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
 deb https://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
+apt-get install -y kubernetes-cni=0.6.0-00
 apt-get install -y kubelet="{{.KubernetesVersion}}-00" kubeadm="{{.KubernetesVersion}}-00" kubectl="{{.KubernetesVersion}}-00"
 apt-mark hold kubelet kubeadm kubectl
 

--- a/pkg/cloud/azure/services/config/node.go
+++ b/pkg/cloud/azure/services/config/node.go
@@ -89,6 +89,7 @@ cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
 deb https://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
+apt-get install -y kubernetes-cni=0.6.0-00
 apt-get install -y kubelet="{{.KubernetesVersion}}-00" kubeadm="{{.KubernetesVersion}}-00" kubectl="{{.KubernetesVersion}}-00"
 apt-mark hold kubelet kubeadm kubectl
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Recent regression in kubernetes installation required to pre install kubernetes cni 0.6 version
Increase memory limits
Default to ubuntu 18.04LTS
Fix Regression in NSG Name in recent PR

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increase provider memory limits
Default to Ubuntu 18
Preinstalls kubernetes cni 0.6.0 due to recent regression in installation
Fix Regression in Node NSG Name in recent PR
```