### PR TITLE
Fix kubernetes version for node startup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ envfile
 
 # vscode
 .vscode
+.idea
 
 # Ignore output manifests
 cmd/clusterctl/examples/azure/out

--- a/cmd/clusterctl/examples/azure/generate-yaml.sh
+++ b/cmd/clusterctl/examples/azure/generate-yaml.sh
@@ -36,6 +36,7 @@ export VNET_NAME="${VNET_NAME:-}"
 # Machine settings.
 export CONTROL_PLANE_MACHINE_TYPE="${CONTROL_PLANE_MACHINE_TYPE:-Standard_B2ms}"
 export NODE_MACHINE_TYPE="${NODE_MACHINE_TYPE:-Standard_B2ms}"
+export KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.13.5}"
 
 # Credentials.
 SSH_KEY_FILE=${OUTPUT_DIR}/sshkey

--- a/cmd/clusterctl/examples/azure/machines.yaml.template
+++ b/cmd/clusterctl/examples/azure/machines.yaml.template
@@ -10,8 +10,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: 1.13.5
-        controlPlane: 1.13.5
+        kubelet: ${KUBERNETES_VERSION}
+        controlPlane: ${KUBERNETES_VERSION}
       providerSpec:
         value:
           apiVersion: azureprovider/v1alpha1
@@ -41,7 +41,7 @@ items:
         set: node
     spec:
       versions:
-        kubelet: 1.13.5
+        kubelet: ${KUBERNETES_VERSION}
       providerSpec:
         value:
           apiVersion: azureprovider/v1alpha1

--- a/pkg/cloud/azure/services/config/startupscript.go
+++ b/pkg/cloud/azure/services/config/startupscript.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog"
@@ -73,7 +74,7 @@ func GetVMStartupScript(machine *actuators.MachineScope, bootstrapToken string) 
 				SaKey:               string(machine.Scope.ClusterConfig.SAKeyPair.Key),
 				BootstrapToken:      bootstrapToken,
 				LBAddress:           dnsName,
-				KubernetesVersion:   machine.Machine.Spec.Versions.ControlPlane,
+				KubernetesVersion:   trimKubernetesVersion(machine.Machine.Spec.Versions.ControlPlane),
 				CloudProviderConfig: getAzureCloudProviderConfig(machine),
 			})
 			if err != nil {
@@ -100,7 +101,7 @@ func GetVMStartupScript(machine *actuators.MachineScope, bootstrapToken string) 
 				PodSubnet:           machine.Scope.Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0],
 				ServiceSubnet:       machine.Scope.Cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0],
 				ServiceDomain:       machine.Scope.Cluster.Spec.ClusterNetwork.ServiceDomain,
-				KubernetesVersion:   machine.Machine.Spec.Versions.ControlPlane,
+				KubernetesVersion:   trimKubernetesVersion(machine.Machine.Spec.Versions.ControlPlane),
 				CloudProviderConfig: getAzureCloudProviderConfig(machine),
 			})
 
@@ -116,7 +117,7 @@ func GetVMStartupScript(machine *actuators.MachineScope, bootstrapToken string) 
 			CACertHash:          caCertHash,
 			BootstrapToken:      bootstrapToken,
 			InternalLBAddress:   azure.DefaultInternalLBIPAddress,
-			KubernetesVersion:   machine.Machine.Spec.Versions.Kubelet,
+			KubernetesVersion:  trimKubernetesVersion(machine.Machine.Spec.Versions.Kubelet),
 			CloudProviderConfig: getAzureCloudProviderConfig(machine),
 		})
 
@@ -128,6 +129,11 @@ func GetVMStartupScript(machine *actuators.MachineScope, bootstrapToken string) 
 		return "", errors.Errorf("Unknown node role %s", machine.Role())
 	}
 	return startupScript, nil
+}
+
+// trimKubernetesVersion removes "v" from prefix if given in this format: v1.13.4
+func trimKubernetesVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
 }
 
 // getAzureCloudProviderConfig gets azure provider config for control plane and kubelet

--- a/pkg/cloud/azure/services/config/startupscript.go
+++ b/pkg/cloud/azure/services/config/startupscript.go
@@ -117,7 +117,7 @@ func GetVMStartupScript(machine *actuators.MachineScope, bootstrapToken string) 
 			CACertHash:          caCertHash,
 			BootstrapToken:      bootstrapToken,
 			InternalLBAddress:   azure.DefaultInternalLBIPAddress,
-			KubernetesVersion:  trimKubernetesVersion(machine.Machine.Spec.Versions.Kubelet),
+			KubernetesVersion:   trimKubernetesVersion(machine.Machine.Spec.Versions.Kubelet),
 			CloudProviderConfig: getAzureCloudProviderConfig(machine),
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, kubernetes version for node startupscript is taken from `machine.Machine.Spec.Versions.ControlPlane`, but it should be from `machine.Machine.Spec.Versions.Kubelet`

Also, if kubernetes version is given with prefix `v` (e.g `v1.13.4`), it removes the prefix `v`

```release-note
Allow Kubernetes version to be set in generator script
```