### PR TITLE
Update to Kubernetes 1.13.5 (CVE mitigation)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,7 +98,7 @@ go_repository(
 
 go_repository(
     name = "io_k8s_sigs_kind",
-    commit = "d4ff13e4808ee5a816ed92bf2d3348bda12413db",
+    commit = "91d92c86cfa4143143841aad7f9b6d0c35e109ea",
     importpath = "sigs.k8s.io/kind",
 )
 
@@ -111,7 +111,7 @@ go_repository(
 go_repository(
     name = "io_k8s_kubernetes",
     importpath = "k8s.io/kubernetes",
-    tag = "v1.13.4",
+    tag = "v1.13.5",
 )
 
 go_repository(

--- a/cmd/clusterctl/examples/azure/machines.yaml.template
+++ b/cmd/clusterctl/examples/azure/machines.yaml.template
@@ -10,8 +10,8 @@ items:
         set: controlplane
     spec:
       versions:
-        kubelet: 1.13.4
-        controlPlane: 1.13.4
+        kubelet: 1.13.5
+        controlPlane: 1.13.5
       providerSpec:
         value:
           apiVersion: azureprovider/v1alpha1
@@ -41,7 +41,7 @@ items:
         set: node
     spec:
       versions:
-        kubelet: 1.13.4
+        kubelet: 1.13.5
       providerSpec:
         value:
           apiVersion: azureprovider/v1alpha1


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**What this PR does / why we need it**:
- [CVE-2019-9946 - CNI - portmap plugin](https://groups.google.com/d/topic/kubernetes-dev/qclJgwECJkM/discussion)
- [CVE-2019-1002101 - kubectl - potential directory traversal](https://groups.google.com/d/topic/kubernetes-dev/falu5dskY2s/discussion)

**Special notes for your reviewer**:
Tested successfully:
```bash
$ kubectl get no -o wide
NAME                    STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
aug-36-controlplane-0   Ready    master   7m2s   v1.13.5   10.0.0.4      <none>        Ubuntu 18.04.2 LTS   4.18.0-1013-azure   containerd://1.2.4
aug-36-node-gfqvj       Ready    <none>   113s   v1.13.5   10.1.0.4      <none>        Ubuntu 18.04.2 LTS   4.18.0-1013-azure   containerd://1.2.4
```

capz users **_must_** update to versions of [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= `v1.13.5`. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update to Kubernetes 1.13.5 (CVE mitigation)
```

/assign @soggiest @awesomenix @juan-lee @serbrech 