### PR TITLE
Add node role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ envfile
 # vscode
 .vscode
 
+# goland
+.idea
+
 # Ignore output manifests
 cmd/clusterctl/examples/azure/out
 cmd/clusterctl/examples/azure/provider-components-base.yaml

--- a/pkg/cloud/azure/services/config/node.go
+++ b/pkg/cloud/azure/services/config/node.go
@@ -48,6 +48,7 @@ nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: azure
     cloud-config: /etc/kubernetes/azure.json
+    node-labels: "node-role.kubernetes.io/node="
 EOF
 
 # Configure containerd prerequisites


### PR DESCRIPTION
**What this PR does / why we need it**:
Add roles to nodes
```
NAME                       STATUS     ROLES    AGE     VERSION
az101-master               Ready      master   6m15s   v1.13.4
standard-b2ms-pool-j92hc   Ready      node     45s     v1.13.4
```

instead of
```
NAME                       STATUS     ROLES    AGE     VERSION
az101-master               Ready      master   6m15s   v1.13.4
standard-b2ms-pool-j92hc   Ready      <none>   45s     v1.13.4
```

ref: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/681

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add node roles to non-controlplane nodes
```

