### PR TITLE
Fix incorrect internalLB deletion name

### DIFF
--- a/pkg/cloud/azure/actuators/cluster/reconciler.go
+++ b/pkg/cloud/azure/actuators/cluster/reconciler.go
@@ -213,11 +213,11 @@ func (s *Reconciler) deleteLB() error {
 	}
 
 	internalLBSpec := &internalloadbalancers.Spec{
-		Name: azure.GenerateNodeSubnetName(s.scope.Cluster.Name),
+		Name: azure.GenerateInternalLBName(s.scope.Cluster.Name),
 	}
 	if err := s.internalLBSvc.Delete(s.scope.Context, internalLBSpec); err != nil {
 		if !azure.ResourceNotFound(err) {
-			return errors.Wrapf(err, "failed to internal load balancer %s for cluster %s", azure.GenerateNodeSubnetName(s.scope.Cluster.Name), s.scope.Cluster.Name)
+			return errors.Wrapf(err, "failed to internal load balancer %s for cluster %s", azure.GenerateInternalLBName(s.scope.Cluster.Name), s.scope.Cluster.Name)
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: John Harris <joharris@vmware.com>

**What this PR does / why we need it**:
The internalLB deletion code incorrectly referred to the subnet name, not the LB name, causing the delete to fail. This PR corrects the naming reference.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #172 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```