### PR TITLE
Fix frontproxy ca cert

### DIFF
--- a/pkg/cloud/azure/services/config/controlplane.go
+++ b/pkg/cloud/azure/services/config/controlplane.go
@@ -162,7 +162,7 @@ echo -n '{{.EtcdCACert}}' > /etc/kubernetes/pki/etcd/ca.crt
 echo -n '{{.EtcdCAKey}}' > /etc/kubernetes/pki/etcd/ca.key
 chmod 600 /etc/kubernetes/pki/etcd/ca.key
 
-echo -n'{{.FrontProxyCACert}}' > /etc/kubernetes/pki/front-proxy-ca.crt
+echo -n '{{.FrontProxyCACert}}' > /etc/kubernetes/pki/front-proxy-ca.crt
 echo -n '{{.FrontProxyCAKey}}' > /etc/kubernetes/pki/front-proxy-ca.key
 chmod 600 /etc/kubernetes/pki/front-proxy-ca.key
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If we join another control plane machine, frontproxy ca cert becomes like this
`-n-----BEGIN CERTIFICATE----- `, so this error occurs

```
failure loading certificate for front-proxy CA: couldn't load the certificate file /etc/kubernetes/pki/front-proxy-ca.crt: error reading /etc/kubernetes/pki/front-proxy-ca.crt: data does not contain any valid RSA or ECDSA certificates
```


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Front Proxy CA Cert
```