### PR TITLE
Add GetControlPlaneMachines function

### DIFF
--- a/pkg/cloud/azure/actuators/machine/actuator.go
+++ b/pkg/cloud/azure/actuators/machine/actuator.go
@@ -54,6 +54,17 @@ func NewActuator(params ActuatorParams) *Actuator {
 	}
 }
 
+// GetControlPlaneMachines retrieves all control plane nodes from a MachineList
+func GetControlPlaneMachines(machineList *clusterv1.MachineList) []*clusterv1.Machine {
+	var cpm []*clusterv1.Machine
+	for _, m := range machineList.Items {
+		if m.Spec.Versions.ControlPlane != "" {
+			cpm = append(cpm, m.DeepCopy())
+		}
+	}
+	return cpm
+}
+
 // Create creates a machine and is invoked by the machine controller.
 func (a *Actuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	if cluster == nil {


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**What this PR does / why we need it**:
Adds a small function, `GetControlPlaneMachines`, which returns a list of control plane machines

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Required to support e2e tests - #212

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```