### PR TITLE
Update CAPI to v0.1.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1173,7 +1173,7 @@
   revision = "21c4ce38f2a793ec01e925ddc31216500183b773"
 
 [[projects]]
-  digest = "1:1aff817d3537e74f08cc2cb278c953fff9d103bbd259e3e257920ec5fab7a7da"
+  digest = "1:d885a5905c58b580aa8a7f58f7d0480e13e12c8abc2ff9ec87c8627253a6bf3f"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "cmd/clusterctl/clientcmd",
@@ -1203,8 +1203,8 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "95a2a8cf2c586592538f823bbb02c00cbcce8a9c"
-  version = "0.1.2"
+  revision = "5ed76e24e0319770757c25fdb07669d89b778fd8"
+  version = "0.1.3"
 
 [[projects]]
   digest = "1:cdf0d8bd1e51c567911d0e8caab0c30db1d5caa1853fcfddd9ffeadb8ff001f2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@ required = [
 
 [[constraint]]
   name = "sigs.k8s.io/cluster-api"
-  version = "0.1.2"
+  version = "0.1.3"
 
 [[constraint]]
   name = "github.com/Azure/azure-sdk-for-go"

--- a/vendor/sigs.k8s.io/cluster-api/Makefile
+++ b/vendor/sigs.k8s.io/cluster-api/Makefile
@@ -22,7 +22,7 @@ export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?=60s
 export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?=60s
 
 # Image URL to use all building/pushing image targets
-export CONTROLLER_IMG ?= gcr.io/k8s-cluster-api/cluster-api-controller:0.1.2
+export CONTROLLER_IMG ?= gcr.io/k8s-cluster-api/cluster-api-controller:0.1.3
 export EXAMPLE_PROVIDER_IMG ?= gcr.io/k8s-cluster-api/example-provider-controller:latest
 
 all: test manager clusterctl
@@ -109,7 +109,7 @@ clean: ## Remove all generated files
 
 .PHONY: docker-build
 docker-build: generate fmt vet manifests ## Build the docker image for controller-manager
-	docker build . -t ${CONTROLLER_IMG}
+	docker build --pull . -t ${CONTROLLER_IMG}
 	@echo "updating kustomize image patch file for manager resource"
 	hack/sed.sh -i.tmp -e 's@image: .*@image: '"${CONTROLLER_IMG}"'@' ./config/default/manager_image_patch.yaml
 
@@ -119,7 +119,7 @@ docker-push: docker-build ## Push the docker image
 
 .PHONY: docker-build-ci
 docker-build-ci: generate fmt vet manifests ## Build the docker image for example provider
-	docker build . -f ./pkg/provider/example/container/Dockerfile -t ${EXAMPLE_PROVIDER_IMG}
+	docker build --pull . -f ./pkg/provider/example/container/Dockerfile -t ${EXAMPLE_PROVIDER_IMG}
 	@echo "updating kustomize image patch file for ci"
 	hack/sed.sh -i.tmp -e 's@image: .*@image: '"${EXAMPLE_PROVIDER_IMG}"'@' ./config/ci/manager_image_patch.yaml
 

--- a/vendor/sigs.k8s.io/cluster-api/config/default/manager_image_patch.yaml
+++ b/vendor/sigs.k8s.io/cluster-api/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/k8s-cluster-api/cluster-api-controller:0.1.2
+      - image: gcr.io/k8s-cluster-api/cluster-api-controller:0.1.3
         name: manager


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**What this PR does / why we need it**:
Update CAPI to v0.1.3

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Addresses a bug in the capi controller image: https://github.com/kubernetes-sigs/cluster-api/issues/999

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update CAPI to v0.1.3
```