### PR TITLE
Setting Dockerfile FROM 1.12 instead of 1.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.12.1 as builder
+FROM golang:1.12 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-azure


### PR DESCRIPTION
Signed-off-by: Tim Carr <tim@timcarr.net>

**What this PR does / why we need it**:

Fixing a minor nit in the Dockerfile FROM 1.12 instead of locking to a version of 1.12.

**Special notes for your reviewer**:

**Release note**:

```release-note
Updating the Dockerfile to use 1.12 instead of 1.12.1
```