### PR TITLE
fix: add retries to containerd download in custom script

### DIFF
--- a/pkg/cloud/azure/services/config/controlplane.go
+++ b/pkg/cloud/azure/services/config/controlplane.go
@@ -122,7 +122,7 @@ export CONTAINERD_VERSION="{{.ContainerdVersion}}"
 export CONTAINERD_SHA256="{{.ContainerdSHA256}}"
 
 # Download containerd tar.
-wget https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
+wget --tries 10 https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
 
 # Check hash.
 echo "${CONTAINERD_SHA256} cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz" | sha256sum --check -
@@ -214,7 +214,7 @@ export CONTAINERD_VERSION="{{.ContainerdVersion}}"
 export CONTAINERD_SHA256="{{.ContainerdSHA256}}"
 
 # Download containerd tar.
-wget https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
+wget --tries 10 https://storage.googleapis.com/cri-containerd-release/cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz
 
 # Check hash.
 echo "${CONTAINERD_SHA256} cri-containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz" | sha256sum --check -


### PR DESCRIPTION
**What this PR does / why we need it**: This PR improves resilience of the custom script containerd download to transient network failures by retrying the download if it fails.

I set the number of retries to 10 for now since that seems like a generous number but we might want to increase that number if we see transient errors that last longer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #224 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add retries to containerd download in custom script
```