### PR TITLE
Added check in generate-yaml.sh that verifies the Azure EnvVars are set

### DIFF
--- a/cmd/clusterctl/examples/azure/generate-yaml.sh
+++ b/cmd/clusterctl/examples/azure/generate-yaml.sh
@@ -17,6 +17,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Verify the required Environment Variables are present.
+echo "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
+echo "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
+echo "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
+echo "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
+
 # Directories.
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 DIR=${DIR:=${SOURCE_DIR}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a check to cmd/clusterctl/examples/azure/generate-yaml.sh that will fail if any of the necessary Azure environment variables are missing or empty.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```
Added check to cmd/clusterctl/examples/azure/generate-yaml.sh to ensure the proper Azure environment variables are in place before proceeding.
```

cc @justaugustus 