### PR TITLE
Added check in generate-yaml.sh that verifies the Azure EnvVars are set

### DIFF
--- a/cmd/clusterctl/examples/azure/generate-yaml.sh
+++ b/cmd/clusterctl/examples/azure/generate-yaml.sh
@@ -18,10 +18,10 @@ set -o nounset
 set -o pipefail
 
 # Verify the required Environment Variables are present.
-echo "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
-echo "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
-echo "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
-echo "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
+: "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
+: "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
+: "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
+: "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
 
 # Directories.
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"


### PR DESCRIPTION
**What this PR does / why we need it**:
 Replaced the echo commands in cmd/clusterctl/examples/azure/generate-yaml.sh environment variable check in favor of colons. Using echos here is unneeded.

/assign @justaugustus 

```release-note
Add check to validate Azure environment variables in generate-yaml.sh
```