### PR TITLE
HA: Add logic for NAT rule selection

### DIFF
--- a/pkg/cloud/azure/actuators/BUILD.bazel
+++ b/pkg/cloud/azure/actuators/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "clients.go",
+        "control_plane_lock.go",
         "getters.go",
         "machine_scope.go",
         "scope.go",

--- a/pkg/cloud/azure/actuators/control_plane_lock.go
+++ b/pkg/cloud/azure/actuators/control_plane_lock.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actuators
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// ControlPlaneConfigMapName returns the name of the ConfigMap used to coordinate the bootstrapping of control plane
+// nodes.
+func ControlPlaneConfigMapName(cluster *v1alpha1.Cluster) string {
+	return fmt.Sprintf("%s-controlplane", cluster.UID)
+}
+
+// ListOptionsForCluster returns a ListOptions with a label selector for clusterName.
+func ListOptionsForCluster(clusterName string) metav1.ListOptions {
+	return metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", v1alpha1.MachineClusterLabelName, clusterName),
+	}
+}

--- a/pkg/cloud/azure/actuators/machine/actuator.go
+++ b/pkg/cloud/azure/actuators/machine/actuator.go
@@ -54,11 +54,11 @@ func NewActuator(params ActuatorParams) *Actuator {
 	}
 }
 
-// GetControlPlaneMachines retrieves all control plane nodes from a MachineList
+// GetControlPlaneMachines retrieves all non-deleted control plane nodes from a MachineList
 func GetControlPlaneMachines(machineList *clusterv1.MachineList) []*clusterv1.Machine {
 	var cpm []*clusterv1.Machine
 	for _, m := range machineList.Items {
-		if m.Spec.Versions.ControlPlane != "" {
+		if m.DeletionTimestamp.IsZero() && m.Spec.Versions.ControlPlane != "" {
 			cpm = append(cpm, m.DeepCopy())
 		}
 	}

--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
@@ -98,6 +98,7 @@ func (s *Service) Reconcile(ctx context.Context, spec v1alpha1.ResourceSpec) err
 			network.BackendAddressPool{
 				ID: (*lb.BackendAddressPools)[0].ID,
 			})
+
 		nicConfig.LoadBalancerInboundNatRules = &[]network.InboundNatRule{
 			{
 				ID: (*lb.InboundNatRules)[nicSpec.NatRule].ID,


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**What this PR does / why we need it**:
When trying to create an HA cluster, node creation fails when attempting to create a NIC with the following message:
```
E0719 23:35:28.363854       1 actuator.go:84] failed to reconcile machine aug-ha-0-controlplane-1 for cluster aug-ha-0: failed to create nic aug-ha-0-controlplane-1-nic for machine aug-ha-0-controlplane-1: unable to create VM network interface: failed to create network interface aug-ha-0-controlplane-1-nic in resource group capz-aug-ha-0: network.InterfacesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InboundNatRuleInUse" Message="Network interface aug-ha-0-controlplane-1-nic is trying to use NAT rule /subscriptions/<subscription_id>/resourceGroups/capz-aug-ha-0/providers/Microsoft.Network/loadBalancers/aug-ha-0-public-lb/inboundNatRules/natRule1 that is already in use by another network interface /subscriptions/<subscription_id>/resourceGroups/CAPZ-AUG-HA-0/providers/Microsoft.Network/networkInterfaces/AUG-HA-0-CONTROLPLANE-0-NIC." Details=[]
```

This adds logic to get the current list of control plane machines and set a NAT rule id based on the length of that list.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable clusters with HA control plane nodes
```