### PR TITLE
Remove SSH private key material from AzureMachineProviderSpec

### DIFF
--- a/cmd/clusterctl/examples/azure/controlplane-machine.yaml.template
+++ b/cmd/clusterctl/examples/azure/controlplane-machine.yaml.template
@@ -31,4 +31,3 @@ items:
               storageAccountType: "Premium_LRS"
             diskSizeGB: 30
           sshPublicKey: ${SSH_PUBLIC_KEY}
-          sshPrivateKey: ${SSH_PRIVATE_KEY}

--- a/cmd/clusterctl/examples/azure/controlplane-machines-ha.yaml.template
+++ b/cmd/clusterctl/examples/azure/controlplane-machines-ha.yaml.template
@@ -31,7 +31,6 @@ items:
               storageAccountType: "Premium_LRS"
             diskSizeGB: 30
           sshPublicKey: ${SSH_PUBLIC_KEY}
-          sshPrivateKey: ${SSH_PRIVATE_KEY}
   - apiVersion: "cluster.k8s.io/v1alpha1"
     kind: Machine
     metadata:
@@ -62,7 +61,6 @@ items:
               storageAccountType: "Premium_LRS"
             diskSizeGB: 30
           sshPublicKey: ${SSH_PUBLIC_KEY}
-          sshPrivateKey: ${SSH_PRIVATE_KEY}
   - apiVersion: "cluster.k8s.io/v1alpha1"
     kind: Machine
     metadata:
@@ -93,4 +91,3 @@ items:
               storageAccountType: "Premium_LRS"
             diskSizeGB: 30
           sshPublicKey: ${SSH_PUBLIC_KEY}
-          sshPrivateKey: ${SSH_PRIVATE_KEY}

--- a/cmd/clusterctl/examples/azure/generate-yaml.sh
+++ b/cmd/clusterctl/examples/azure/generate-yaml.sh
@@ -144,7 +144,6 @@ ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N '' 1>/dev/null
 echo "Machine SSH key generated in ${SSH_KEY_FILE}"
 
 export SSH_PUBLIC_KEY=$(cat "${SSH_KEY_FILE}.pub" | base64 | tr -d '\r\n')
-export SSH_PRIVATE_KEY=$(cat "${SSH_KEY_FILE}" | base64 | tr -d '\r\n')
 
 if [[ -z "${VNET_NAME}" ]]; then
   $ENVSUBST < "$CLUSTER_TEMPLATE_FILE" > "${CLUSTER_GENERATED_FILE}"

--- a/cmd/clusterctl/examples/azure/machine-deployment.yaml.template
+++ b/cmd/clusterctl/examples/azure/machine-deployment.yaml.template
@@ -37,4 +37,3 @@ spec:
               storageAccountType: "Premium_LRS"
             diskSizeGB: 30
           sshPublicKey: ${SSH_PUBLIC_KEY}
-          sshPrivateKey: ${SSH_PRIVATE_KEY}

--- a/cmd/clusterctl/examples/azure/machines.yaml.template
+++ b/cmd/clusterctl/examples/azure/machines.yaml.template
@@ -31,7 +31,6 @@ items:
               storageAccountType: "Premium_LRS"
             diskSizeGB: 30
           sshPublicKey: ${SSH_PUBLIC_KEY}
-          sshPrivateKey: ${SSH_PRIVATE_KEY}
   - apiVersion: "cluster.k8s.io/v1alpha1"
     kind: Machine
     metadata:
@@ -61,4 +60,3 @@ items:
               storageAccountType: "Premium_LRS"
             diskSizeGB: 30
           sshPublicKey: ${SSH_PUBLIC_KEY}
-          sshPrivateKey: ${SSH_PRIVATE_KEY}

--- a/config/crds/azureprovider_v1alpha1_azuremachineproviderspec.yaml
+++ b/config/crds/azureprovider_v1alpha1_azuremachineproviderspec.yaml
@@ -63,8 +63,6 @@ spec:
           - managedDisk
           - diskSizeGB
           type: object
-        sshPrivateKey:
-          type: string
         sshPublicKey:
           type: string
         vmSize:
@@ -75,7 +73,6 @@ spec:
       - image
       - osDisk
       - sshPublicKey
-      - sshPrivateKey
   version: v1alpha1
 status:
   acceptedNames:

--- a/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
@@ -34,12 +34,11 @@ type AzureMachineProviderSpec struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Location      string `json:"location"`
-	VMSize        string `json:"vmSize"`
-	Image         Image  `json:"image"`
-	OSDisk        OSDisk `json:"osDisk"`
-	SSHPublicKey  string `json:"sshPublicKey"`
-	SSHPrivateKey string `json:"sshPrivateKey"`
+	Location     string `json:"location"`
+	VMSize       string `json:"vmSize"`
+	Image        Image  `json:"image"`
+	OSDisk       OSDisk `json:"osDisk"`
+	SSHPublicKey string `json:"sshPublicKey"`
 }
 
 // KubeadmConfiguration holds the various configurations that kubeadm uses.

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -174,7 +174,6 @@ func makeMachine() *capi.Machine {
 	machineSpec, err := actuators.MachineConfigFromProviderSpec(nil, machine.Spec.ProviderSpec, &cloudtest.Log{})
 	Expect(err).To(BeNil())
 	machineSpec.Location = defaultLocation
-	machineSpec.SSHPrivateKey = ""
 	machineSpec.SSHPublicKey = ""
 	machine.Spec.ProviderSpec.Value, err = capz.EncodeMachineSpec(machineSpec)
 	Expect(err).To(BeNil())


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**What this PR does / why we need it**:
We're currently sending SSH private key material in the machine provider config, which is a vestige of the pre-refactor configs. This is no longer required.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove SSH private key material from AzureMachineProviderSpec
```