### PR TITLE
Fixes cluster-delete in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,12 +268,11 @@ create-cluster-management: ## Create a development Kubernetes cluster on Azure i
 		create -f cmd/clusterctl/examples/azure/out/machine-deployment.yaml
 
 .PHONY: delete-cluster
-delete-cluster: binaries ## Deletes the development Kubernetes Cluster "test1"
+delete-cluster: binaries ## Deletes the development Kubernetes Cluster
 	bin/clusterctl delete cluster -v 4 \
 	--bootstrap-type kind \
-	--cluster test1 \
 	--kubeconfig ./kubeconfig \
-	-p ./cmd/clusterctl/examples/azure/out/provider-components.yaml \
+	-p ./cmd/clusterctl/examples/azure/out/provider-components.yaml
 
 kind-reset: ## Destroys the "clusterapi" kind cluster.
 	kind delete cluster --name=clusterapi || true


### PR DESCRIPTION


Signed-off-by: John Harris <joharris@vmware.com>

**What this PR does / why we need it**:
The command implied that the cluster-name was used to identify the
cluster to delete. This isn't the case (it needs to be the name
of the cluster as defined in the kubeconfig if set). As the kubeconfig
is generated per cluster, it's pretty safe to just point to it and not
specify a name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @justaugustus 