### PR TITLE
Added ability to select AZ

### DIFF
--- a/cmd/clusterctl/examples/azure/controlplane-machine.yaml.template
+++ b/cmd/clusterctl/examples/azure/controlplane-machine.yaml.template
@@ -19,6 +19,7 @@ items:
           roles:
           - Master
           location: ${LOCATION}
+          availabilityZone: ${AVAILABILITY_ZONE}
           vmSize: ${CONTROL_PLANE_MACHINE_TYPE}
           image:
             publisher: "Canonical"

--- a/cmd/clusterctl/examples/azure/machine-deployment.yaml.template
+++ b/cmd/clusterctl/examples/azure/machine-deployment.yaml.template
@@ -25,6 +25,7 @@ spec:
           roles:
           - Node
           location: ${LOCATION}
+          availabilityZone: ${AVAILABILITY_ZONE}
           vmSize: ${NODE_MACHINE_TYPE}
           image:
             publisher: "Canonical"

--- a/cmd/clusterctl/examples/azure/machines.yaml.template
+++ b/cmd/clusterctl/examples/azure/machines.yaml.template
@@ -19,6 +19,7 @@ items:
           roles:
           - Master
           location: ${LOCATION}
+          availabilityZone: ${AVAILABILITY_ZONE}
           vmSize: ${CONTROL_PLANE_MACHINE_TYPE}
           image:
             publisher: "Canonical"
@@ -48,6 +49,7 @@ items:
           roles:
           - Node
           location: ${LOCATION}
+          availabilityZone: ${AVAILABILITY_ZONE}
           vmSize: ${NODE_MACHINE_TYPE}
           image:
             publisher: "Canonical"

--- a/config/crds/azureprovider_v1alpha1_azureclusterproviderstatus.yaml
+++ b/config/crds/azureprovider_v1alpha1_azureclusterproviderstatus.yaml
@@ -21,6 +21,8 @@ spec:
           type: string
         bastion:
           properties:
+            availabilityZone:
+              type: string
             id:
               type: string
             identity:

--- a/config/crds/azureprovider_v1alpha1_azuremachineproviderspec.yaml
+++ b/config/crds/azureprovider_v1alpha1_azuremachineproviderspec.yaml
@@ -19,6 +19,8 @@ spec:
             of an object. Servers should convert recognized schemas to the latest
             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
+        availabilityZone:
+          type: string
         image:
           properties:
             offer:
@@ -349,6 +351,7 @@ spec:
           type: string
       required:
       - location
+      - availabilityZone
       - vmSize
       - image
       - osDisk

--- a/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
+++ b/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
@@ -34,11 +34,12 @@ type AzureMachineProviderSpec struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Location     string `json:"location"`
-	VMSize       string `json:"vmSize"`
-	Image        Image  `json:"image"`
-	OSDisk       OSDisk `json:"osDisk"`
-	SSHPublicKey string `json:"sshPublicKey"`
+	Location         string `json:"location"`
+	AvailabilityZone string `json:"availabilityZone"`
+	VMSize           string `json:"vmSize"`
+	Image            Image  `json:"image"`
+	OSDisk           OSDisk `json:"osDisk"`
+	SSHPublicKey     string `json:"sshPublicKey"`
 
 	// KubeadmConfiguration holds the kubeadm configuration options
 	// TODO: Backfill logic

--- a/pkg/apis/azureprovider/v1alpha1/types.go
+++ b/pkg/apis/azureprovider/v1alpha1/types.go
@@ -339,6 +339,8 @@ type VM struct {
 	ID   string `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
 
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+
 	// Hardware profile
 	VMSize string `json:"vmSize,omitempty"`
 

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -491,9 +491,17 @@ func (r *Reconciler) createVirtualMachine(ctx context.Context, nicName string) e
 
 	vmInterface, err := r.virtualMachinesSvc.Get(ctx, vmSpec)
 	if err != nil && vmInterface == nil {
-		vmZone, zoneErr := r.getVirtualMachineZone(ctx)
-		if zoneErr != nil {
-			return errors.Wrap(zoneErr, "failed to get availability zone")
+		var vmZone string
+		var zoneErr error
+
+		vmZone = r.scope.MachineConfig.AvailabilityZone
+
+		if r.scope.MachineConfig.AvailabilityZone == "" {
+			vmZone, zoneErr = r.getVirtualMachineZone(ctx)
+			if zoneErr != nil {
+				return errors.Wrap(zoneErr, "failed to get availability zone")
+			}
+			klog.Info("No availability zone set, selecting random availability zone:", vmZone)
 		}
 
 		vmSpec = &virtualmachines.Spec{

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
@@ -150,6 +150,8 @@ func (s *Service) Reconcile(ctx context.Context, spec v1alpha1.ResourceSpec) err
 		},
 	}
 
+	klog.V(2).Infof("Setting zone %s ", vmSpec.Zone)
+
 	if vmSpec.Zone != "" {
 		zones := []string{vmSpec.Zone}
 		virtualMachine.Zones = &zones


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a config option to the machine spec to select Availability Zones.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #169 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allows user to specify the availability zones their machines will be deployed into via the machine manifest file.
```