### PR TITLE
[v1alpha2] Update Calico and temporarily move CNI deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,8 +280,13 @@ create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on Azur
 		--namespace=default \
 		--cluster-name=$(CLUSTER_NAME)
 	# Apply addons on the target cluster, waiting for the control-plane to become available.
-	$(CLUSTERCTL) \
-		alpha phases apply-addons -v=3 \
+# TODO: Uncomment this once we've enabled image building: https://github.com/kubernetes-sigs/image-builder/pull/49
+#       Addons (CNI) currently fail to deploy, likely due to a timeout with API server availability.
+#       Without a pre-built image, capz takes longer for the control plane to come up.
+#       In the meantime, we'll use a `postKubeadmCommands` in controlplane-0 (examples/controlplane/controlplane.yaml).
+#       Please also remove that command once we confirm the create-cluster target works again.
+#	$(CLUSTERCTL) \
+		alpha phases apply-addons -v=10 \
 		--kubeconfig=./kubeconfig \
 		-a examples/addons.yaml
 	# Create a worker node with MachineDeployment.

--- a/examples/addons.yaml
+++ b/examples/addons.yaml
@@ -388,6 +388,7 @@ rules:
       - networksets
       - clusterinformations
       - hostendpoints
+      - blockaffinities
     verbs:
       - get
       - list
@@ -515,7 +516,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.8.2
+          image: calico/cni:v3.9.1
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -535,7 +536,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.8.2
+          image: calico/cni:v3.9.1
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -569,7 +570,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.8.2
+          image: calico/pod2daemon-flexvol:v3.9.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -578,7 +579,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.8.2
+          image: calico/node:v3.9.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -631,10 +632,10 @@ spec:
             requests:
               cpu: 250m
           livenessProbe:
-            httpGet:
-              path: /liveness
-              port: 9099
-              host: localhost
+            exec:
+              command:
+              - /bin/calico-node
+              - -felix-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -745,7 +746,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.8.2
+          image: calico/kube-controllers:v3.9.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -70,6 +70,8 @@ spec:
         readOnly: true
   preKubeadmCommands:
   - bash -c /tmp/kubeadm-bootstrap.sh
+  postKubeadmCommands:
+  - kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/v1alpha2/examples/addons.yaml
   files:
   - path: /tmp/kubeadm-bootstrap.sh
     owner: "root:root"


### PR DESCRIPTION
**What this PR does / why we need it**:
Calico to v3.9.1.

Addons (CNI) currently fail to deploy, likely due to a timeout with
API server availability. Without a pre-built image, capz takes longer
for the control plane to come up. To work around this, we'll use a
`postKubeadmCommands` in controlplane-0
(examples/controlplane/controlplane.yaml). This should be removed once
we confirm the create-cluster target can successfully deploy CNI.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This should be the final (_knocks on wood_) piece before reintegrating to `master` branch.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Calico to v3.9.1
```