### PR TITLE
OWNERS: Add CAPI maintainers and update labels for SIG Cluster Lifecycle

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,15 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
+  - sig-cluster-lifecycle-leads
+  - cluster-api-admins
+  - cluster-api-maintainers
   - cluster-api-azure-maintainers
 
 reviewers:
+  - cluster-api-azure-maintainers
   - cluster-api-azure-reviewers
 
 labels:
-  - sig/azure
+  - sig/cluster-lifecycle
+  - area/provider/azure

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,21 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
 
 aliases:
+  sig-cluster-lifecycle-leads:
+    - luxas
+    - justinsb
+    - timothysc
+  cluster-api-admins:
+    - justinsb
+    - detiber
+    - davidewatson
+    - vincepri
+  cluster-api-maintainers:
+    - justinsb
+    - detiber
+    - ncdc
+    - vincepri
+    - chuckha
   cluster-api-azure-maintainers:
     - awesomenix
     - justaugustus


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**What this PR does / why we need it**:
ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/284, https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/276

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @vincepri @soggiest @awesomenix 
/priority important-soon
/milestone v0.3
/kind cleanup