### PR TITLE
Update default Kubernetes version to v1.16.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ examples/provider-components-base.yaml
 examples/provider-components/provider-components-*.yaml
 config/samples
 manager_image_patch.yaml-e
+
+# Bazel
+bazel-*

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ TODO
 
 This provider's versions are compatible with the following versions of Cluster API:
 
-|  | Cluster API `v1alpha1` (`v0.1.x`) | Cluster API `v1alpha2` (`v0.2.x`) (unreleased) |
+|  | Cluster API `v1alpha1` (`v0.1.x`) | Cluster API `v1alpha2` (`v0.2.x`) |
 |---|---|---|
 |Azure Provider `v0.2.x` | ✓ |  |
 |Azure Provider `v0.3.x` |  | ✓ |
@@ -42,6 +42,7 @@ This provider's versions are able to install and manage the following versions o
 | Kubernetes 1.13 | ✓ |  |
 | Kubernetes 1.14 | ✓ | ✓ |
 | Kubernetes 1.15 | ✓ | ✓ |
+| Kubernetes 1.16 |  | ✓ |
 
 
 Each version of Cluster API for Azure will attempt to support two Kubernetes versions e.g., Cluster API for Azure `v0.1` may support Kubernetes 1.13 and Kubernetes 1.14.

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -29,7 +29,7 @@ RANDOM_STRING=$(date | md5sum | head -c8)
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-capz-${RANDOM_STRING}}"
 export VNET_NAME="${VNET_NAME:-}"
-export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.15.3}"
+export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.1}"
 export KUBERNETES_SEMVER="${KUBERNETES_VERSION#v}"
 
 # Machine settings.


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**What this PR does / why we need it**:
Kubernetes 1.16.1 is out! https://github.com/kubernetes/kubernetes/releases/tag/v1.16.1

Holding until the debs/rpms are cut and I have a chance to test this.
/hold

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update default Kubernetes version to v1.16.1
```