### PR TITLE
:bug: Validate a location supports Availability Zones before VM creation

### DIFF
--- a/cloud/defaults.go
+++ b/cloud/defaults.go
@@ -37,6 +37,27 @@ const (
 	UserAgent = "cluster-api-azure-services"
 )
 
+// SupportedAvailabilityZoneLocations is a slice of the locations where Availability Zones are supported.
+// This is used to validate whether a virtual machine should leverage an Availability Zone.
+// Based on the Availability Zones listed in https://docs.microsoft.com/en-us/azure/availability-zones/az-overview
+var SupportedAvailabilityZoneLocations = []string{
+	// Americas
+	"centralus",
+	"eastus",
+	"eastus2",
+	"westus2",
+
+	// Europe
+	"francecentral",
+	"northeurope",
+	"uksouth",
+	"westeurope",
+
+	// Asia Pacific
+	"japaneast",
+	"southeastasia",
+}
+
 // GenerateVnetName generates a virtual network name, based on the cluster name.
 func GenerateVnetName(clusterName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, "vnet")


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce a new method (isAvailabilityZoneSupported) which determines if
Availability Zones are supported in a selected location based on
SupportedAvailabilityZoneLocations, a string slice built from the
supported zones listed in
https://docs.microsoft.com/en-us/azure/availability-zones/az-overview

Workaround for https://github.com/Azure/azure-sdk-for-go/issues/5968.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #294 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Validate a location supports Availability Zones before VM creation
```