### PR TITLE
update release binary golang version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ release-binary: $(RELEASE_DIR)
 		-e GOARCH=$(GOARCH) \
 		-v "$$(pwd):/workspace" \
 		-w /workspace \
-		golang:1.12.9 \
+		golang:1.12.10 \
 		go build -a -ldflags '-extldflags "-static"' \
 		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(RELEASE_BINARY)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
https://golang.org/doc/devel/release.html#go1.12
go1.12.10 (released 2019/09/25) includes security fixes to the net/http and net/textproto packages. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update  build golang version to 1.12.10
```