### PR TITLE
Bump kubernetes version in generated examples to 1.16.2

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -29,7 +29,7 @@ RANDOM_STRING=$(date | md5sum | head -c8)
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-capz-${RANDOM_STRING}}"
 export VNET_NAME="${VNET_NAME:-${CLUSTER_NAME}-vnet}"
-export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.1}"
+export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.2}"
 export KUBERNETES_SEMVER="${KUBERNETES_VERSION#v}"
 
 # Machine settings.


### PR DESCRIPTION

**What this PR does / why we need it**:
 - Bump the version of Kubernetes in the generate example script from 1.16.1 to 1.16.2
 - Bump the version of Kubernrtes in the conformance test script
 - 1.16.1 has (CVE-2019-11253)

**Special notes for your reviewer**:
related to: 
 - https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/236
 - https://github.com/kubernetes-sigs/image-builder/pull/87


**Release note**:
```release-note
The version of Kubernetes used in generated examples is now 1.16.2
```