### PR TITLE
🐛 fix auth in cloud provider

### DIFF
--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -75,20 +75,22 @@ spec:
     content: |
       {
         "cloud": "AzurePublicCloud",
-        "tenantID": "${AZURE_TENANT_ID}",
-        "subscriptionID": "${AZURE_SUBSCRIPTION_ID}",
+        "tenantId": "${AZURE_TENANT_ID}",
+        "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
+        "aadClientId": "${AZURE_CLIENT_ID}",
+        "aadClientSecret": "${AZURE_CLIENT_SECRET}",
         "resourceGroup": "${CLUSTER_NAME}",
         "securityGroupName": "${CLUSTER_NAME}-controlplane-nsg",
         "location": "${AZURE_LOCATION}",
-        "vmType": "vmss",
+        "vmType": "standard",
         "vnetName": "${CLUSTER_NAME}",
         "vnetResourceGroup": "${CLUSTER_NAME}",
         "subnetName": "${CLUSTER_NAME}-controlplane-subnet",
         "routeTableName": "${CLUSTER_NAME}-node-routetable",
         "userAssignedID": "${CLUSTER_NAME}",
-        "loadBalancerSku": "Standard",
+        "loadBalancerSku": "standard",
         "maximumLoadBalancerRuleCount": 250,
-        "useManagedIdentityExtension": true,
+        "useManagedIdentityExtension": false,
         "useInstanceMetadata": true
       }
 ---
@@ -150,19 +152,20 @@ spec:
       {
         "cloud": "AzurePublicCloud",
         "tenantID": "${AZURE_TENANT_ID}",
-        "subscriptionID": "${AZURE_SUBSCRIPTION_ID}",
+        "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
+        "aadClientId": "${AZURE_CLIENT_ID}",
+        "aadClientSecret": "${AZURE_CLIENT_SECRET}",
         "resourceGroup": "${CLUSTER_NAME}",
         "securityGroupName": "${CLUSTER_NAME}-controlplane-nsg",
         "location": "${AZURE_LOCATION}",
-        "vmType": "vmss",
+        "vmType": "standard",
         "vnetName": "${CLUSTER_NAME}",
         "vnetResourceGroup": "${CLUSTER_NAME}",
         "subnetName": "${CLUSTER_NAME}-controlplane-subnet",
         "routeTableName": "${CLUSTER_NAME}-node-routetable",
-        "userAssignedID": "${CLUSTER_NAME}",
-        "loadBalancerSku": "Standard",
+        "loadBalancerSku": "standard",
         "maximumLoadBalancerRuleCount": 250,
-        "useManagedIdentityExtension": true,
+        "useManagedIdentityExtension": false,
         "useInstanceMetadata": true
       }
 ---
@@ -223,19 +226,20 @@ spec:
     content: |
       {
         "cloud": "AzurePublicCloud",
-        "tenantID": "${AZURE_TENANT_ID}",
-        "subscriptionID": "${AZURE_SUBSCRIPTION_ID}",
+        "tenantId": "${AZURE_TENANT_ID}",
+        "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
+        "aadClientId": "${AZURE_CLIENT_ID}",
+        "aadClientSecret": "${AZURE_CLIENT_SECRET}",
         "resourceGroup": "${CLUSTER_NAME}",
         "securityGroupName": "${CLUSTER_NAME}-controlplane-nsg",
         "location": "${AZURE_LOCATION}",
-        "vmType": "vmss",
+        "vmType": "standard",
         "vnetName": "${CLUSTER_NAME}",
         "vnetResourceGroup": "${CLUSTER_NAME}",
         "subnetName": "${CLUSTER_NAME}-controlplane-subnet",
         "routeTableName": "${CLUSTER_NAME}-node-routetable",
-        "userAssignedID": "${CLUSTER_NAME}",
-        "loadBalancerSku": "Standard",
+        "loadBalancerSku": "standard",
         "maximumLoadBalancerRuleCount": 250,
-        "useManagedIdentityExtension": true,
+        "useManagedIdentityExtension": false,
         "useInstanceMetadata": true
       }

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -69,19 +69,20 @@ spec:
         content: |
           {
             "cloud": "AzurePublicCloud",
-            "tenantID": "${AZURE_TENANT_ID}",
-            "subscriptionID": "${AZURE_SUBSCRIPTION_ID}",
+            "tenantId": "${AZURE_TENANT_ID}",
+            "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
+            "aadClientId": "${AZURE_CLIENT_ID}",
+            "aadClientSecret": "${AZURE_CLIENT_SECRET}",
             "resourceGroup": "${CLUSTER_NAME}",
             "securityGroupName": "${CLUSTER_NAME}-node-nsg",
             "location": "${AZURE_LOCATION}",
-            "vmType": "vmss",
+            "vmType": "standard",
             "vnetName": "${CLUSTER_NAME}",
             "vnetResourceGroup": "${CLUSTER_NAME}",
             "subnetName": "${CLUSTER_NAME}-node-subnet",
             "routeTableName": "${CLUSTER_NAME}-node-routetable",
-            "userAssignedID": "${CLUSTER_NAME}",
-            "loadBalancerSku": "Standard",
+            "loadBalancerSku": "standard",
             "maximumLoadBalancerRuleCount": 250,
-            "useManagedIdentityExtension": true,
+            "useManagedIdentityExtension": false,
             "useInstanceMetadata": true
           }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds client secret auth to cloudprovider config (this allows the CP to create resources such as public ips from LoadBalancer type LB etc)
- Removes invalid `userAssignedID` field (user assigned identity field is called [`userAssignedIdentityId`](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/docs/cloud-provider-config.md#auth-configs) ) and disables managed identity until there is a design for emsi #312 
- Sets `vmType` to `standard` since we are using VMs, not VMSS

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds client secret auth to cloudprovider
```