### PR TITLE
✨ support the ability for public IPs on azuremachines

### DIFF
--- a/api/v1alpha2/azuremachine_types.go
+++ b/api/v1alpha2/azuremachine_types.go
@@ -50,6 +50,10 @@ type AzureMachineSpec struct {
 	// AzureMachine's value takes precedence.
 	// +optional
 	AdditionalTags Tags `json:"additionalTags,omitempty"`
+
+	// AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.
+	// +optional
+	AllocatePublicIP bool `json:"allocatePublicIP,omitempty"`
 }
 
 // AzureMachineStatus defines the observed state of AzureMachine

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -44,6 +44,10 @@ spec:
                 If both the AzureCluster and the AzureMachine specify the same tag
                 name with different values, the AzureMachine's value takes precedence.
               type: object
+            allocatePublicIP:
+              description: AllocatePublicIP allows the ability to create dynamic public
+                ips for machines where this value is true.
+              type: boolean
             availabilityZone:
               properties:
                 enabled:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -52,6 +52,10 @@ spec:
                         specify the same tag name with different values, the AzureMachine's
                         value takes precedence.
                       type: object
+                    allocatePublicIP:
+                      description: AllocatePublicIP allows the ability to create dynamic
+                        public ips for machines where this value is true.
+                      type: boolean
                     availabilityZone:
                       properties:
                         enabled:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will add the ability to request that public IPs be allocated for
a given azuremachine/machinedeployment. The request for allocation is
simply part of the azuremachine manifest, like so:

```
spec:
  allocatePublicIP: true
```

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```