### PR TITLE
🏃 Add default Marketplace image logic

### DIFF
--- a/api/v1alpha2/azuremachine_types.go
+++ b/api/v1alpha2/azuremachine_types.go
@@ -37,7 +37,7 @@ type AzureMachineSpec struct {
 	VMSize           string           `json:"vmSize"`
 	AvailabilityZone AvailabilityZone `json:"availabilityZone,omitempty"`
 
-	Image Image `json:"image"`
+	Image *Image `json:"image,omitempty"`
 
 	OSDisk OSDisk `json:"osDisk"`
 

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -255,7 +255,11 @@ func (in *AzureMachineSpec) DeepCopyInto(out *AzureMachineSpec) {
 		**out = **in
 	}
 	in.AvailabilityZone.DeepCopyInto(&out.AvailabilityZone)
-	in.Image.DeepCopyInto(&out.Image)
+	if in.Image != nil {
+		in, out := &in.Image, &out.Image
+		*out = new(Image)
+		(*in).DeepCopyInto(*out)
+	}
 	out.OSDisk = in.OSDisk
 	if in.AdditionalTags != nil {
 		in, out := &in.AdditionalTags, &out.AdditionalTags

--- a/cloud/defaults.go
+++ b/cloud/defaults.go
@@ -18,6 +18,10 @@ package azure
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha2"
 )
 
 const (
@@ -35,6 +39,15 @@ const (
 	DefaultAzureDNSZone = "cloudapp.azure.com"
 	// UserAgent used for communicating with azure
 	UserAgent = "cluster-api-azure-services"
+)
+
+const (
+	// DefaultImageOfferID is the default Azure Marketplace offer ID
+	DefaultImageOfferID = "capi"
+	// DefaultImagePublisherID is the default Azure Marketplace publisher ID
+	DefaultImagePublisherID = "cncf-upstream"
+	// LatestVersion is the image version latest
+	LatestVersion = "latest"
 )
 
 // SupportedAvailabilityZoneLocations is a slice of the locations where Availability Zones are supported.
@@ -116,4 +129,31 @@ func GenerateNICName(machineName string) string {
 // GenerateOSDiskName generates the name of an OS disk based on the name of a VM.
 func GenerateOSDiskName(machineName string) string {
 	return fmt.Sprintf("%s_OSDisk", machineName)
+}
+
+// GetDefaultImageSKUID gets the SKU ID of the image to use for the provided version of Kubernetes.
+func getDefaultImageSKUID(k8sVersion string) string {
+	if strings.HasPrefix(k8sVersion, "v1.16") {
+		return "k8s-1dot16-ubuntu-1804"
+	}
+	if strings.HasPrefix(k8sVersion, "v1.15") {
+		return "k8s-1dot15-ubuntu-1804"
+	}
+	if strings.HasPrefix(k8sVersion, "v1.14") {
+		return "k8s-1dot14-ubuntu-1804"
+	}
+	if strings.HasPrefix(k8sVersion, "v1.13") {
+		return "k8s-1dot13-ubuntu-1804"
+	}
+	return ""
+}
+
+// GetDefaultUbuntuImage returns the default image spec for Ubuntu.
+func GetDefaultUbuntuImage(k8sVersion string) infrav1.Image {
+	return infrav1.Image{
+		Publisher: to.StringPtr(DefaultImagePublisherID),
+		Offer:     to.StringPtr(DefaultImageOfferID),
+		SKU:       to.StringPtr(getDefaultImageSKUID(k8sVersion)),
+		Version:   to.StringPtr(LatestVersion),
+	}
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -109,7 +109,6 @@ spec:
             vmSize:
               type: string
           required:
-          - image
           - location
           - osDisk
           - sshPublicKey

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -118,7 +118,6 @@ spec:
                     vmSize:
                       type: string
                   required:
-                  - image
                   - location
                   - osDisk
                   - sshPublicKey

--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -24,11 +24,6 @@ metadata:
 spec:
   location: ${AZURE_LOCATION}
   vmSize: ${CONTROL_PLANE_MACHINE_TYPE}
-  image:
-    publisher: "cncf-upstream"
-    offer: "capi"
-    sku: "k8s-1dot16-ubuntu-1804"
-    version: "latest"
   osDisk:
     osType: "Linux"
     diskSizeGB: 30
@@ -120,11 +115,6 @@ metadata:
 spec:
   location: ${AZURE_LOCATION}
   vmSize: ${CONTROL_PLANE_MACHINE_TYPE}
-  image:
-    publisher: "cncf-upstream"
-    offer: "capi"
-    sku: "k8s-1dot16-ubuntu-1804"
-    version: "latest"
   osDisk:
     osType: "Linux"
     diskSizeGB: 30
@@ -195,11 +185,6 @@ metadata:
 spec:
   location: ${AZURE_LOCATION}
   vmSize: ${CONTROL_PLANE_MACHINE_TYPE}
-  image:
-    publisher: "cncf-upstream"
-    offer: "capi"
-    sku: "k8s-1dot16-ubuntu-1804"
-    version: "latest"
   osDisk:
     osType: "Linux"
     diskSizeGB: 30

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -37,11 +37,6 @@ spec:
     spec:
       location: ${AZURE_LOCATION}
       vmSize: ${NODE_MACHINE_TYPE}
-      image:
-        publisher: "cncf-upstream"
-        offer: "capi"
-        sku: "k8s-1dot16-ubuntu-1804"
-        version: "latest"
       osDisk:
         osType: "Linux"
         diskSizeGB: 30


### PR DESCRIPTION
**What this PR does / why we need it**:
- if an image ID is provided, use that image
- if a shared gallery image is provided, use that image
- if an Azure Marketplace image is provided, use that image
- else, use the default image for that Kubernetes version (i.e. latest version for that SKU)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #300 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add defaults for VM images
```