### PR TITLE
fix: developer getting started docs with working example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,18 +280,7 @@ release-notes: $(RELEASE_NOTES)
 ## --------------------------------------
 
 .PHONY: create-cluster
-create-cluster: $(CLUSTERCTL) ## Create a development Kubernetes cluster on Azure using examples
-	$(CLUSTERCTL) \
-	create cluster -v 4 \
-	--bootstrap-flags="name=clusterapi" \
-	--bootstrap-type kind \
-	-m ./examples/_out/controlplane.yaml \
-	-c ./examples/_out/cluster.yaml \
-	-p ./examples/_out/provider-components.yaml \
-	-a ./examples/addons.yaml
-
-.PHONY: create-cluster-management
-create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes cluster on Azure in a KIND management cluster.
+create-cluster: ## Create a development Kubernetes cluster on Azure in a KIND management cluster.
 	kind create cluster --name=clusterapi
 	# Apply provider-components.
 	kubectl \
@@ -301,35 +290,40 @@ create-cluster-management: $(CLUSTERCTL) ## Create a development Kubernetes clus
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		create -f examples/_out/cluster.yaml
-	# Create control plane machine.
+	# Create control plane machines.
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		create -f examples/_out/controlplane.yaml
-	# Get KubeConfig using clusterctl.
-	$(CLUSTERCTL) \
-		alpha phases get-kubeconfig -v=3 \
+	# wait for the first control plane machine to be ready
+	./examples/wait-for-ready.sh
+	# Fetch the Kubeconfig for the target cluster
+	source ./examples/_out/.env; \
+	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
-		--namespace=default \
-		--cluster-name=$(CLUSTER_NAME)
-	# Apply addons on the target cluster, waiting for the control-plane to become available.
-	$(CLUSTERCTL) \
-		alpha phases apply-addons -v=10 \
-		--kubeconfig=./kubeconfig \
-		-a examples/addons.yaml
-	# Create a worker node with MachineDeployment.
+		--namespace=default get secret/$$CLUSTER_NAME-kubeconfig -o json \
+		| jq -r .data.value \
+		| base64 --decode > ./examples/_out/clusterapi.kubeconfig
+
+	# Deploy a CNI soution, Calico
+	kubectl --kubeconfig=./examples/_out/clusterapi.kubeconfig \
+	  apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
+	# Create 2 worker nodes with MachineDeployment.
 	kubectl \
 		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		create -f examples/_out/machinedeployment.yaml
 
+	@echo 'run "kubectl --kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") ..." to work with the kind cluster'
+	@echo 'run "kubectl --kubeconfig=./examples/_out/clusterapi.kubeconfig ..." to work with the new target cluster'
+
 .PHONY: delete-cluster
-delete-cluster: $(CLUSTERCTL) ## Deletes the development Kubernetes Cluster "test1"
-	$(CLUSTERCTL) \
-	delete cluster -v 4 \
-	--bootstrap-type kind \
-	--bootstrap-flags="name=clusterapi" \
-	--cluster $(CLUSTER_NAME) \
-	--kubeconfig ./kubeconfig \
-	-p ./examples/_out/provider-components.yaml \
+delete-cluster: $(CLUSTERCTL) ## Deletes the example Kubernetes Cluster "clusterapi"
+	# Fetch the Kubeconfig for the target cluster
+	source ./examples/_out/.env; \
+	kubectl \
+		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
+		delete cluster $$CLUSTER_NAME
+
+	kind delete cluster --name=clusterapi
 
 .PHONY: kind-reset
 kind-reset: ## Destroys the "clusterapi" kind cluster.

--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -74,7 +74,7 @@ spec:
         "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
         "aadClientId": "${AZURE_CLIENT_ID}",
         "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-        "resourceGroup": "${CLUSTER_NAME}",
+        "resourceGroup": "${AZURE_RESOURCE_GROUP}",
         "securityGroupName": "${CLUSTER_NAME}-controlplane-nsg",
         "location": "${AZURE_LOCATION}",
         "vmType": "standard",

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -27,7 +27,7 @@ command -v "${ENVSUBST}" >/dev/null 2>&1 || echo -v "Cannot find ${ENVSUBST} in 
 RANDOM_STRING=$(date | md5sum | head -c8)
 
 # Cluster.
-export CLUSTER_NAME="${CLUSTER_NAME:-capz-${RANDOM_STRING}}"
+export CLUSTER_NAME="${CLUSTER_NAME:-capz-example-${RANDOM_STRING}}"
 export VNET_NAME="${VNET_NAME:-${CLUSTER_NAME}-vnet}"
 export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.2}"
 export KUBERNETES_SEMVER="${KUBERNETES_VERSION#v}"
@@ -49,6 +49,7 @@ PROVIDER_COMPONENTS_GENERATED_FILE=${OUTPUT_DIR}/provider-components.yaml
 CLUSTER_GENERATED_FILE=${OUTPUT_DIR}/cluster.yaml
 CONTROLPLANE_GENERATED_FILE=${OUTPUT_DIR}/controlplane.yaml
 MACHINEDEPLOYMENT_GENERATED_FILE=${OUTPUT_DIR}/machinedeployment.yaml
+ENV_GENERATED_FILE=${OUTPUT_DIR}/.env
 
 # Overwrite flag.
 OVERWRITE=0
@@ -126,11 +127,11 @@ kustomize build "${SOURCE_DIR}/machinedeployment" | envsubst >> "${MACHINEDEPLOY
 echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.
-curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.2.3/cluster-api-components.yaml > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.2.7/cluster-api-components.yaml > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 echo "Downloaded ${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 
 # Generate Kubeadm Bootstrap Provider components file.
-curl -L https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases/download/v0.1.1/bootstrap-components.yaml > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
+curl -L https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases/download/v0.1.5/bootstrap-components.yaml > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
 echo "Downloaded ${COMPONENTS_KUBEADM_GENERATED_FILE}"
 
 # Generate Azure Infrastructure Provider components file.
@@ -141,3 +142,5 @@ echo "Generated ${COMPONENTS_AZURE_GENERATED_FILE}"
 kustomize build "${SOURCE_DIR}/provider-components" | envsubst > "${PROVIDER_COMPONENTS_GENERATED_FILE}"
 echo "Generated ${PROVIDER_COMPONENTS_GENERATED_FILE}"
 echo "WARNING: ${PROVIDER_COMPONENTS_GENERATED_FILE} includes Azure credentials"
+
+echo "CLUSTER_NAME=${CLUSTER_NAME}" > "${ENV_GENERATED_FILE}"

--- a/examples/wait-for-ready.sh
+++ b/examples/wait-for-ready.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Directories.
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+OUTPUT_DIR=${OUTPUT_DIR:-${SOURCE_DIR}/_out}
+
+ENV_GENERATED_FILE=${OUTPUT_DIR}/.env
+
+# shellcheck disable=SC1090
+source "${ENV_GENERATED_FILE}"
+
+ready="false"
+kubeconfigPath=$(kind get kubeconfig-path --name="clusterapi")
+echo "Waiting for any machine in cluster ${CLUSTER_NAME} to be in running state..."
+while [ $ready == "false" ]; do
+  output=$(kubectl --kubeconfig="$kubeconfigPath" get machines -o json)
+  ready=$(echo "$output" | jq -r 'any(.items[]; .status.phase=="running")')
+  [ "$ready" == "false" ] && echo "Waiting..." && sleep 30
+done
+echo 'found a running Machine'


### PR DESCRIPTION
**What this PR does / why we need it**:

The developer getting started docs are really out of date. When trying to follow `./docs/devepment.md`, I ran across several broken commands and missing guidance.

In this PR, I address getting an initial example cluster up and running.
- add kustomize to the required tooling
- remove dependency on `clusterctl` for `make cluster-create`
- add information about generating and cleaning up example manifests
- add wait until ready script to provide status updates while machines are provisioning
- remove content about go vendor directories
- output a `.env` file during example generation to help with commands that may need to be run later

TODOs:
- `make test` doesn't work on my local machine. Seems like `./scripts/fetch_ext_bins.sh` is only called during CI runs and is not really described for local development. Perhaps, make test should execute tests in a container and replicate the CI infra? See below for error.

```
Running Suite: Controller Suite
===============================
Random Seed: 1574273964
Will run 2 of 2 specs

E1120 10:19:24.496084   37823 server.go:228] controller-runtime/test-env "msg"="unable to start the controlplane" "error"="fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"  "tries"=0
E1120 10:19:24.498637   37823 server.go:228] controller-runtime/test-env "msg"="unable to start the controlplane" "error"="fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"  "tries"=1
E1120 10:19:24.501045   37823 server.go:228] controller-runtime/test-env "msg"="unable to start the controlplane" "error"="fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"  "tries"=2
E1120 10:19:24.503288   37823 server.go:228] controller-runtime/test-env "msg"="unable to start the controlplane" "error"="fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"  "tries"=3
E1120 10:19:24.505579   37823 server.go:228] controller-runtime/test-env "msg"="unable to start the controlplane" "error"="fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory"  "tries"=4
STEP: bootstrapping test environment
Failure [0.015 seconds]
[BeforeSuite] BeforeSuite
/Users/davidjustice/code/k8s/capz/controllers/suite_test.go:59

  Unexpected error:
      <*errors.errorString | 0xc000496bb0>: {
          s: "failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory",
      }
      failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory
  occurred

  /Users/davidjustice/code/k8s/capz/controllers/suite_test.go:69
------------------------------
STEP: tearing down the test environment
Panic [0.000 seconds]
[AfterSuite] AfterSuite
/Users/davidjustice/code/k8s/capz/controllers/suite_test.go:84

  Test Panicked
  runtime error: invalid memory address or nil pointer dereference
``` 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update developer getting started documentation.
```