### PR TITLE
fix: make test should work without having to run ./script/ci-test first

### DIFF
--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -23,7 +23,4 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${REPO_ROOT}/hack/ensure-go.sh"
 
 cd "${REPO_ROOT}" && \
-	source ./scripts/fetch_ext_bins.sh && \
-	fetch_tools && \
-	setup_envs && \
 	make test

--- a/scripts/fetch_ext_bins.sh
+++ b/scripts/fetch_ext_bins.sh
@@ -58,8 +58,9 @@ function header_text {
   echo "$header$*$reset"
 }
 
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+tools_bin=${REPO_ROOT}/hack/tools/bin
 tmp_root=/tmp
-
 kb_root_dir=${tmp_root}/kubebuilder
 
 # Skip fetching and untaring the tools by setting the SKIP_FETCH_TOOLS variable
@@ -70,18 +71,6 @@ kb_root_dir=${tmp_root}/kubebuilder
 # If you skip fetching tools, this script will use the tools already on your
 # machine, but rebuild the kubebuilder and kubebuilder-bin binaries.
 SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
-
-function prepare_staging_dir {
-  header_text "preparing staging dir"
-
-  if [[ -z "${SKIP_FETCH_TOOLS}" ]]; then
-    rm -rf "${kb_root_dir}"
-  else
-    rm -f "${kb_root_dir}/kubebuilder/bin/kubebuilder"
-    rm -f "${kb_root_dir}/kubebuilder/bin/kubebuilder-gen"
-    rm -f "${kb_root_dir}/kubebuilder/bin/vendor.tar.gz"
-  fi
-}
 
 # fetch k8s API gen tools and make it available under kb_root_dir/bin.
 function fetch_tools {
@@ -98,14 +87,7 @@ function fetch_tools {
     curl -fsL ${kb_tools_download_url} -o "${kb_tools_archive_path}"
   fi
   tar -zvxf "${kb_tools_archive_path}" -C "${tmp_root}/"
-}
 
-function setup_envs {
-  header_text "setting up env vars"
-
-  # Setup env vars
-  export PATH=/tmp/kubebuilder/bin:$PATH
-  export TEST_ASSET_KUBECTL=/tmp/kubebuilder/bin/kubectl
-  export TEST_ASSET_KUBE_APISERVER=/tmp/kubebuilder/bin/kube-apiserver
-  export TEST_ASSET_ETCD=/tmp/kubebuilder/bin/etcd
+  mkdir -p "${tools_bin}"
+  mv "${kb_root_dir}"/bin/* "${tools_bin}"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

If you clone the repo initially and run make test, you will not have some of the things needed to run the tests (etcd, kube-apiserver, etc). These bins are installed in `./scripts/fetch_ext_bins.sh`, which is invoked in `./scripts/ci-test.sh`, which seems unintuitive to invoke rather than `make test`.

This PR will install the bins when `make test` is invoked allowing the tests to be executed without invoking the bin install through `./scripts/ci-test.sh`.

related: #331 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```