### PR TITLE
:runner: placeholder e2e shell script

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+
+# This script is part of the e2e effort. Current plan is to:
+# - Merge dummy ci-e2e script
+# - Create a prow presubmit that calls the dummy script
+# - Fill in the ci-e2e along with the e2e PR


### PR DESCRIPTION
Signed-off-by: Javier Darsie jadarsie@microsoft.com

**What this PR does / why we need it**:

This PR is part of the e2e effort. The goal is to have the e2e check before the suite is ready for review. 

Current plan is to:
- Merge dummy `ci-e2e.sh` (this PR)
- Add a prow [presubmit](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml) that calls the dummy script (`test-infra` repo)
- Update the e2e PR (#326) to call `make test-e2e` from `ci-e2e.sh` 

**Release note**:

```release-note
NONE
```