### PR TITLE
Change kind min version to 0.6.1 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,22 +297,18 @@ create-cluster: ## Create a development Kubernetes cluster on Azure in a KIND ma
 	kind create cluster --name=clusterapi
 	# Apply provider-components.
 	kubectl \
-		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		create -f examples/_out/provider-components.yaml
 	# Create Cluster.
 	kubectl \
-		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		create -f examples/_out/cluster.yaml
 	# Create control plane machines.
 	kubectl \
-		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		create -f examples/_out/controlplane.yaml
 	# wait for the first control plane machine to be ready
 	./examples/wait-for-ready.sh
 	# Fetch the Kubeconfig for the target cluster
 	source ./examples/_out/.env; \
 	kubectl \
-		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		--namespace=default get secret/$$CLUSTER_NAME-kubeconfig -o json \
 		| jq -r .data.value \
 		| base64 --decode > ./examples/_out/clusterapi.kubeconfig
@@ -322,10 +318,9 @@ create-cluster: ## Create a development Kubernetes cluster on Azure in a KIND ma
 	  apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
 	# Create 2 worker nodes with MachineDeployment.
 	kubectl \
-		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		create -f examples/_out/machinedeployment.yaml
 
-	@echo 'run "kubectl --kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") ..." to work with the kind cluster'
+	@echo 'Set kubectl context to the kind management cluster by running "kubectl config set-context kind-clusterapi"'
 	@echo 'run "kubectl --kubeconfig=./examples/_out/clusterapi.kubeconfig ..." to work with the new target cluster'
 
 .PHONY: delete-cluster
@@ -333,7 +328,6 @@ delete-cluster: $(CLUSTERCTL) ## Deletes the example Kubernetes Cluster "cluster
 	# Fetch the Kubeconfig for the target cluster
 	source ./examples/_out/.env; \
 	kubectl \
-		--kubeconfig=$$(kind get kubeconfig-path --name="clusterapi") \
 		delete cluster $$CLUSTER_NAME
 
 	kind delete cluster --name=clusterapi

--- a/docs/development.md
+++ b/docs/development.md
@@ -177,8 +177,6 @@ Launch a bootstrap cluster and then run the generated manifests creating a targe
 While cluster build out is running, you can optionally follow the controller logs in a separate window as follows:
 
 ```bash
-export KUBECONFIG="$(kind get kubeconfig-path --name="clusterapi")" # Export the kind kubeconfig
-
 time kubectl get po -o wide --all-namespaces -w # Watch pod creation until azure-provider-controller-manager-0 is available
 
 kubectl logs azure-provider-controller-manager-0 -n azure-provider-system -f # Follow the controller logs

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,9 +43,9 @@
 - [Go]
 
 [brew]: https://brew.sh/
-[Go]: https://golang.org/dl/
+[go]: https://golang.org/dl/
 [jq]: https://stedolan.github.io/jq/download/
-[KIND]: https://sigs.k8s.io/kind
+[kind]: https://sigs.k8s.io/kind
 [kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [kustomize]: https://github.com/kubernetes-sigs/kustomize
 
@@ -66,6 +66,7 @@ If you're interested in developing cluster-api-provider-azure and getting the la
 An Azure Service Principal is needed for usage by the `clusterctl` tool and for populating the controller manifests. This utilizes [environment-based authentication](https://docs.microsoft.com/en-us/go/azure/azure-sdk-go-authorization#use-environment-based-authentication).
 
 The following environment variables should be set:
+
 - `AZURE_SUBSCRIPTION_ID`
 - `AZURE_TENANT_ID`
 - `AZURE_CLIENT_ID`
@@ -86,6 +87,7 @@ tar -xvf cluster-api-provider-azure-examples.tar
 A set of sane defaults are utilized when generating manifests via `./azure/generate-yaml.sh`, but these can be overridden by exporting environment variables.
 
 Here is a list of commonly overriden configuration parameters (the full list is available in `./azure/generate-yaml.sh`):
+
 ```bash
 # Azure settings.
 export AZURE_LOCATION="eastus"
@@ -162,7 +164,6 @@ I0324 23:23:58.081879   27739 kind.go:72] Ran: kind [create cluster --name=clust
  ✓ [control-plane] Starting Kubernetes (this may take a minute) ☸
 Cluster creation complete. You can now use the cluster with:
 
-export KUBECONFIG="$(kind get kubeconfig-path --name="clusterapi")"
 kubectl cluster-info
 I0324 23:23:58.081925   27739 kind.go:69] Running: kind [get kubeconfig-path --name=clusterapi]
 I0324 23:23:58.149609   27739 kind.go:72] Ran: kind [get kubeconfig-path --name=clusterapi] Output: /home/fakeuser/.kube/kind-config-clusterapi
@@ -234,9 +235,10 @@ I0324 23:53:58.997892   27739 createbootstrapcluster.go:36] Cleaning up bootstra
 I0324 23:53:58.997937   27739 kind.go:69] Running: kind [delete cluster --name=clusterapi]
 I0324 23:54:00.260254   27739 kind.go:72] Ran: kind [delete cluster --name=clusterapi] Output: Deleting cluster "clusterapi" ...
 ```
+
 </details>
 
-The created KIND cluster is ephemeral and is cleaned up automatically when done. During the cluster creation, the KIND configuration is written to a local directory and can be retrieved using `kind get kubeconfig-path --name="clusterapi"`.
+The created KIND cluster is ephemeral and is cleaned up automatically when done. During the cluster creation, the kubectl context is set to "kind-clusterapi" and can be retrieved using `kubectl cluster-info --context kind-clusterapi`.
 
 For a more in-depth look into what `clusterctl` is doing during this create step, please see the [clusterctl document](/docs/clusterctl.md).
 
@@ -245,12 +247,12 @@ For a more in-depth look into what `clusterctl` is doing during this create step
 The kubeconfig for the new cluster is created in the directory from where the above `clusterctl create` was run.
 
 Run the following command to point `kubectl` to the kubeconfig of the new cluster:
+
 ```bash
 export KUBECONFIG=$(pwd)/kubeconfig
 ```
 
 Alternatively, move the kubeconfig file to a desired location and set the `KUBECONFIG` environment variable accordingly.
-
 
 ## Troubleshooting
 
@@ -259,7 +261,6 @@ Alternatively, move the kubeconfig file to a desired location and set the `KUBEC
 Logs can be tailed using [`kubectl`][kubectl]:
 
 ```bash
-export KUBECONFIG=$(kind get kubeconfig-path --name="clusterapi")
 kubectl logs azure-provider-controller-manager-0 -n azure-provider-system -f
 ```
 

--- a/examples/wait-for-ready.sh
+++ b/examples/wait-for-ready.sh
@@ -23,10 +23,9 @@ ENV_GENERATED_FILE=${OUTPUT_DIR}/.env
 source "${ENV_GENERATED_FILE}"
 
 ready="false"
-kubeconfigPath=$(kind get kubeconfig-path --name="clusterapi")
 echo "Waiting for any machine in cluster ${CLUSTER_NAME} to be in running state..."
 while [ $ready == "false" ]; do
-  output=$(kubectl --kubeconfig="$kubeconfigPath" get machines -o json)
+  output=$(kubectl get machines -o json)
   ready=$(echo "$output" | jq -r 'any(.items[]; .status.phase=="running")')
   [ "$ready" == "false" ] && echo "Waiting..." && sleep 30
 done

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KIND_VERSION=v0.5.1
+MINIMUM_KIND_VERSION=v0.6.1
 
 # Ensure the kind tool exists and is a viable version, or installs it
 verify_kind_version() {
@@ -41,7 +41,7 @@ verify_kind_version() {
 
   local kind_version
   kind_version=$(kind version)
-  if [[ "${MINIMUM_KIND_VERSION}" != $(echo -e "${MINIMUM_KIND_VERSION}\n${kind_version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+   if ! [[ "${kind_version}" =~ ${MINIMUM_KIND_VERSION} ]]; then
     cat <<EOF
 Detected kind version: ${kind_version}.
 Requires ${MINIMUM_KIND_VERSION} or greater.


### PR DESCRIPTION
**What this PR does / why we need it**:
 - change min version of kind to 0.6.1
 - remove `--kubeconfig=$(kind get kubeconfig-path --name="clusterapi")` from Makefile and scripts

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #355 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kind minimum version used in testing is now 0.6.1
```