### PR TITLE
increase e2e timeout for delete cluster to 20 min

### DIFF
--- a/test/e2e/framework/clean_up.go
+++ b/test/e2e/framework/clean_up.go
@@ -36,7 +36,7 @@ type CleanUpInput struct {
 
 func (c *CleanUpInput) setDefaults() {
 	if c.DeleteTimeout == 0*time.Second {
-		c.DeleteTimeout = 10 * time.Minute
+		c.DeleteTimeout = 20 * time.Minute
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
 - increase e2e timeout for delete cluster to `20` mins _(instead of 10 mins)_  to fix e2e tests


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```