### PR TITLE
Add log artifacts for E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ bazel-*
 # Tilt files.
 .tiltbuild
 
-# junit output
+# e2e output
 test/e2e/junit.e2e_suite.*.xml
+test/e2e/logs/*

--- a/test/e2e/framework/management/kind/mgmt.go
+++ b/test/e2e/framework/management/kind/mgmt.go
@@ -203,6 +203,15 @@ func (c *Cluster) ClientFromRestConfig(restConfig *rest.Config) (client.Client, 
 	return c.Client, nil
 }
 
+// GetClientSet returns a clientset to the management cluster to be used for object interface expansions such as pod logs.
+func (c *Cluster) GetClientSet() (*kubernetes.Clientset, error) {
+	restConfig, err := clientcmd.BuildConfigFromFlags("", c.KubeconfigPath)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return kubernetes.NewForConfig(restConfig)
+}
+
 // GetClient returns a controller-rutnime client for the management cluster.
 func (c *Cluster) GetClient() (client.Client, error) {
 	restConfig, err := clientcmd.BuildConfigFromFlags("", c.KubeconfigPath)


### PR DESCRIPTION
**What this PR does / why we need it**: Collect capz and cabpk controller-manager logs after each E2E test suite.
Also change the default VM size to one with more quota in the CI subscription, and fix the image to match the default k8s version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```