### PR TITLE
Removing soggiest from project owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,7 +20,6 @@ aliases:
     - awesomenix
     - CecileRobertMichon
     - justaugustus
-    - soggiest
   cluster-api-azure-reviewers:
     - juan-lee
     - nader-ziada


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing myself as a maintainer of CAPZ. I haven't been able to work on it in the recent past and I don't feel I can safely say I can maintain this project anymore.

**Special notes for your reviewer**:

It's been a pleasure watching this project come to fruition and getting to work with you all. I hope I get the chance to work with you all again.

```release-note
NONE
```