### PR TITLE
chore: add proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,33 @@
+---
+name: Enhancement Proposal
+about: Propose larger efforts, breaking changes, or new features
+
+---
+
+> ⚠️ Cluster API Azure maintainers can ask to turn an issue-proposal into a [CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/YYYYMMDD-template.md) when necessary. This is to be expected for large changes that impact multiple components, breaking changes, or new large features.
+
+***Goals***
+1. Goal 1
+1. Goal 2
+
+***Non-Goals/Future Work***
+1. Non-Goal 1
+1. Non-Goal 2
+
+**User Story**
+
+As a [developer/user/operator] I would like to [high level description] for [reasons]
+
+**Detailed Description**
+
+[A clear and concise description of what you want to happen.]
+
+**Contract changes [optional]**
+
+[Describe contract changes between Cluster API Azure Provider controllers, if applicable.]
+
+**Data model changes [optional]**
+
+[Describe contract changes between Cluster API Azure Provider controllers, if applicable.]
+
+/kind proposal


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a proposals template. We need it because the repo does not have one. By placing a template, we can encourage new proposal and provide a standard format for such proposals.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add proposal issue template based on CAPI template
```