### PR TITLE
🐛 Fix capi selector in make create-cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ create-cluster: ## Create a development Kubernetes cluster on Azure in a KIND ma
 		create -f examples/_out/provider-components.yaml
 	# Wait for capi-controller 
 	kubectl \
-		wait --for=condition=Ready --timeout=5m -n capi-system pod -l control-plane=cluster-api-controller-manager
+		wait --for=condition=Ready --timeout=5m -n capi-system pod -l control-plane=controller-manager
     # Wait for capz-controller 
 	kubectl \
 		wait --for=condition=Ready --timeout=5m -n capz-system pod -l control-plane=capz-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**: The selector is `controller-manager`, not `cluster-api-controller-manager`. https://github.com/kubernetes-sigs/cluster-api/blob/master/config/manager/manager.yaml#L12

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix capi selector in make create-cluster
```