### PR TITLE
:runner: Add clusterctl-settings.json

### DIFF
--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -1,0 +1,7 @@
+{
+  "name": "infrastructure-azure",
+  "config": {
+    "componentsFile": "infrastructure-components.yaml",
+    "nextVersion": "v0.4.0"
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds the clusterctl-settings.json so the Azure provider can be tested with clusterctl even if now there are no published releases for v1alpha3

XRef #kubernetes-sigs/cluster-api#2027

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add clusterctl-settings.json
```