### PR TITLE
🏃tests: Followup add a few more tests - testing invalid specs

### DIFF
--- a/cloud/services/disks/disks.go
+++ b/cloud/services/disks/disks.go
@@ -43,7 +43,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	diskSpec, ok := spec.(*Spec)
 	if !ok {
-		return errors.New("Invalid disk specification")
+		return errors.New("invalid disk specification")
 	}
 	klog.V(2).Infof("deleting disk %s", diskSpec.Name)
 	err := s.Client.Delete(ctx, s.Scope.ResourceGroup(), diskSpec.Name)

--- a/cloud/services/internalloadbalancers/internalloadbalancers_test.go
+++ b/cloud/services/internalloadbalancers/internalloadbalancers_test.go
@@ -39,6 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const expectedInvalidSpec = "invalid internal load balancer specification"
+
 func init() {
 	clusterv1.AddToScheme(scheme.Scheme)
 }
@@ -86,7 +88,7 @@ func TestInvalidInternalLBSpec(t *testing.T) {
 	if err == nil {
 		t.Fatalf("it should fail")
 	}
-	if err.Error() != "invalid internal load balancer specification" {
+	if err.Error() != expectedInvalidSpec {
 		t.Fatalf("got an unexpected error: %v", err)
 	}
 
@@ -94,7 +96,7 @@ func TestInvalidInternalLBSpec(t *testing.T) {
 	if err == nil {
 		t.Fatalf("it should fail")
 	}
-	if err.Error() != "invalid internal load balancer specification" {
+	if err.Error() != expectedInvalidSpec {
 		t.Fatalf("got an unexpected error: %v", err)
 	}
 
@@ -102,7 +104,7 @@ func TestInvalidInternalLBSpec(t *testing.T) {
 	if err == nil {
 		t.Fatalf("it should fail")
 	}
-	if err.Error() != "invalid internal load balancer specification" {
+	if err.Error() != expectedInvalidSpec {
 		t.Fatalf("got an unexpected error: %v", err)
 	}
 }

--- a/cloud/services/publicloadbalancers/publicloadbalancers_test.go
+++ b/cloud/services/publicloadbalancers/publicloadbalancers_test.go
@@ -36,6 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const expectedInvalidSpec = "invalid public loadbalancer specification"
+
 func init() {
 	clusterv1.AddToScheme(scheme.Scheme)
 }
@@ -83,7 +85,7 @@ func TestInvalidPublicLBSpec(t *testing.T) {
 	if err == nil {
 		t.Fatalf("it should fail")
 	}
-	if err.Error() != "invalid public loadbalancer specification" {
+	if err.Error() != expectedInvalidSpec {
 		t.Fatalf("got an unexpected error: %v", err)
 	}
 
@@ -91,7 +93,7 @@ func TestInvalidPublicLBSpec(t *testing.T) {
 	if err == nil {
 		t.Fatalf("it should fail")
 	}
-	if err.Error() != "invalid public loadbalancer specification" {
+	if err.Error() != expectedInvalidSpec {
 		t.Fatalf("got an unexpected error: %v", err)
 	}
 
@@ -99,7 +101,7 @@ func TestInvalidPublicLBSpec(t *testing.T) {
 	if err == nil {
 		t.Fatalf("it should fail")
 	}
-	if err.Error() != "invalid public loadbalancer specification" {
+	if err.Error() != expectedInvalidSpec {
 		t.Fatalf("got an unexpected error: %v", err)
 	}
 }

--- a/cloud/services/publicloadbalancers/publicloadbalancers_test.go
+++ b/cloud/services/publicloadbalancers/publicloadbalancers_test.go
@@ -40,6 +40,70 @@ func init() {
 	clusterv1.AddToScheme(scheme.Scheme)
 }
 
+func TestInvalidPublicLBSpec(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	publicLBMock := mock_publicloadbalancers.NewMockClient(mockCtrl)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+	}
+
+	client := fake.NewFakeClient(cluster)
+
+	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+		AzureClients: scope.AzureClients{
+			SubscriptionID: "123",
+			Authorizer:     autorest.NullAuthorizer{},
+		},
+		Client:  client,
+		Cluster: cluster,
+		AzureCluster: &infrav1.AzureCluster{
+			Spec: infrav1.AzureClusterSpec{
+				Location: "test-location",
+				ResourceGroup: "my-rg",
+				NetworkSpec: infrav1.NetworkSpec{
+					Vnet: infrav1.VnetSpec{Name: "my-vnet", ResourceGroup: "my-rg"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create test context: %v", err)
+	}
+
+	s := &Service{
+		Scope:  clusterScope,
+		Client: publicLBMock,
+	}
+
+	// Wrong Spec
+	wrongSpec := &network.PublicIPAddress{}
+
+	err = s.Reconcile(context.TODO(), &wrongSpec)
+	if err == nil {
+		t.Fatalf("it should fail")
+	}
+	if err.Error() != "invalid public loadbalancer specification" {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
+
+	_, err = s.Get(context.TODO(), &wrongSpec)
+	if err == nil {
+		t.Fatalf("it should fail")
+	}
+	if err.Error() != "invalid public loadbalancer specification" {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
+
+	err = s.Delete(context.TODO(), &wrongSpec)
+	if err == nil {
+		t.Fatalf("it should fail")
+	}
+	if err.Error() != "invalid public loadbalancer specification" {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
+}
+
 func TestGetPublicLB(t *testing.T) {
 	testcases := []struct {
 		name          string


### PR DESCRIPTION
**What this PR does / why we need it**:
Followup add a few more tests - testing invalid specs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Addresses https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/359

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
NONE
```

/cc @CecileRobertMichon 