### PR TITLE
🏃routetables/test: add initial tests for route tables

### DIFF
--- a/cloud/services/routetables/routetables.go
+++ b/cloud/services/routetables/routetables.go
@@ -35,7 +35,7 @@ type Spec struct {
 func (s *Service) Get(ctx context.Context, spec interface{}) (interface{}, error) {
 	routeTableSpec, ok := spec.(*Spec)
 	if !ok {
-		return network.RouteTable{}, errors.New("Invalid Route Table Specification")
+		return network.RouteTable{}, errors.New("invalid Route Table Specification")
 	}
 	routeTable, err := s.Client.Get(ctx, s.Scope.ResourceGroup(), routeTableSpec.Name)
 	if err != nil && azure.ResourceNotFound(err) {
@@ -54,7 +54,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	}
 	routeTableSpec, ok := spec.(*Spec)
 	if !ok {
-		return errors.New("Invalid Route Table Specification")
+		return errors.New("invalid Route Table Specification")
 	}
 	klog.V(2).Infof("creating route table %s", routeTableSpec.Name)
 	err := s.Client.CreateOrUpdate(
@@ -82,7 +82,7 @@ func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	}
 	routeTableSpec, ok := spec.(*Spec)
 	if !ok {
-		return errors.New("Invalid Route Table Specification")
+		return errors.New("invalid Route Table Specification")
 	}
 	klog.V(2).Infof("deleting route table %s", routeTableSpec.Name)
 	err := s.Client.Delete(ctx, s.Scope.ResourceGroup(), routeTableSpec.Name)

--- a/cloud/services/routetables/routetables_test.go
+++ b/cloud/services/routetables/routetables_test.go
@@ -1,0 +1,440 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routetables
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/routetables/mock_routetables"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/golang/mock/gomock"
+
+	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/scope"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const expectedInvalidSpec = "invalid Route Table Specification"
+
+func init() {
+	clusterv1.AddToScheme(scheme.Scheme)
+}
+
+func TestInvalidRouteTableSpec(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	routetableMock := mock_routetables.NewMockClient(mockCtrl)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+	}
+
+	client := fake.NewFakeClient(cluster)
+
+	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+		AzureClients: scope.AzureClients{
+			SubscriptionID: "123",
+			Authorizer:     autorest.NullAuthorizer{},
+		},
+		Client:  client,
+		Cluster: cluster,
+		AzureCluster: &infrav1.AzureCluster{
+			Spec: infrav1.AzureClusterSpec{
+				Location: "test-location",
+				ResourceGroup: "my-rg",
+				NetworkSpec: infrav1.NetworkSpec{
+					Vnet: infrav1.VnetSpec{Name: "my-vnet", ResourceGroup: "my-rg"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create test context: %v", err)
+	}
+
+	s := &Service{
+		Scope:  clusterScope,
+		Client: routetableMock,
+	}
+
+	// Wrong Spec
+	wrongSpec := &network.PublicIPAddress{}
+
+	_, err = s.Get(context.TODO(), &wrongSpec)
+	if err == nil {
+		t.Fatalf("it should fail")
+	}
+	if err.Error() != expectedInvalidSpec {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
+
+	err = s.Reconcile(context.TODO(), &wrongSpec)
+	if err == nil {
+		t.Fatalf("it should fail")
+	}
+	if err.Error() != expectedInvalidSpec {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
+
+	err = s.Delete(context.TODO(), &wrongSpec)
+	if err == nil {
+		t.Fatalf("it should fail")
+	}
+	if err.Error() != expectedInvalidSpec {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
+}
+
+func TestGetRouteTable(t *testing.T) {
+	testcases := []struct {
+		name           string
+		routetableSpec Spec
+		expectedError  string
+		expect         func(m *mock_routetables.MockClientMockRecorder)
+	}{
+		{
+			name: "get existing route table",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			expectedError: "",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.Get(context.TODO(), "my-rg", "my-routetable").Return(network.RouteTable{}, nil)
+			},
+		},
+		{
+			name: "route table not found",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			expectedError: "route table my-routetable not found: #: Not found: StatusCode=404",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.Get(context.TODO(), "my-rg", "my-routetable").Return(network.RouteTable{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+			},
+		},
+		{
+			name: "route table retrieval fails",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			expectedError: "#: Internal Server Error: StatusCode=500",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.Get(context.TODO(), "my-rg", "my-routetable").Return(network.RouteTable{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			routetableMock := mock_routetables.NewMockClient(mockCtrl)
+
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+			}
+
+			client := fake.NewFakeClient(cluster)
+
+			tc.expect(routetableMock.EXPECT())
+
+			clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+				AzureClients: scope.AzureClients{
+					SubscriptionID: "123",
+					Authorizer:     autorest.NullAuthorizer{},
+				},
+				Client:  client,
+				Cluster: cluster,
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						Location: "test-location",
+						ResourceGroup: "my-rg",
+						NetworkSpec: infrav1.NetworkSpec{
+							Vnet: infrav1.VnetSpec{Name: "my-vnet", ResourceGroup: "my-rg"},
+						},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create test context: %v", err)
+			}
+
+			s := &Service{
+				Scope:  clusterScope,
+				Client: routetableMock,
+			}
+
+			_, err = s.Get(context.TODO(), &tc.routetableSpec)
+			if err != nil {
+				if tc.expectedError == "" || err.Error() != tc.expectedError {
+					t.Fatalf("got an unexpected error: %v", err)
+				}
+			} else {
+				if tc.expectedError != "" {
+					t.Fatalf("expected an error: %v", tc.expectedError)
+
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileRouteTables(t *testing.T) {
+	testcases := []struct {
+		name           string
+		routetableSpec Spec
+		tags           infrav1.Tags
+		expectedError  string
+		expect         func(m *mock_routetables.MockClientMockRecorder)
+	}{
+		{
+			name: "route tables in custom vnet mode",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			tags: infrav1.Tags{
+				"Name": "my-vnet",
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": "shared",
+				"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
+			},
+			expectedError: "",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.CreateOrUpdate(context.TODO(), "my-rg", "my-routetable", gomock.AssignableToTypeOf(network.RouteTable{}))
+			},
+		},
+		{
+			name: "route table create successfully",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			tags: infrav1.Tags{
+				"Name": "my-vnet",
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": "owned",
+				"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
+			},
+			expectedError: "",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.CreateOrUpdate(context.TODO(), "my-rg", "my-routetable", gomock.AssignableToTypeOf(network.RouteTable{}))
+			},
+		},
+		{
+			name: "fail to create a route table",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			tags: infrav1.Tags{
+				"Name": "my-vnet",
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": "owned",
+				"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
+			},
+			expectedError: "failed to create route table my-routetable in resource group my-rg: #: Internal Server Error: StatusCode=500",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.CreateOrUpdate(context.TODO(), "my-rg", "my-routetable", gomock.AssignableToTypeOf(network.RouteTable{})).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			routetableMock := mock_routetables.NewMockClient(mockCtrl)
+
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+			}
+
+			client := fake.NewFakeClient(cluster)
+
+			tc.expect(routetableMock.EXPECT())
+
+			clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+				AzureClients: scope.AzureClients{
+					SubscriptionID: "123",
+					Authorizer:     autorest.NullAuthorizer{},
+				},
+				Client:  client,
+				Cluster: cluster,
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						Location: "test-location",
+						ResourceGroup: "my-rg",
+						NetworkSpec: infrav1.NetworkSpec{
+							Vnet: infrav1.VnetSpec{
+								ID:            "my-vnet-id",
+								Name:          "my-vnet",
+								ResourceGroup: "my-rg",
+								Tags:          tc.tags,
+							},
+						},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create test context: %v", err)
+			}
+
+			s := &Service{
+				Scope:  clusterScope,
+				Client: routetableMock,
+			}
+
+			if err := s.Reconcile(context.TODO(), &tc.routetableSpec); err != nil {
+				if tc.expectedError == "" || err.Error() != tc.expectedError {
+					t.Fatalf("got an unexpected error: %v", err)
+				}
+			} else {
+				if tc.expectedError != "" {
+					t.Fatalf("expected an error: %v", tc.expectedError)
+
+				}
+			}
+		})
+	}
+}
+
+func TestDeleteRouteTable(t *testing.T) {
+	testcases := []struct {
+		name           string
+		routetableSpec Spec
+		tags           infrav1.Tags
+		expectedError  string
+		expect         func(m *mock_routetables.MockClientMockRecorder)
+	}{
+		{
+			name: "route tables in custom vnet mode",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			tags: infrav1.Tags{
+				"Name": "my-vnet",
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": "shared",
+				"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
+			},
+			expectedError: "",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.Delete(context.TODO(), "my-rg", "my-routetable")
+			},
+		},
+		{
+			name: "route table deleted successfully",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			tags: infrav1.Tags{
+				"Name": "my-vnet",
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": "owned",
+				"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
+			},
+			expectedError: "",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.Delete(context.TODO(), "my-rg", "my-routetable")
+			},
+		},
+		{
+			name: "route table already deleted",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			tags: infrav1.Tags{
+				"Name": "my-vnet",
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": "owned",
+				"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
+			},
+			expectedError: "",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.Delete(context.TODO(), "my-rg", "my-routetable").Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not Found"))
+			},
+		},
+		{
+			name: "route table deletion fails",
+			routetableSpec: Spec{
+				Name: "my-routetable",
+			},
+			tags: infrav1.Tags{
+				"Name": "my-vnet",
+				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": "owned",
+				"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
+			},
+			expectedError: "failed to delete route table my-routetable in resource group my-rg: #: Internal Server Error: StatusCode=500",
+			expect: func(m *mock_routetables.MockClientMockRecorder) {
+				m.Delete(context.TODO(), "my-rg", "my-routetable").Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			routetableMock := mock_routetables.NewMockClient(mockCtrl)
+
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+			}
+
+			client := fake.NewFakeClient(cluster)
+
+			tc.expect(routetableMock.EXPECT())
+
+			clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+				AzureClients: scope.AzureClients{
+					SubscriptionID: "123",
+					Authorizer:     autorest.NullAuthorizer{},
+				},
+				Client:  client,
+				Cluster: cluster,
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						Location: "test-location",
+						ResourceGroup: "my-rg",
+						NetworkSpec: infrav1.NetworkSpec{
+							Vnet: infrav1.VnetSpec{
+								ID:            "my-vnet-id",
+								Name:          "my-vnet",
+								ResourceGroup: "my-rg",
+								Tags:          tc.tags,
+							},
+						},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create test context: %v", err)
+			}
+
+			s := &Service{
+				Scope:  clusterScope,
+				Client: routetableMock,
+			}
+
+			if err := s.Delete(context.TODO(), &tc.routetableSpec); err != nil {
+				if tc.expectedError == "" || err.Error() != tc.expectedError {
+					t.Fatalf("got an unexpected error: %v", err)
+				}
+			} else {
+				if tc.expectedError != "" {
+					t.Fatalf("expected an error: %v", tc.expectedError)
+
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add initial tests for route tables

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Addresses https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/359

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @CecileRobertMichon 