### PR TITLE
:runner: Update default k8s version to 1.16.7

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -29,7 +29,7 @@ RANDOM_STRING=$(date | md5sum | head -c8)
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-capz-example-${RANDOM_STRING}}"
 export VNET_NAME="${VNET_NAME:-${CLUSTER_NAME}-vnet}"
-export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.6}"
+export KUBERNETES_VERSION="${KUBERNETES_VERSION:-v1.16.7}"
 export KUBERNETES_SEMVER="${KUBERNETES_VERSION#v}"
 
 # Machine settings.

--- a/test/e2e/framework/framework_flags.go
+++ b/test/e2e/framework/framework_flags.go
@@ -40,7 +40,7 @@ const (
 
 	// DefaultKubernetesVersion is the default value for Flags.KubernetesVersion
 	// if the env var KUBERNETES_VERSION is an empty string.
-	DefaultKubernetesVersion = "v1.16.6"
+	DefaultKubernetesVersion = "v1.16.7"
 )
 
 // Flags contains command-line flags used by the e2e framework.


### PR DESCRIPTION
**What this PR does / why we need it**: Updates default Kubernetes version to the latest 1.16 patch, 1.16.7.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated default k8s version to 1.16.7
```