### PR TITLE
🏃nic: remove unnecessary else if from Get method

### DIFF
--- a/cloud/services/networkinterfaces/networkinterfaces.go
+++ b/cloud/services/networkinterfaces/networkinterfaces.go
@@ -47,10 +47,9 @@ func (s *Service) Get(ctx context.Context, spec interface{}) (interface{}, error
 	nic, err := s.Client.Get(ctx, s.Scope.ResourceGroup(), nicSpec.Name)
 	if err != nil && azure.ResourceNotFound(err) {
 		return nil, errors.Wrapf(err, "network interface %s not found", nicSpec.Name)
-	} else if err != nil {
-		return nic, err
 	}
-	return nic, nil
+
+	return nic, err
 }
 
 // Reconcile gets/creates/updates a network interface.


### PR DESCRIPTION
**What this PR does / why we need it**:
similar did here: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/413
remove the else if method because it is not needed.

/kind cleanup

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @CecileRobertMichon 