### PR TITLE
🏃tests: Load SSH public key from file via env var AZURE_SSH_PUBLIC_KEY_FILE

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -24,6 +24,7 @@
     - [Executing unit tests](#executing-unit-tests)
   - [Automated Testing](#automated-testing)
     - [Mocks](#mocks)
+    - [E2E Testing](#e2e-testing)
 
 <!-- /TOC -->
 
@@ -219,6 +220,16 @@ To generate the mocks you can run
 ```bash
 make generate-go
 ```
+
+#### E2E Testing
+
+To run E2E locally, set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID` and run:
+
+```bash
+./scripts/ci-e2e.sh
+```
+
+You can optionally set `AZURE_SSH_PUBLIC_KEY_FILE` to use your own ssh key.
 
 <!-- References -->
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Load the ssh public key if the AZURE_SSH_PUBLIC_KEY_FILE env var is set

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/349

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/cc @CecileRobertMichon 