### PR TITLE
[WIP] 🏃 control plane NSG does not open the SSH port by default.

### DIFF
--- a/cloud/services/securitygroups/securitygroups.go
+++ b/cloud/services/securitygroups/securitygroups.go
@@ -65,20 +65,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 		klog.V(2).Infof("using additional rules for control plane %s", nsgSpec.Name)
 		securityRules = &[]network.SecurityRule{
 			{
-				Name: to.StringPtr("allow_ssh"),
-				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-					Protocol:                 network.SecurityRuleProtocolTCP,
-					SourceAddressPrefix:      to.StringPtr("*"),
-					SourcePortRange:          to.StringPtr("*"),
-					DestinationAddressPrefix: to.StringPtr("*"),
-					DestinationPortRange:     to.StringPtr("22"),
-					Access:                   network.SecurityRuleAccessAllow,
-					Direction:                network.SecurityRuleDirectionInbound,
-					Priority:                 to.Int32Ptr(100),
-				},
-			},
-			{
-				Name: to.StringPtr("allow_6443"),
+				Name: to.StringPtr("AllowAPIServer"),
 				SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 					Protocol:                 network.SecurityRuleProtocolTCP,
 					SourceAddressPrefix:      to.StringPtr("*"),

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -21,6 +21,10 @@ set -o pipefail
 GOPATH_BIN="$(go env GOPATH)/bin/"
 MINIMUM_KIND_VERSION=v0.6.1
 
+version_gte() {
+  test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" == "$1"
+}
+
 # Ensure the kind tool exists and is a viable version, or installs it
 verify_kind_version() {
 
@@ -40,8 +44,8 @@ verify_kind_version() {
   fi
 
   local kind_version
-  kind_version=$(kind version)
-   if ! [[ "${kind_version}" =~ ${MINIMUM_KIND_VERSION} ]]; then
+  kind_version=$(kind version | cut -d ' ' -f 2)
+  if version_gte ${MINIMUM_KIND_VERSION} ${kind_version}; then
     cat <<EOF
 Detected kind version: ${kind_version}.
 Requires ${MINIMUM_KIND_VERSION} or greater.


### PR DESCRIPTION
Signed-off-by: Javier Darsie jadarsie@microsoft.com

**What this PR does / why we need it**:
This PR takes care of item 1 from the [list of requirements](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/104#issuecomment-589756634) in #104 

> Change the default NSG rules so they are more restrictive, we don't want the NSG to ever be open to the whole internet

Please let me know if this is not what it was expected.

**Which issue(s) this PR fixes**:
Fixes part of #104

**Release note**:
```release-note
Control plane NSG does not open the SSH port by default.
```