### PR TITLE
fix: fix typo in certmanager config

### DIFF
--- a/config/crd/patches/cainjection_in_azureclusters.yaml
+++ b/config/crd/patches/cainjection_in_azureclusters.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: azureclusters.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_azuremachines.yaml
+++ b/config/crd/patches/cainjection_in_azuremachines.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: azuremachines.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_azuremachinetemplates.yaml
+++ b/config/crd/patches/cainjection_in_azuremachinetemplates.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: azuremachinetemplates.infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
**What this PR does / why we need it**: Fix annotations to use `cert-manager.io` instead of `certmanager.io`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #428 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```