### PR TITLE
🏃change the APIServer health probe to HTTPS

### DIFF
--- a/cloud/services/internalloadbalancers/internalloadbalancers.go
+++ b/cloud/services/internalloadbalancers/internalloadbalancers.go
@@ -52,7 +52,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 		return errors.New("invalid internal load balancer specification")
 	}
 	klog.V(2).Infof("creating internal load balancer %s", internalLBSpec.Name)
-	probeName := "tcpHTTPSProbe"
+	probeName := "HTTPSProbe"
 	frontEndIPConfigName := "controlplane-internal-lbFrontEnd"
 	backEndAddressPoolName := "controlplane-internal-backEndPool"
 	idPrefix := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers", s.Scope.SubscriptionID, s.Scope.ResourceGroup())
@@ -111,7 +111,8 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 					{
 						Name: &probeName,
 						ProbePropertiesFormat: &network.ProbePropertiesFormat{
-							Protocol:          network.ProbeProtocolTCP,
+							Protocol:          network.ProbeProtocolHTTPS,
+							RequestPath:       to.StringPtr("/healthz"),
 							Port:              to.Int32Ptr(s.Scope.APIServerPort()),
 							IntervalInSeconds: to.Int32Ptr(15),
 							NumberOfProbes:    to.Int32Ptr(4),


### PR DESCRIPTION
**What this PR does / why we need it**:  Use the HTTPS probe which is only available for Standard Load Balancers for the API Server health probe and use the `/healthz` endpoint.

https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview#httpsprobe

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change the APIServer health probe to HTTPS
```