### PR TITLE
fix: change example OS disk size to 128GB

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -109,7 +109,7 @@ spec:
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
       osDisk:
         osType: "Linux"
-        diskSizeGB: 30
+        diskSizeGB: 128
         managedDisk:
           storageAccountType: "Premium_LRS"
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}

--- a/test/e2e/resource_generators.go
+++ b/test/e2e/resource_generators.go
@@ -150,7 +150,7 @@ func (n *NodeGenerator) GenerateNode(creds auth.Creds, clusterName string) frame
 				},
 			},
 			OSDisk: infrav1.OSDisk{
-				DiskSizeGB: 30,
+				DiskSizeGB: 128,
 				OSType:     "Linux",
 				ManagedDisk: infrav1.ManagedDisk{
 					StorageAccountType: "Premium_LRS",


### PR DESCRIPTION
**What this PR does / why we need it**: etcd is currently mounted on the OS disk. To mitigate #435 while we evaluate using a data disk instead and following the guidance at https://etcd.io/docs/v3.4.0/op-guide/hardware/, changing the example DiskSizeGB to 128. This value is configurable so can be increased or decreased by users if needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Mitigates #435 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
change example OS disk size to 128GB
```