### PR TITLE
fix: dynamically assign NAT Rules to allow control plane scaling

### DIFF
--- a/cloud/defaults.go
+++ b/cloud/defaults.go
@@ -25,20 +25,22 @@ import (
 )
 
 const (
-	// DefaultUserName is the default username for created vm
+	// DefaultUserName is the default username for created VM.
 	DefaultUserName = "capi"
-	// DefaultVnetCIDR is the default Vnet CIDR
+	// DefaultVnetCIDR is the default Vnet CIDR.
 	DefaultVnetCIDR = "10.0.0.0/8"
-	// DefaultControlPlaneSubnetCIDR is the default Control Plane Subnet CIDR
+	// DefaultControlPlaneSubnetCIDR is the default Control Plane Subnet CIDR.
 	DefaultControlPlaneSubnetCIDR = "10.0.0.0/16"
-	// DefaultNodeSubnetCIDR is the default Node Subnet CIDR
+	// DefaultNodeSubnetCIDR is the default Node Subnet CIDR.
 	DefaultNodeSubnetCIDR = "10.1.0.0/16"
-	// DefaultInternalLBIPAddress is the default internal load balancer ip address
+	// DefaultInternalLBIPAddress is the default internal load balancer IP address.
 	DefaultInternalLBIPAddress = "10.0.0.100"
-	// DefaultAzureDNSZone is the default provided azure dns zone
+	// DefaultAzureDNSZone is the default provided Azure DNS zone.
 	DefaultAzureDNSZone = "cloudapp.azure.com"
-	// UserAgent used for communicating with azure
+	// UserAgent used for communicating with Azure.
 	UserAgent = "cluster-api-azure-services"
+	// MaxNumberOfControlPlanes is the maximum allowed number of control planes, used to determine number of needed Inbound NAT Rules.
+	MaxNumberOfControlPlanes = 7
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**: Control plane machines may get deleted and added. If that's the case, we need to make sure the NatRule index isn't out of bounds. This is a little complex because the NAT rules are pre-created as part of the external load balancer but then only assigned to a network interface when a machine is created. This is an attempt to make the nat rule assignment more resilient to sclaing. When a machine is created, we look for the first available index. When it is deleted, we remove it from the map and mark that index as free. Because multiple machines can be deleted/created concurrently, the slice of used indices needed a mechanism to protect it from race conditions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #446 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```