### PR TITLE
🏃api/tests: standardize gomega usage

### DIFF
--- a/api/v1alpha2/conversion_test.go
+++ b/api/v1alpha2/conversion_test.go
@@ -21,6 +21,7 @@ import (
 
 	fuzz "github.com/google/gofuzz"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	v1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"

--- a/api/v1alpha2/tags_test.go
+++ b/api/v1alpha2/tags_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestTags_Merge(t *testing.T) {
+	g := NewWithT(t)
+
 	tests := []struct {
 		name     string
 		other    Tags
@@ -80,10 +83,7 @@ func TestTags_Merge(t *testing.T) {
 			}
 
 			tags.Merge(tc.other)
-			if e, a := tc.expected, tags; !reflect.DeepEqual(e, a) {
-				t.Errorf("expected %#v, got %#v", e, a)
-			}
+			g.Expect(tags).To(Equal(tc.expected))
 		})
 	}
-
 }

--- a/api/v1alpha3/azureimage_validation_test.go
+++ b/api/v1alpha3/azureimage_validation_test.go
@@ -19,10 +19,14 @@ package v1alpha3
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func TestImageRequired(t *testing.T) {
+	g := NewWithT(t)
+
 	type test struct {
 		Image *Image
 	}
@@ -30,21 +34,15 @@ func TestImageRequired(t *testing.T) {
 	extension := test{}
 
 	errs := ValidateImage(extension.Image, field.NewPath("image"))
-	if len(errs) != 1 {
-		t.Errorf("unexpected number of errors, expected 1 but got %d", len(errs))
-	}
-	if errs[0].Type.String() != field.ErrorTypeRequired.String() {
-		t.Errorf("unexpected field required error but go %s", errs[0].Type.String())
-	}
-	if errs[0].Field != "image" {
-		t.Errorf("unexpected field name, expected image but got %s", errs[0].Field)
-	}
-	if errs[0].Detail == "" {
-		t.Error("expected a non-empty error detail")
-	}
+	g.Expect(errs).To(HaveLen(1))
+	g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+	g.Expect(errs[0].Field).To(Equal("image"))
+	g.Expect(errs[0].Detail).NotTo(BeEmpty())
 }
 
 func TestImageTooManyDetails(t *testing.T) {
+	g := NewWithT(t)
+
 	image := &Image{
 		Marketplace: &AzureMarketplaceImage{
 			Offer:     "OFFER",
@@ -60,13 +58,13 @@ func TestImageTooManyDetails(t *testing.T) {
 			Version:        "1.0.0.",
 		},
 	}
-	errs := ValidateImage(image, field.NewPath("image"))
-	if len(errs) != 1 {
-		t.Errorf("unexpected number of errors, expected 1 but got %d", len(errs))
-	}
+
+	g.Expect(ValidateImage(image, field.NewPath("image"))).To(HaveLen(1))
 }
 
 func TestSharedImageGalleryValid(t *testing.T) {
+	g := NewWithT(t)
+
 	testCases := map[string]struct {
 		image          *Image
 		expectedErrors int
@@ -97,16 +95,14 @@ func TestSharedImageGalleryValid(t *testing.T) {
 		},
 	}
 
-	for k, tc := range testCases {
-		errs := ValidateImage(tc.image, field.NewPath("image"))
-
-		if len(errs) != tc.expectedErrors {
-			t.Errorf("test case '%s' failed, expected %d errors but got %d: %#v", k, tc.expectedErrors, len(errs), errs)
-		}
+	for _, tc := range testCases {
+		g.Expect(ValidateImage(tc.image, field.NewPath("image"))).To(HaveLen(tc.expectedErrors))
 	}
 }
 
 func TestMarketPlaceImageValid(t *testing.T) {
+	g := NewWithT(t)
+
 	testCases := map[string]struct {
 		image          *Image
 		expectedErrors int
@@ -133,16 +129,14 @@ func TestMarketPlaceImageValid(t *testing.T) {
 		},
 	}
 
-	for k, tc := range testCases {
-		errs := ValidateImage(tc.image, field.NewPath("image"))
-
-		if len(errs) != tc.expectedErrors {
-			t.Errorf("test case '%s' failed, expected %d errors but got %d: %#v", k, tc.expectedErrors, len(errs), errs)
-		}
+	for _, tc := range testCases {
+		g.Expect(ValidateImage(tc.image, field.NewPath("image"))).To(HaveLen(tc.expectedErrors))
 	}
 }
 
 func TestImageByIDValid(t *testing.T) {
+	g := NewWithT(t)
+
 	testCases := map[string]struct {
 		image          *Image
 		expectedErrors int
@@ -157,12 +151,8 @@ func TestImageByIDValid(t *testing.T) {
 		},
 	}
 
-	for k, tc := range testCases {
-		errs := ValidateImage(tc.image, field.NewPath("image"))
-
-		if len(errs) != tc.expectedErrors {
-			t.Errorf("test case '%s' failed, expected %d errors but got %d: %#v", k, tc.expectedErrors, len(errs), errs)
-		}
+	for _, tc := range testCases {
+		g.Expect(ValidateImage(tc.image, field.NewPath("image"))).To(HaveLen(tc.expectedErrors))
 	}
 }
 

--- a/api/v1alpha3/azuremachine_webhook_test.go
+++ b/api/v1alpha3/azuremachine_webhook_test.go
@@ -18,9 +18,13 @@ package v1alpha3
 
 import (
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestAzureMachine_ValidateCreate(t *testing.T) {
+	g := NewWithT(t)
+
 	tests := []struct {
 		name    string
 		machine *AzureMachine
@@ -59,8 +63,11 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.machine.ValidateCreate(); (err != nil) != tc.wantErr {
-				t.Errorf("ValidateCreate() error = %v, wantErr %v", err, tc.wantErr)
+			err := tc.machine.ValidateCreate()
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}

--- a/api/v1alpha3/tags_test.go
+++ b/api/v1alpha3/tags_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestTags_Merge(t *testing.T) {
+	g := NewWithT(t)
+
 	tests := []struct {
 		name     string
 		other    Tags
@@ -80,10 +83,7 @@ func TestTags_Merge(t *testing.T) {
 			}
 
 			tags.Merge(tc.other)
-			if e, a := tc.expected, tags; !reflect.DeepEqual(e, a) {
-				t.Errorf("expected %#v, got %#v", e, a)
-			}
+			g.Expect(tags).To(Equal(tc.expected))
 		})
 	}
-
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR follow the same approach we did for `cluster-api` in this issue: https://github.com/kubernetes-sigs/cluster-api/issues/2433

To follow the same we are applying to the pattern here as well.

Will be opening PR for each folder to make the review easier

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/454

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @CecileRobertMichon 