### PR TITLE
cloud/tests: standardize gomega usage

### DIFF
--- a/cloud/defaults_test.go
+++ b/cloud/defaults_test.go
@@ -19,11 +19,12 @@ package azure
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestGetDefaultImageSKUID(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewWithT(t)
+
 	var tests = []struct {
 		k8sVersion     string
 		expectedResult string
@@ -74,12 +75,13 @@ func TestGetDefaultImageSKUID(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.k8sVersion, func(t *testing.T) {
 			id, err := getDefaultImageSKUID(test.k8sVersion)
-			g.Expect(id).To(gomega.Equal(test.expectedResult))
+
 			if test.expectedError {
-				g.Expect(err).ToNot(gomega.BeNil())
+				g.Expect(err).To(HaveOccurred())
 			} else {
-				g.Expect(err).To(gomega.BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 			}
+			g.Expect(id).To(Equal(test.expectedResult))
 		})
 	}
 }

--- a/cloud/services/availabilityzones/availabilityzones_test.go
+++ b/cloud/services/availabilityzones/availabilityzones_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/availabilityzones/mock_availabilityzones"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
@@ -40,6 +41,8 @@ func init() {
 }
 
 func TestGetAvailabilityZones(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name                 string
 		availabilityZoneSpec Spec
@@ -106,24 +109,19 @@ func TestGetAvailabilityZones(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: azMock,
 			}
 
-			if _, err := s.Get(context.TODO(), &tc.availabilityZoneSpec); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			_, err = s.Get(context.TODO(), &tc.availabilityZoneSpec)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}

--- a/cloud/services/groups/groups_test.go
+++ b/cloud/services/groups/groups_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/groups/mock_groups"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -41,6 +42,8 @@ func init() {
 }
 
 func TestGetGroups(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name          string
 		expectedError string
@@ -96,9 +99,7 @@ func TestGetGroups(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
@@ -106,21 +107,19 @@ func TestGetGroups(t *testing.T) {
 			}
 
 			_, err = s.Get(context.TODO(), nil)
-			if err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestReconcileGroups(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name               string
 		clusterScopeParams scope.ClusterScopeParams
@@ -212,30 +211,27 @@ func TestReconcileGroups(t *testing.T) {
 			tc.clusterScopeParams.Client = client
 			tc.clusterScopeParams.Cluster = cluster
 			clusterScope, err := scope.NewClusterScope(tc.clusterScopeParams)
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: groupsMock,
 			}
 
-			if err := s.Reconcile(context.TODO(), nil); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Reconcile(context.TODO(), nil)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestDeleteGroups(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name               string
 		clusterScopeParams scope.ClusterScopeParams
@@ -399,24 +395,19 @@ func TestDeleteGroups(t *testing.T) {
 			tc.clusterScopeParams.Client = client
 			tc.clusterScopeParams.Cluster = cluster
 			clusterScope, err := scope.NewClusterScope(tc.clusterScopeParams)
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: groupsMock,
 			}
 
-			if err := s.Delete(context.TODO(), nil); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Delete(context.TODO(), nil)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}

--- a/cloud/services/publicips/publicips_test.go
+++ b/cloud/services/publicips/publicips_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/publicips/mock_publicips"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -42,6 +43,8 @@ func init() {
 const expectedInvalidSpec = "invalid PublicIP Specification"
 
 func TestInvalidPublicIPSpec(t *testing.T) {
+	g := NewWithT(t)
+
 	mockCtrl := gomock.NewController(t)
 	publicIPsMock := mock_publicips.NewMockClient(mockCtrl)
 
@@ -68,9 +71,7 @@ func TestInvalidPublicIPSpec(t *testing.T) {
 			},
 		},
 	})
-	if err != nil {
-		t.Fatalf("Failed to create test context: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
 
 	s := &Service{
 		Scope:  clusterScope,
@@ -81,31 +82,21 @@ func TestInvalidPublicIPSpec(t *testing.T) {
 	wrongSpec := &network.LoadBalancer{}
 
 	err = s.Reconcile(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 
 	_, err = s.Get(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 
 	err = s.Delete(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 }
 
 func TestGetPublicIP(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name          string
 		publicIPsSpec Spec
@@ -171,9 +162,7 @@ func TestGetPublicIP(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
@@ -181,21 +170,19 @@ func TestGetPublicIP(t *testing.T) {
 			}
 
 			_, err = s.Get(context.TODO(), &tc.publicIPsSpec)
-			if err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestReconcilePublicLoadBalancer(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name          string
 		publicIPsSpec Spec
@@ -254,30 +241,27 @@ func TestReconcilePublicLoadBalancer(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: publicIPsMock,
 			}
 
-			if err := s.Reconcile(context.TODO(), &tc.publicIPsSpec); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Reconcile(context.TODO(), &tc.publicIPsSpec)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestDeletePublicIP(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name          string
 		publicIPsSpec Spec
@@ -348,24 +332,19 @@ func TestDeletePublicIP(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: publicIPsMock,
 			}
 
-			if err := s.Delete(context.TODO(), &tc.publicIPsSpec); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Delete(context.TODO(), &tc.publicIPsSpec)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}

--- a/cloud/services/publicloadbalancers/publicloadbalancers_test.go
+++ b/cloud/services/publicloadbalancers/publicloadbalancers_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/publicips/mock_publicips"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/publicloadbalancers/mock_publicloadbalancers"
 
@@ -43,6 +44,8 @@ func init() {
 }
 
 func TestInvalidPublicLBSpec(t *testing.T) {
+	g := NewWithT(t)
+
 	mockCtrl := gomock.NewController(t)
 	publicLBMock := mock_publicloadbalancers.NewMockClient(mockCtrl)
 
@@ -69,9 +72,7 @@ func TestInvalidPublicLBSpec(t *testing.T) {
 			},
 		},
 	})
-	if err != nil {
-		t.Fatalf("Failed to create test context: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
 
 	s := &Service{
 		Scope:  clusterScope,
@@ -82,31 +83,21 @@ func TestInvalidPublicLBSpec(t *testing.T) {
 	wrongSpec := &network.PublicIPAddress{}
 
 	err = s.Reconcile(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 
 	_, err = s.Get(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 
 	err = s.Delete(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 }
 
 func TestGetPublicLB(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name          string
 		publicLBSpec  Spec
@@ -175,9 +166,7 @@ func TestGetPublicLB(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
@@ -185,21 +174,19 @@ func TestGetPublicLB(t *testing.T) {
 			}
 
 			_, err = s.Get(context.TODO(), &tc.publicLBSpec)
-			if err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestReconcilePublicLoadBalancer(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name          string
 		publicLBSpec  Spec
@@ -292,9 +279,7 @@ func TestReconcilePublicLoadBalancer(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:           clusterScope,
@@ -302,21 +287,20 @@ func TestReconcilePublicLoadBalancer(t *testing.T) {
 				PublicIPsClient: publicIPsMock,
 			}
 
-			if err := s.Reconcile(context.TODO(), &tc.publicLBSpec); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Reconcile(context.TODO(), &tc.publicLBSpec)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestDeletePublicLB(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name          string
 		publicLBSpec  Spec
@@ -390,24 +374,19 @@ func TestDeletePublicLB(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: publicLBMock,
 			}
 
-			if err := s.Delete(context.TODO(), &tc.publicLBSpec); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Delete(context.TODO(), &tc.publicLBSpec)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}

--- a/cloud/services/routetables/routetables_test.go
+++ b/cloud/services/routetables/routetables_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/routetables/mock_routetables"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -42,6 +43,8 @@ func init() {
 }
 
 func TestInvalidRouteTableSpec(t *testing.T) {
+	g := NewWithT(t)
+
 	mockCtrl := gomock.NewController(t)
 	routetableMock := mock_routetables.NewMockClient(mockCtrl)
 
@@ -68,9 +71,7 @@ func TestInvalidRouteTableSpec(t *testing.T) {
 			},
 		},
 	})
-	if err != nil {
-		t.Fatalf("Failed to create test context: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
 
 	s := &Service{
 		Scope:  clusterScope,
@@ -81,31 +82,21 @@ func TestInvalidRouteTableSpec(t *testing.T) {
 	wrongSpec := &network.PublicIPAddress{}
 
 	_, err = s.Get(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 
 	err = s.Reconcile(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 
 	err = s.Delete(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 }
 
 func TestGetRouteTable(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name           string
 		routetableSpec Spec
@@ -174,9 +165,7 @@ func TestGetRouteTable(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
@@ -184,21 +173,19 @@ func TestGetRouteTable(t *testing.T) {
 			}
 
 			_, err = s.Get(context.TODO(), &tc.routetableSpec)
-			if err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestReconcileRouteTables(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name           string
 		routetableSpec Spec
@@ -288,30 +275,27 @@ func TestReconcileRouteTables(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: routetableMock,
 			}
 
-			if err := s.Reconcile(context.TODO(), &tc.routetableSpec); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Reconcile(context.TODO(), &tc.routetableSpec)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestDeleteRouteTable(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name           string
 		routetableSpec Spec
@@ -416,24 +400,19 @@ func TestDeleteRouteTable(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: routetableMock,
 			}
 
-			if err := s.Delete(context.TODO(), &tc.routetableSpec); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Delete(context.TODO(), &tc.routetableSpec)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}

--- a/cloud/services/securitygroups/securitygroups_test.go
+++ b/cloud/services/securitygroups/securitygroups_test.go
@@ -21,6 +21,9 @@ import (
 	"net/http"
 	"testing"
 
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/securitygroups/mock_securitygroups"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/mock/gomock"
 
@@ -29,7 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/scope"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/securitygroups/mock_securitygroups"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -39,6 +41,8 @@ func init() {
 }
 
 func TestReconcileSecurityGroups(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name           string
 		sgName         string
@@ -102,9 +106,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
@@ -115,14 +117,14 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				Name:           tc.sgName,
 				IsControlPlane: tc.isControlPlane,
 			}
-			if err := s.Reconcile(context.TODO(), sgSpec); err != nil {
-				t.Fatalf("got an unexpected error: %v", err)
-			}
+			g.Expect(s.Reconcile(context.TODO(), sgSpec)).To(Succeed())
 		})
 	}
 }
 
 func TestDeleteSecurityGroups(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name   string
 		sgName string
@@ -171,9 +173,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
@@ -185,9 +185,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				IsControlPlane: false,
 			}
 
-			if err := s.Delete(context.TODO(), sgSpec); err != nil {
-				t.Fatalf("got an unexpected error: %v", err)
-			}
+			g.Expect(s.Delete(context.TODO(), sgSpec)).To(Succeed())
 		})
 	}
 }

--- a/cloud/services/virtualmachineextensions/virtualmachineextensions_test.go
+++ b/cloud/services/virtualmachineextensions/virtualmachineextensions_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/virtualmachineextensions/mock_virtualmachineextensions"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -43,6 +44,8 @@ func init() {
 }
 
 func TestInvalidVMExtensions(t *testing.T) {
+	g := NewWithT(t)
+
 	mockCtrl := gomock.NewController(t)
 	vmextensionsMock := mock_virtualmachineextensions.NewMockClient(mockCtrl)
 
@@ -69,9 +72,7 @@ func TestInvalidVMExtensions(t *testing.T) {
 			},
 		},
 	})
-	if err != nil {
-		t.Fatalf("Failed to create test context: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
 
 	s := &Service{
 		Scope:  clusterScope,
@@ -82,31 +83,21 @@ func TestInvalidVMExtensions(t *testing.T) {
 	wrongSpec := &network.PublicIPAddress{}
 
 	_, err = s.Get(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 
 	err = s.Reconcile(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 
 	err = s.Delete(context.TODO(), &wrongSpec)
-	if err == nil {
-		t.Fatalf("it should fail")
-	}
-	if err.Error() != expectedInvalidSpec {
-		t.Fatalf("got an unexpected error: %v", err)
-	}
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(expectedInvalidSpec))
 }
 
 func TestGetVMExtensions(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name            string
 		vmExtensionSpec Spec
@@ -181,9 +172,7 @@ func TestGetVMExtensions(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
@@ -191,21 +180,19 @@ func TestGetVMExtensions(t *testing.T) {
 			}
 
 			_, err = s.Get(context.TODO(), &tc.vmExtensionSpec)
-			if err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestReconcileVMExtensions(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name            string
 		vmExtensionSpec Spec
@@ -272,30 +259,27 @@ func TestReconcileVMExtensions(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: vmExtensionMock,
 			}
 
-			if err := s.Reconcile(context.TODO(), &tc.vmExtensionSpec); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Reconcile(context.TODO(), &tc.vmExtensionSpec)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestDeleteVMExtensions(t *testing.T) {
+	g := NewWithT(t)
+
 	testcases := []struct {
 		name            string
 		vmExtensionSpec Spec
@@ -374,24 +358,19 @@ func TestDeleteVMExtensions(t *testing.T) {
 					},
 				},
 			})
-			if err != nil {
-				t.Fatalf("Failed to create test context: %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			s := &Service{
 				Scope:  clusterScope,
 				Client: vmExtensionMock,
 			}
 
-			if err := s.Delete(context.TODO(), &tc.vmExtensionSpec); err != nil {
-				if tc.expectedError == "" || err.Error() != tc.expectedError {
-					t.Fatalf("got an unexpected error: %v", err)
-				}
+			err = s.Delete(context.TODO(), &tc.vmExtensionSpec)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
-				if tc.expectedError != "" {
-					t.Fatalf("expected an error: %v", tc.expectedError)
-
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR follow the same approach we did for `cluster-api` in this issue: https://github.com/kubernetes-sigs/cluster-api/issues/2433

To follow the same we are applying to the pattern here as well.

Will be opening PR for each folder to make the review easier

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/454

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @CecileRobertMichon 