### PR TITLE
🏃controllers/tests: standardize gomega usage

### DIFF
--- a/controllers/azurecluster_controller_test.go
+++ b/controllers/azurecluster_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/controllers/azuremachine_controller_unit_test.go
+++ b/controllers/azuremachine_controller_unit_test.go
@@ -19,6 +19,8 @@ package controllers
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,6 +53,7 @@ func newMachine(clusterName, machineName string) *clusterv1.Machine {
 		},
 	}
 }
+
 func newMachineWithInfrastructureRef(clusterName, machineName string) *clusterv1.Machine {
 	m := newMachine(clusterName, machineName)
 	m.Spec.InfrastructureRef = v1.ObjectReference{
@@ -61,6 +64,7 @@ func newMachineWithInfrastructureRef(clusterName, machineName string) *clusterv1
 	}
 	return m
 }
+
 func newCluster(name string) *clusterv1.Cluster {
 	return &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -71,10 +75,11 @@ func newCluster(name string) *clusterv1.Cluster {
 }
 
 func TestAzureMachineReconciler_AzureClusterToAzureMachines(t *testing.T) {
+	g := NewWithT(t)
+
 	scheme, err := setupScheme()
-	if err != nil {
-		t.Fatal(err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
+
 	clusterName := "my-cluster"
 	initObjects := []runtime.Object{
 		newCluster(clusterName),
@@ -105,7 +110,6 @@ func TestAzureMachineReconciler_AzureClusterToAzureMachines(t *testing.T) {
 			},
 		},
 	})
-	if len(requests) != 2 {
-		t.Fatalf("Expected 2 but found %d requests", len(initObjects))
-	}
+
+	g.Expect(requests).To(HaveLen(2))
 }

--- a/controllers/azuremachine_reconciler_test.go
+++ b/controllers/azuremachine_reconciler_test.go
@@ -19,6 +19,8 @@ package controllers
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
@@ -28,6 +30,8 @@ import (
 )
 
 func TestGetControlPlaneMachines(t *testing.T) {
+	g := NewWithT(t)
+
 	controlPlaneMachine0 := clusterv1.Machine{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "control-plane-0",
@@ -101,20 +105,18 @@ func TestGetControlPlaneMachines(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			actual := GetControlPlaneMachines(c.machineList)
-			if len(actual) != len(c.expected) {
-				t.Fatalf("Got unexpected GetControlPlaneMachines result. Expected length: %v. Got: %v.", len(actual), len(c.expected))
-			}
-			for i, v := range c.expected {
-				if v.ObjectMeta.Name != actual[i].ObjectMeta.Name {
-					t.Fatalf("Got unexpected GetControlPlaneMachines result. Expected Item: %v. Got: %v.", v, actual[i])
+			g.Expect(actual).To(HaveLen(len(c.expected)))
 
-				}
+			for i, v := range c.expected {
+				g.Expect(v.ObjectMeta.Name).To(Equal(actual[i].ObjectMeta.Name))
 			}
 		})
 	}
 }
 
 func TestIsAvailabilityZoneSupported(t *testing.T) {
+	g := NewWithT(t)
+
 	s := azureMachineService{
 		machineScope: &scope.MachineScope{
 			Logger: log.Log.Logger,
@@ -128,9 +130,7 @@ func TestIsAvailabilityZoneSupported(t *testing.T) {
 
 	for _, l := range azure.SupportedAvailabilityZoneLocations {
 		s.machineScope.AzureCluster.Spec.Location = l
-		if s.isAvailabilityZoneSupported() != true {
-			t.Errorf("isAvailabilityZoneSupported should return true for supported region %s but returned %t", l, s.isAvailabilityZoneSupported())
-		}
+		g.Expect(s.isAvailabilityZoneSupported()).To(BeTrue())
 	}
 
 	unSupportedLocations := []string{
@@ -140,8 +140,6 @@ func TestIsAvailabilityZoneSupported(t *testing.T) {
 
 	for _, l := range unSupportedLocations {
 		s.machineScope.AzureCluster.Spec.Location = l
-		if s.isAvailabilityZoneSupported() != false {
-			t.Errorf("isAvailabilityZoneSupported should return false for unsupported region %s but returned %t", l, s.isAvailabilityZoneSupported())
-		}
+		g.Expect(s.isAvailabilityZoneSupported()).To(BeFalse())
 	}
 }

--- a/controllers/azuremachine_tags_unit_test.go
+++ b/controllers/azuremachine_tags_unit_test.go
@@ -19,11 +19,12 @@ package controllers
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestTagsChanged(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewWithT(t)
+
 	var tests = map[string]struct {
 		annotation             map[string]interface{}
 		src                    map[string]string
@@ -110,10 +111,10 @@ func TestTagsChanged(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			changed, created, deleted, newAnnotation := tagsChanged(test.annotation, test.src)
-			g.Expect(changed).To(gomega.Equal(test.expectedResult))
-			g.Expect(created).To(gomega.Equal(test.expectedCreated))
-			g.Expect(deleted).To(gomega.Equal(test.expectedDeleted))
-			g.Expect(newAnnotation).To(gomega.Equal(test.expectedNewAnnotations))
+			g.Expect(changed).To(Equal(test.expectedResult))
+			g.Expect(created).To(Equal(test.expectedCreated))
+			g.Expect(deleted).To(Equal(test.expectedDeleted))
+			g.Expect(newAnnotation).To(Equal(test.expectedNewAnnotations))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR follow the same approach we did for `cluster-api` in this issue: https://github.com/kubernetes-sigs/cluster-api/issues/2433

To follow the same we are applying to the pattern here as well.

Will be opening PR for each folder to make the review easier

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 - Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/454

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @CecileRobertMichon 