### PR TITLE
Enable control plane retry join experimental feature in cluster template

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -38,6 +38,7 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
+    useExperimentalRetryJoin: true,
     initConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/kustomizeversions.yaml
+++ b/templates/kustomizeversions.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   kubeadmConfigSpec:
+    useExperimentalRetryJoin: true,
     clusterConfiguration:
       kubernetesVersion: "ci/${CI_VERSION}"
     preKubeadmCommands:

--- a/test/e2e/control_plane_cluster_test.go
+++ b/test/e2e/control_plane_cluster_test.go
@@ -62,7 +62,7 @@ func (o *ControlPlaneClusterInput) SetDefaults() {
 	}
 
 	if o.DeleteTimeout == 0 {
-		o.DeleteTimeout = 20 * time.Minute
+		o.DeleteTimeout = 30 * time.Minute
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: The retries have anecdotally shown to greatly improve provisioning success. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable experimental retry join for KubeadmControlPlane
```