### PR TITLE
Create Dev Cluster should fail if errors during execution

### DIFF
--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 # Verify the required Environment Variables are present.
 : "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
 : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"


### PR DESCRIPTION
**What this PR does / why we need it**:
`hack/create-dev-cluster.sh` was missing failure options in bash not stopping execution when failure occurred:

```
sigs.k8s.io/controller-runtime@v0.5.2: write /go/pkg/mod/cache/download/sigs.k8s.io/controller-runtime/@v/v0.5.2.zip.tmp997750697: no space left on device
The command '/bin/sh -c go mod download' returned a non-zero code: 1
Makefile:194: recipe for target 'docker-build' failed
make: *** [docker-build] Error 1
================ MAKE CLEAN ===============
make clean-bin
make[1]: Entering directory '/home/user/projects/cluster-api-provider-azure'
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix development cluster creation script to fail on error
```