### PR TITLE
🏃 e2e testing cleanup

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -31,7 +31,7 @@ source "${REPO_ROOT}/hack/ensure-kind.sh"
 # shellcheck source=../hack/ensure-kubectl.sh
 source "${REPO_ROOT}/hack/ensure-kubectl.sh"
 # shellcheck source=../hack/ensure-kustomize.sh
-source "${REPO_ROOT}/hack/ensure-kustomize.sh"  
+source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 
 random-string() {
     cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -39,6 +39,4 @@ export REGISTRY=e2e
 make test-e2e
 test_status="${?}"
 
-# TODO last chance to clean up resources if prow job leaves something behind
-
 exit "${test_status}"

--- a/test/e2e/utils/cleanup_e2e_resources.go
+++ b/test/e2e/utils/cleanup_e2e_resources.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"log"
+
+	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/auth"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+	"github.com/Azure/go-autorest/autorest"
+	azureAuth "github.com/Azure/go-autorest/autorest/azure/auth"
+)
+
+// GetGroup gets the resource group if exist
+func GetGroup(ctx context.Context, creds auth.Creds, resourceName string) (resources.Group, error) {
+	groupClient, err := getGroupsClient(creds)
+	if err != nil {
+		return resources.Group{}, err
+	}
+	return groupClient.Get(ctx, resourceName)
+}
+
+// CleanupE2EResources deletes the resource group created during the testing
+func CleanupE2EResources(ctx context.Context, creds auth.Creds, resourceName string) error {
+	groupClient, err := getGroupsClient(creds)
+	if err != nil {
+		return err
+	}
+
+	deleteGroupFuture, err := groupClient.Delete(ctx, resourceName)
+	if err != nil {
+		log.Printf("failed to delete group %s: %s\n", resourceName, err.Error())
+	}
+
+	autorestClient := autorest.Client{
+		PollingDelay:    autorest.DefaultPollingDelay,
+		PollingDuration: autorest.DefaultPollingDuration,
+		RetryAttempts:   autorest.DefaultRetryAttempts,
+		RetryDuration:   autorest.DefaultRetryDuration,
+		Authorizer:      groupClient.Authorizer,
+	}
+
+	log.Println("waiting for the group deletion")
+
+	err = deleteGroupFuture.WaitForCompletionRef(context.Background(), autorestClient)
+	if err != nil {
+		log.Printf("failed to wait for deletion %s\n", err.Error())
+		return err
+	}
+
+	log.Printf("group %s deleted\n", resourceName)
+	return nil
+}
+
+func getGroupsClient(creds auth.Creds) (resources.GroupsClient, error) {
+	groupsClient := resources.NewGroupsClient(creds.SubscriptionID)
+	a, err := getAuthorizer(creds)
+	if err != nil {
+		return resources.GroupsClient{}, err
+	}
+	groupsClient.Authorizer = a
+	return groupsClient, nil
+}
+
+func getAuthorizer(creds auth.Creds) (autorest.Authorizer, error) {
+	credsConfig := azureAuth.NewClientCredentialsConfig(creds.ClientID, creds.ClientSecret, creds.TenantID)
+	return credsConfig.Authorizer()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

At the end of the e2e tests after the teardown of the cluster we add an extra step just to check if the resource group still exists, and if exist we delete it to clean the tests.

My understanding from the ticket is we need to do in the `ci-e2e.sh` after the `make test-e2e` ran and then we load the credentials and check/clean the resource. But talking with @CecileRobertMichon in slack she points me to another direction and we should check that at the end of the e2e go test execution and do the cleanup there.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 - Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/348

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
e2e: cleanup leftovers resources
```