### PR TITLE
Fix conformance test script to allow building from k8s release

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -289,7 +289,32 @@ To run E2E locally, set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SUBSCRI
 ./scripts/ci-e2e.sh
 ```
 
-You can optionally set `AZURE_SSH_PUBLIC_KEY_FILE` to use your own ssh key.
+You can optionally set `AZURE_SSH_PUBLIC_KEY_FILE` to use your own SSH key.
+
+#### Conformance Testing
+
+To run Conformance locally, set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID` and run:
+
+```bash
+./scripts/ci-conformance.sh
+```
+
+You can optionally set the following variables:
+
+| Variable                    | Description                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `AZURE_SSH_PUBLIC_KEY_FILE` | Use your own SSH key.                                                                                          |
+| `SKIP_CREATE_CLUSTER`       | Skip cluster creation.                                                                                         |
+| `SKIP_TESTS`                | Skip running Kubernetes E2E tests.                                                                             |
+| `SKIP_CLEANUP`              | Skip deleting the cluster after the tests finish running.                                                      |
+| `KUBECONFIG`                | Provide your existing cluster kubeconfig filepath. If no kubeconfig is provided, `./kubeconfig` will be used.  |
+| `SKIP`                      | Regexp for test cases to skip.                                                                                 |
+| `FOCUS`                     | Regexp for which test cases to run.                                                                            |
+| `PARALLEL`                  | Skip serial tests and set --ginkgo-parallel.                                                                  |
+| `USE_CI_ARTIFACTS`          | Use a CI version of Kubernetes, ie. not a released version (eg. `v1.19.0-alpha.1.426+0926c9c47677e9`)          |
+| `CI_VERSION`                | Provide a custom CI version of Kubernetes. By default, the latest master commit will be used.                  |
+
+You can also customize the configuration of the CAPZ cluster (assuming that `SKIP_CREATE_CLUSTER` is not set). See [Customizing the cluster deployment](#customizing-the-cluster-deployment) for more details.
 
 <!-- References -->
 


### PR DESCRIPTION
**What this PR does / why we need it**: Fix conformance test script to allow building from k8s release. Some bash improvements, fixed indents. Also adds documentation for running locally.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```