### PR TITLE
fix: do not require REGISTRY in create-dev-cluster

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -153,7 +153,7 @@ started prerequisites section](./getting-started.md#Prerequisites)
 
 #### Creating a dev cluster
 
-The steps below are provided in a convenient script in [hack/create-dev-cluster.sh](hack/create-dev-cluster.sh). Be sure to set `REGISTRY="<container-registry>"`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SUBSCRIPTION_ID`, and `AZURE_TENANT_ID` before running. Optionally, you can override the different cluster configuration variables. For example, to override the workload cluster name:
+The steps below are provided in a convenient script in [hack/create-dev-cluster.sh](hack/create-dev-cluster.sh). Be sure to set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SUBSCRIPTION_ID`, and `AZURE_TENANT_ID` before running. Optionally, you can override the different cluster configuration variables. For example, to override the workload cluster name:
 
 ```bash
 CLUSTER_NAME=<my-capz-cluster-name> ./hack/create-dev-cluster.sh

--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -22,7 +22,8 @@ set -o pipefail
 : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
 : "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
 : "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
-: "${REGISTRY:?Environment variable empty or not defined.}"
+
+export REGISTRY="${REGISTRY:-registry.local/fake}"
 
 # Cluster settings.
 export CLUSTER_NAME="${CLUSTER_NAME:-capz-test}"


### PR DESCRIPTION
**What this PR does / why we need it**:
To make initial development cluster setup easier, we should default the `REGISTRY` env var.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #508

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default REGISTRY when creating a development cluster using
```