### PR TITLE
Only print updating tags log if tags are changed and get updated

### DIFF
--- a/controllers/azuremachine_tags.go
+++ b/controllers/azuremachine_tags.go
@@ -35,13 +35,13 @@ const (
 
 // Ensure that the tags of the machine are correct
 func (r *AzureMachineReconciler) reconcileTags(machineScope *scope.MachineScope, clusterScope *scope.ClusterScope, additionalTags map[string]string) error {
-	machineScope.Info("Updating tags on AzureMachine")
 	annotation, err := r.machineAnnotationJSON(machineScope.AzureMachine, TagsLastAppliedAnnotation)
 	if err != nil {
 		return err
 	}
 	changed, created, deleted, newAnnotation := tagsChanged(annotation, additionalTags)
 	if changed {
+		machineScope.Info("Updating tags on AzureMachine")
 		vmSpec := &virtualmachines.Spec{
 			Name: machineScope.Name(),
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: Right now the "updating tags" log line gets printed at every controller loop, even if the tags are unchanged. This is a minor cosmetic fix to only print the log line if the tags are actually getting updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Only print updating tags log if tags are changed and get updated
```