### PR TITLE
Add step to parse prow credentials in create cluster script

### DIFF
--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -17,6 +17,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# for Prow we use the provided AZURE_CREDENTIALS file
+if [[ -n "${AZURE_CREDENTIALS}" ]]; then
+    export AZURE_SUBSCRIPTION_ID="$(cat ${AZURE_CREDENTIALS} | grep SubscriptionID | cut -d '=' -f 2)"
+    export AZURE_TENANT_ID="$(cat ${AZURE_CREDENTIALS} | grep TenantID | cut -d '=' -f 2)"
+    export AZURE_CLIENT_ID="$(cat ${AZURE_CREDENTIALS} | grep ClientID | cut -d '=' -f 2)"
+    # password might contain an '=' sign so we need to get all the fields after the first '=' 
+    export AZURE_CLIENT_SECRET="$(cat ${AZURE_CREDENTIALS} | grep ClientSecret | cut -d '=' -f 2-)"
+fi 
+
 # Verify the required Environment Variables are present.
 : "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
 : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"


### PR DESCRIPTION
**What this PR does / why we need it**: In order to run a periodic conformance test, we need to script to be able to pick up the Azure credentials which are provided as a file in the form:

```
[Creds]
ClientID = "$(AAD_CLIENT_ID)"
ClientSecret = "$(AAD_CLIENT_SECRET)"
TenantID = "$(TENANT_ID)"
SubscriptionID = "$(SUBSCRIPTION_ID)"
StorageAccountName = "$(STORAGE_ACCOUNT_NAME)"
StorageAccountKey = "$(STORAGE_ACCOUNT_KEY)"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```