### PR TITLE
docs: move creds before tilt for clarity; fix 404

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -95,6 +95,11 @@ A few Makefile and scripts are offered to work with go modules:
 
 - `hack/ensure-go.sh` file checks that the Go version and environment variables are properly set.
 
+### Setting up the environment
+
+Your environment must have the Azure credentials as outlined in the [getting
+started prerequisites section](./getting-started.md#Prerequisites)
+
 ### Using Tilt
 
 To use [Tilt](https://tilt.dev/) for a simplified development workflow, follow the [instructions](https://cluster-api.sigs.k8s.io/developer/tilt.html) in the cluster-api repo.  The instructions will walk you through cloning the Cluster API (capi) repository and configuring Tilt to use `kind` to delpoy the cluster api managment components.
@@ -146,14 +151,9 @@ make delete-workload-cluster
 
 ### Manual Testing
 
-#### Setting up the environment
-
-Your environment must have the Azure credentials as outlined in the [getting
-started prerequisites section](./getting-started.md#Prerequisites)
-
 #### Creating a dev cluster
 
-The steps below are provided in a convenient script in [hack/create-dev-cluster.sh](hack/create-dev-cluster.sh). Be sure to set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SUBSCRIPTION_ID`, and `AZURE_TENANT_ID` before running. Optionally, you can override the different cluster configuration variables. For example, to override the workload cluster name:
+The steps below are provided in a convenient script in [hack/create-dev-cluster.sh](../hack/create-dev-cluster.sh). Be sure to set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SUBSCRIPTION_ID`, and `AZURE_TENANT_ID` before running. Optionally, you can override the different cluster configuration variables. For example, to override the workload cluster name:
 
 ```bash
 CLUSTER_NAME=<my-capz-cluster-name> ./hack/create-dev-cluster.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if you run through the docs for tilt, you don't ever hit our prerequisites section to generate credentials for Azure. This moves that step from manual testing earlier to clarify it's always necessary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```