### PR TITLE
feat: validate AzureCluster update for location property

### DIFF
--- a/api/v1alpha3/azurecluster_webhook.go
+++ b/api/v1alpha3/azurecluster_webhook.go
@@ -17,8 +17,14 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 // log is for logging in this package.
@@ -28,4 +34,41 @@ func (r *AzureCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha3-azurecluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=azurecluster,versions=v1alpha3,name=validation.azurecluster.infrastructure.cluster.x-k8s.io
+
+var _ webhook.Validator = &AzureCluster{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *AzureCluster) ValidateCreate() error {
+	machinelog.Info("validate create", "name", r.Name)
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *AzureCluster) ValidateUpdate(old runtime.Object) error {
+	machinelog.Info("validate update", "name", r.Name)
+	azureCluster, ok := old.(*AzureCluster)
+	if !ok {
+		return fmt.Errorf("update object is not a AzureCluster type")
+	}
+
+	if azureCluster.Spec.Location != r.Spec.Location {
+		allErrs := field.ErrorList{}
+		allErrs = append(allErrs, field.Invalid(field.NewPath("location"), r.Spec.Location, "AzureCluster Location is not mutable"))
+		return apierrors.NewInvalid(
+			GroupVersion.WithKind("AzureCluster").GroupKind(),
+			r.Spec.Location, allErrs)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *AzureCluster) ValidateDelete() error {
+	machinelog.Info("validate delete", "name", r.Name)
+
+	return nil
 }

--- a/api/v1alpha3/azurecluster_webhook_test.go
+++ b/api/v1alpha3/azurecluster_webhook_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAzureCluster_ValidateUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name    string
+		cluster *AzureCluster
+		updated *AzureCluster
+		wantErr bool
+	}{
+		{
+			name:    "no change",
+			cluster: createAzureCluster(t, "westus2"),
+			updated: createAzureCluster(t, "westus2"),
+			wantErr: false,
+		},
+		{
+			name:    "no change",
+			cluster: createAzureCluster(t, "westus2"),
+			updated: createAzureCluster(t, "eastus"),
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cluster.ValidateUpdate(tc.updated)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func createAzureCluster(t *testing.T, location string) *AzureCluster {
+	return &AzureCluster{
+		Spec: AzureClusterSpec{
+			Location: location,
+		},
+	}
+}

--- a/api/v1alpha3/azurecluster_webhook_test.go
+++ b/api/v1alpha3/azurecluster_webhook_test.go
@@ -35,14 +35,14 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 	}{
 		{
 			name:    "no change",
-			cluster: createAzureCluster(t, "westus2"),
-			updated: createAzureCluster(t, "westus2"),
+			cluster: createAzureCluster("westus2"),
+			updated: createAzureCluster("westus2"),
 			err:     nil,
 		},
 		{
 			name:    "update location should throw an error",
-			cluster: createAzureCluster(t, "westus2"),
-			updated: createAzureCluster(t, "eastus"),
+			cluster: createAzureCluster("westus2"),
+			updated: createAzureCluster("eastus"),
 			err: apierrors.NewInvalid(
 				GroupVersion.WithKind("AzureCluster").GroupKind(),
 				"westus2", field.ErrorList{
@@ -53,6 +53,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			err := tc.cluster.ValidateUpdate(tc.updated)
 			if tc.err != nil {
 				g.Expect(err).To(HaveOccurred())
@@ -64,7 +65,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 	}
 }
 
-func createAzureCluster(t *testing.T, location string) *AzureCluster {
+func createAzureCluster(location string) *AzureCluster {
 	return &AzureCluster{
 		Spec: AzureClusterSpec{
 			Location: location,

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -38,6 +38,25 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha3-azurecluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.azurecluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - azurecluster
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha3-azuremachine
   failurePolicy: Fail
   matchPolicy: Equivalent


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds CRUD validations as webhooks to the AzureCluster resource type.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #497 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```