### PR TITLE
Collect capz logs in conformance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ tilt-settings.json
 # e2e output
 test/e2e/junit.e2e_suite.*.xml
 test/e2e/logs/*
+_artifacts


### PR DESCRIPTION
**What this PR does / why we need it**: Help debug https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#periodic-conformance-v1alpha3. 

Wny not collect more logs? don't want to overlap with #474, this is the bare minimum to help debug what's going on in the periodic job.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```