### PR TITLE
dependency: Update hack/tools controller-tools to v0.2.8

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.6
+    controller-gen.kubebuilder.io/version: v0.2.8
   creationTimestamp: null
   name: azureclusters.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.6
+    controller-gen.kubebuilder.io/version: v0.2.8
   creationTimestamp: null
   name: azuremachines.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.6
+    controller-gen.kubebuilder.io/version: v0.2.8
   creationTimestamp: null
   name: azuremachinetemplates.infrastructure.cluster.x-k8s.io
 spec:

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -17,11 +17,10 @@ require (
 	github.com/gophercloud/gophercloud v0.6.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/russross/blackfriday v2.0.0+incompatible // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	k8s.io/code-generator v0.18.0-alpha.2.0.20200130061103-7dfd5e9157ef
 	sigs.k8s.io/cluster-api/hack/tools v0.0.0-20200319204836-a97903fa1e7e
-	sigs.k8s.io/controller-tools v0.2.6
+	sigs.k8s.io/controller-tools v0.2.8
 	sigs.k8s.io/kustomize/kustomize/v3 v3.5.4
 	sigs.k8s.io/testing_frameworks v0.1.2
 )

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -481,9 +481,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uY
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/russross/blackfriday v2.0.0+incompatible h1:cBXrhZNUf9C+La9/YpS+UHpUT8YD6Td9ZMSU9APFcsk=
-github.com/russross/blackfriday v2.0.0+incompatible/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/securego/gosec v0.0.0-20191002120514-e680875ea14d/go.mod h1:w5+eXa0mYznDkHaMCXA4XYffjlH+cy1oyKbfzJXa2Do=
 github.com/securego/gosec v0.0.0-20200103095621-79fbf3af8d83 h1:AtnWoOvTioyDXFvu96MWEeE8qj4COSQnJogzLy/u41A=
@@ -831,6 +830,8 @@ sigs.k8s.io/cluster-api/hack/tools v0.0.0-20200319204836-a97903fa1e7e h1:fTrmXG0
 sigs.k8s.io/cluster-api/hack/tools v0.0.0-20200319204836-a97903fa1e7e/go.mod h1:8aibHfbqxNthBN4KKnk8UV9xTHKB3TE5nzxeNkH9xrU=
 sigs.k8s.io/controller-tools v0.2.6 h1:4Fo36alFw5+Fffz7HhNd2EFBFvckqVkb4ePnIj0uLUc=
 sigs.k8s.io/controller-tools v0.2.6/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9uAiBVsaJSE=
+sigs.k8s.io/controller-tools v0.2.8 h1:UmYsnu89dn8/wBhjKL3lkGyaDGRnPDYUx2+iwXRnylA=
+sigs.k8s.io/controller-tools v0.2.8/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9uAiBVsaJSE=
 sigs.k8s.io/kubebuilder/docs/book/utils v0.0.0-20200226075303-ed8438ec10a4/go.mod h1:nyAxPBUS04gN3IRuEQ0elG4mVeto/d/qQRsW2PsyAy4=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=


### PR DESCRIPTION
**What this PR does / why we need it**:
```
make release-manifests                                                        ✔  10691  12:51:30
cd hack/tools; go build -tags=tools -o bin/kustomize sigs.k8s.io/kustomize/kustomize/v3
# k8s.io/kubectl/pkg/util/templates
../../../../../pkg/mod/k8s.io/kubectl@v0.0.0-20191219154910-1528d4eea6dd/pkg/util/templates/markdown.go:30:5: cannot use &ASCIIRenderer literal (type *ASCIIRenderer) as type blackfriday.Renderer in assignment:
	*ASCIIRenderer does not implement blackfriday.Renderer (missing RenderFooter method)
../../../../../pkg/mod/k8s.io/kubectl@v0.0.0-20191219154910-1528d4eea6dd/pkg/util/templates/markdown.go:66:11: undefined: blackfriday.LIST_ITEM_BEGINNING_OF_LIST
../../../../../pkg/mod/k8s.io/kubectl@v0.0.0-20191219154910-1528d4eea6dd/pkg/util/templates/markdown.go:73:11: undefined: blackfriday.LIST_TYPE_ORDERED
../../../../../pkg/mod/k8s.io/kubectl@v0.0.0-20191219154910-1528d4eea6dd/pkg/util/templates/normalizers.go:73:35: too many arguments to conversion to blackfriday.Markdown: blackfriday.Markdown(bytes, composite literal, blackfriday.EXTENSION_NO_INTRA_EMPHASIS)
make: *** [/Users/cerobert/go/src/sigs.k8s.io/cluster-api-provider-azure/hack/tools/bin/kustomize] Error 2
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
dependency: Update hack/tools controller-tools to v0.2.8
```