### PR TITLE
Change prow creds parsing to allow no new lines

### DIFF
--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -17,13 +17,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# for Prow we use the provided AZURE_CREDENTIALS file
+# for Prow we use the provided AZURE_CREDENTIALS file.
+# the file is expected to be in toml format.
 if [[ -n "${AZURE_CREDENTIALS:-}" ]]; then
-    export AZURE_SUBSCRIPTION_ID="$(cat ${AZURE_CREDENTIALS} | grep SubscriptionID | cut -d '=' -f 2)"
-    export AZURE_TENANT_ID="$(cat ${AZURE_CREDENTIALS} | grep TenantID | cut -d '=' -f 2)"
-    export AZURE_CLIENT_ID="$(cat ${AZURE_CREDENTIALS} | grep ClientID | cut -d '=' -f 2)"
-    # password might contain an '=' sign so we need to get all the fields after the first '=' 
-    export AZURE_CLIENT_SECRET="$(cat ${AZURE_CREDENTIALS} | grep ClientSecret | cut -d '=' -f 2-)"
+    export AZURE_SUBSCRIPTION_ID="$(cat ${AZURE_CREDENTIALS} | grep -E -o 'SubscriptionID[[:blank:]]*=[[:blank:]]*"[^[:space:]"]+"' | cut -d '"' -f 2)"
+    export AZURE_TENANT_ID="$(cat ${AZURE_CREDENTIALS} | grep -E -o 'TenantID[[:blank:]]*=[[:blank:]]*"[^[:space:]"]+"' | cut -d '"' -f 2)"
+    export AZURE_CLIENT_ID="$(cat ${AZURE_CREDENTIALS} | grep -E -o 'ClientID[[:blank:]]*=[[:blank:]]*"[^[:space:]"]+"' | cut -d '"' -f 2)"
+    export AZURE_CLIENT_SECRET="$(cat ${AZURE_CREDENTIALS} | grep -E -o 'ClientSecret[[:blank:]]*=[[:blank:]]*"[^[:space:]"]+"' | cut -d '"' -f 2)"
 fi 
 
 # Verify the required Environment Variables are present.

--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -17,15 +17,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# for Prow we use the provided AZURE_CREDENTIALS file.
-# the file is expected to be in toml format.
-if [[ -n "${AZURE_CREDENTIALS:-}" ]]; then
-    export AZURE_SUBSCRIPTION_ID="$(cat ${AZURE_CREDENTIALS} | grep -E -o 'SubscriptionID[[:blank:]]*=[[:blank:]]*"[^[:space:]"]+"' | cut -d '"' -f 2)"
-    export AZURE_TENANT_ID="$(cat ${AZURE_CREDENTIALS} | grep -E -o 'TenantID[[:blank:]]*=[[:blank:]]*"[^[:space:]"]+"' | cut -d '"' -f 2)"
-    export AZURE_CLIENT_ID="$(cat ${AZURE_CREDENTIALS} | grep -E -o 'ClientID[[:blank:]]*=[[:blank:]]*"[^[:space:]"]+"' | cut -d '"' -f 2)"
-    export AZURE_CLIENT_SECRET="$(cat ${AZURE_CREDENTIALS} | grep -E -o 'ClientSecret[[:blank:]]*=[[:blank:]]*"[^[:space:]"]+"' | cut -d '"' -f 2)"
-fi 
-
 # Verify the required Environment Variables are present.
 : "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
 : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"

--- a/hack/parse-prow-creds.sh
+++ b/hack/parse-prow-creds.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+parse_cred() {
+    grep -E -o "$1[[:blank:]]*=[[:blank:]]*\"[^[:space:]\"]+\"" | cut -d '"' -f 2
+}
+
+# for Prow we use the provided AZURE_CREDENTIALS file.
+# the file is expected to be in toml format.
+if [[ -n "${AZURE_CREDENTIALS:-}" ]]; then
+    export AZURE_SUBSCRIPTION_ID="$(cat ${AZURE_CREDENTIALS} | parse_cred SubscriptionID)"
+    export AZURE_TENANT_ID="$(cat ${AZURE_CREDENTIALS} | parse_cred TenantID)"
+    export AZURE_CLIENT_ID="$(cat ${AZURE_CREDENTIALS} | parse_cred ClientID)"
+    export AZURE_CLIENT_SECRET="$(cat ${AZURE_CREDENTIALS} | parse_cred ClientSecret)"
+fi

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -33,6 +33,8 @@ source "${REPO_ROOT}/hack/ensure-kind.sh"
 source "${REPO_ROOT}/hack/ensure-kubectl.sh"
 # shellcheck source=../hack/ensure-kustomize.sh
 source "${REPO_ROOT}/hack/ensure-kustomize.sh"
+# shellcheck source=../hack/parse-prow-creds.sh
+source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 
 random-string() {
     cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1


### PR DESCRIPTION
**What this PR does / why we need it**: Currently, the parsing of prow creds only works if the credential file separates each key/value with a new line which isn't always true for yaml files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```