### PR TITLE
[conformance] Don't fail if can't move ginkgo binary

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -71,7 +71,8 @@ build_k8s() {
     # ensure the e2e script will find our binaries ...
     mkdir -p "${PWD}/_output/bin/"
     cp -f "${PWD}/bazel-bin/test/e2e/e2e.test" "${PWD}/_output/bin/e2e.test"
-    cp -f "${PWD}/bazel-bin/vendor/github.com/onsi/ginkgo/ginkgo/darwin_amd64_stripped/ginkgo" "${PWD}/_output/bin/ginkgo"
+    # workaround for mac os
+    cp -f "${PWD}/bazel-bin/vendor/github.com/onsi/ginkgo/ginkgo/darwin_amd64_stripped/ginkgo" "${PWD}/_output/bin/ginkgo" || true
     export KUBECTL_PATH="$(dirname "$(find "${PWD}/bazel-bin/" -name kubectl -type f)")/kubectl"
     PATH="${KUBECTL_PATH}:${PATH}"
     export PATH


### PR DESCRIPTION
**What this PR does / why we need it**: Makes the copy ginkgo binary step optional in the conformance script that was added as a workaround to be able to run locally on mac os.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```