### PR TITLE
chore: ignore all files in dockerignore by default

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,11 @@
-.git
-.github
-.vscode
-bin/
-config/
-hack/
-docs/
-templates/
-scripts/
-**/.md
-tilt-provider.json
+# Ignore everything
+**
+
+# Allow only these
+!/api/**
+!/cloud/**
+!/controllers/**
+!/pkg/**
+!/main.go
+!/go.mod
+!/go.sum


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore all the things in docker unless explicitly added to the docker context. Below are a couple reasons why I think it would be beneficial to have an opt in model, rather than an opt out model for dockerignore.
1) As the project changes, folders will be added, some of those only in a development setting, like `.tiltbuild` which holds compiled bins. Including large files in the docker context will slow down docker builds.
2) Some of the files in the directory will likely have credentials, like SSH keys, Azure creds, etc. By default, it would be prudent to ensure these files never end up in the docker context during a build as it brings them one step closer to landing in a published layer. 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```