### PR TITLE
🏃 allow for extra args in entrypoint

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -141,6 +141,11 @@ def capz():
         tilt_dockerfile_header,
     ])
 
+    entrypoint = ["sh", "/start.sh", "/manager"]
+    extra_args = p.get("extra_args")
+    if extra_args:
+        entrypoint.extend(extra_args)
+
     # Set up an image build for the provider. The live update configuration syncs the output from the local_resource
     # build into the container.
     docker_build(
@@ -148,7 +153,7 @@ def capz():
         context = "./.tiltbuild/",
         dockerfile_contents = dockerfile_contents,
         target = "tilt",
-        entrypoint = ["sh", "/start.sh", "/manager"],
+        entrypoint = entrypoint,
         only = "manager",
         live_update = [
             sync("./.tiltbuild/manager", "/manager"),


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows extra args from the tilt provider config.

This makes testing things like feature flags much easier. It needs to be in provider config rather than settings so it can be used across all providers (settings files are 1 per invocation I think? but we could change that).

Same as https://github.com/kubernetes-sigs/cluster-api/pull/2932 for CAPI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
NONE
```