### PR TITLE
Move AzureMachine SSHPublicKey validation to webhook

### DIFF
--- a/api/v1alpha3/azuremachine_default.go
+++ b/api/v1alpha3/azuremachine_default.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
+)
+
+// SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureMachine
+func (m *AzureMachine) SetDefaultSSHPublicKey() error {
+	sshKeyData := m.Spec.SSHPublicKey
+	if sshKeyData == "" {
+		privateKey, perr := rsa.GenerateKey(rand.Reader, 2048)
+		if perr != nil {
+			return errors.Wrap(perr, "Failed to generate private key")
+		}
+
+		publicRsaKey, perr := ssh.NewPublicKey(&privateKey.PublicKey)
+		if perr != nil {
+			return errors.Wrap(perr, "Failed to generate public key")
+		}
+		m.Spec.SSHPublicKey = string(ssh.MarshalAuthorizedKey(publicRsaKey))
+	}
+
+	return nil
+}

--- a/api/v1alpha3/azuremachine_default_test.go
+++ b/api/v1alpha3/azuremachine_default_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAzureMachine_SetDefaultSSHPublicKey(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		machine *AzureMachine
+	}
+
+	existingPublicKey := "testpublickey"
+	publicKeyExistTest := test{machine: createMachineWithSSHPublicKey(t, existingPublicKey)}
+	publicKeyNotExistTest := test{machine: createMachineWithSSHPublicKey(t, "")}
+
+	err := publicKeyExistTest.machine.SetDefaultSSHPublicKey()
+	g.Expect(err).To(BeNil())
+	g.Expect(publicKeyExistTest.machine.Spec.SSHPublicKey).To(Equal(existingPublicKey))
+
+	err = publicKeyNotExistTest.machine.SetDefaultSSHPublicKey()
+	g.Expect(err).To(BeNil())
+	g.Expect(publicKeyNotExistTest.machine.Spec.SSHPublicKey).To(Not(BeEmpty()))
+}
+
+func createMachineWithSSHPublicKey(t *testing.T, sshPublicKey string) *AzureMachine {
+	return &AzureMachine{
+		Spec: AzureMachineSpec{
+			SSHPublicKey: sshPublicKey,
+			Image: &Image{
+				SharedGallery: &AzureSharedGalleryImage{
+					SubscriptionID: "SUB123",
+					ResourceGroup:  "RG123",
+					Name:           "NAME123",
+					Gallery:        "GALLERY1",
+					Version:        "1.0.0",
+				},
+			},
+		},
+	}
+}

--- a/api/v1alpha3/azuremachine_validation.go
+++ b/api/v1alpha3/azuremachine_validation.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"golang.org/x/crypto/ssh"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateSSHKey validates an SSHKey
+func ValidateSSHKey(sshKey string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if _, _, _, _, err := ssh.ParseAuthorizedKey([]byte(sshKey)); err != nil {
+		allErrs = append(allErrs, field.Required(fldPath, "the SSH public key is not valid"))
+		return allErrs
+	}
+
+	return allErrs
+}

--- a/api/v1alpha3/azuremachine_validation_test.go
+++ b/api/v1alpha3/azuremachine_validation_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestAzureMachine_ValidateSSHKey(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name    string
+		sshKey  string
+		wantErr bool
+	}{
+		{
+			name:    "valid ssh key",
+			sshKey:  generateSSHPublicKey(),
+			wantErr: false,
+		},
+		{
+			name:    "invalid ssh key",
+			sshKey:  "invalid ssh key",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSSHKey(tc.sshKey, field.NewPath("sshPublicKey"))
+			if tc.wantErr {
+				g.Expect(err).ToNot(HaveLen(0))
+			} else {
+				g.Expect(err).To(HaveLen(0))
+			}
+		})
+	}
+}
+
+func generateSSHPublicKey() string {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	publicRsaKey, _ := ssh.NewPublicKey(&privateKey.PublicKey)
+	return string(ssh.MarshalAuthorizedKey(publicRsaKey))
+}

--- a/api/v1alpha3/azuremachine_webhook.go
+++ b/api/v1alpha3/azuremachine_webhook.go
@@ -49,12 +49,24 @@ func (m *AzureMachine) ValidateCreate() error {
 			m.Name, errs)
 	}
 
+	if errs := ValidateSSHKey(m.Spec.SSHPublicKey, field.NewPath("sshPublicKey")); len(errs) > 0 {
+		return apierrors.NewInvalid(
+			GroupVersion.WithKind("AzureMachine").GroupKind(),
+			m.Name, errs)
+	}
+
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (m *AzureMachine) ValidateUpdate(old runtime.Object) error {
 	machinelog.Info("validate update", "name", m.Name)
+
+	if errs := ValidateSSHKey(m.Spec.SSHPublicKey, field.NewPath("sshPublicKey")); len(errs) > 0 {
+		return apierrors.NewInvalid(
+			GroupVersion.WithKind("AzureMachine").GroupKind(),
+			m.Name, errs)
+	}
 
 	return nil
 }
@@ -64,4 +76,14 @@ func (m *AzureMachine) ValidateDelete() error {
 	machinelog.Info("validate delete", "name", m.Name)
 
 	return nil
+}
+
+// Default implements webhookutil.defaulter so a webhook will be registered for the type
+func (m *AzureMachine) Default() {
+	machinelog.Info("default", "name", m.Name)
+
+	err := m.SetDefaultSSHPublicKey()
+	if err != nil {
+		machinelog.Error(err, "SetDefaultSshPublicKey failed")
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we are generating SSH keys in virtualmachines.go if the SSH Key field is empty https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/cloud/services/virtualmachines/virtualmachines.go#L100

This should be done in a defaulting webhook and a validating webhook should validate this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #491

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

This PR doesn't change any image  version.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Move AzureMachine SSHPublicKey generation into AzureMachine webhook.
Also adding SSHPublicKey validation in the webhook.
```