### PR TITLE
conformance: fix kubeadm version when using CI_VERSION 

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -72,15 +72,16 @@ create_cluster() {
     # export cluster template which contains the manifests needed for creating the Azure cluster to run the tests
     if [[ -n ${CI_VERSION:-} || -n ${USE_CI_ARTIFACTS:-} ]]; then
         export CLUSTER_TEMPLATE="test/cluster-template-conformance-ci-version.yaml"
+        export CI_VERSION=${CI_VERSION:-$(curl -sSL https://dl.k8s.io/ci/k8s-master.txt)}
+        export KUBERNETES_VERSION=${CI_VERSION}
     else
         export CLUSTER_TEMPLATE="test/cluster-template-conformance.yaml"
     fi
 
     export CLUSTER_NAME="capz-conformance-$(head /dev/urandom | LC_ALL=C tr -dc a-z0-9 | head -c 6 ; echo '')"
     # Conformance test suite needs a cluster with at least 2 nodes
-    export CONTROL_PLANE_MACHINE_COUNT=${CONTROL_PLANE_MACHINE_COUNT:-3}
+    export CONTROL_PLANE_MACHINE_COUNT=${CONTROL_PLANE_MACHINE_COUNT:-1}
     export WORKER_MACHINE_COUNT=${WORKER_MACHINE_COUNT:-2}
-    export CI_VERSION=${CI_VERSION:-$(curl -sSL https://dl.k8s.io/ci/k8s-master.txt)}
     export REGISTRY=conformance
     # timestamp is in RFC-3339 format to match kubetest
     export TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')

--- a/templates/test/cluster-template-conformance-ci-version.yaml
+++ b/templates/test/cluster-template-conformance-ci-version.yaml
@@ -323,6 +323,12 @@ metadata:
 spec:
   template:
     spec:
+      image:
+        marketplace:
+          offer: capi
+          publisher: cncf-upstream
+          sku: k8s-1dot18dot2-ubuntu-1804
+          version: 2020.04.17
       location: ${AZURE_LOCATION}
       osDisk:
         diskSizeGB: 128
@@ -340,6 +346,12 @@ metadata:
 spec:
   template:
     spec:
+      image:
+        marketplace:
+          offer: capi
+          publisher: cncf-upstream
+          sku: k8s-1dot18dot2-ubuntu-1804
+          version: 2020.04.17
       location: ${AZURE_LOCATION}
       osDisk:
         diskSizeGB: 30

--- a/templates/test/conformance-ci-version/patches/ci-version.yaml
+++ b/templates/test/conformance-ci-version/patches/ci-version.yaml
@@ -106,6 +106,22 @@ spec:
           "useInstanceMetadata": true
         }
 ---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AzureMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      image:
+        # we use the 1.18.2 image as a workaround there is no published marketplace image for k8s CI versions.
+        # 1.18.2 binaries and images will get replaced to the desired version by the script above.
+        marketplace:
+          publisher: cncf-upstream
+          offer: capi
+          sku: k8s-1dot18dot2-ubuntu-1804
+          version: "2020.04.17"
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
@@ -210,3 +226,19 @@ spec:
               "useManagedIdentityExtension": false,
               "useInstanceMetadata": true
             }
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      image:
+        # we use the 1.18.2 image as a workaround there is no published marketplace image for k8s CI versions.
+        # 1.18.2 binaries and images will get replaced to the desired version by the script above.
+        marketplace:
+          publisher: cncf-upstream
+          offer: capi
+          sku: k8s-1dot18dot2-ubuntu-1804
+          version: "2020.04.17"


### PR DESCRIPTION
**What this PR does / why we need it**: https://github.com/kubernetes-sigs/cluster-api/blob/master/controlplane/kubeadm/controllers/controller.go#L257-L261 changes the kube-proxy image using the `version` value in KCP spec. In order to use `CI_VERSION` as `KUBERNETES_VERSION`, we need to set the VM image to be used. Otherwise, capz will try to find an missing image. 

Also change the default number of control plane machines to 1 to speed up the tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
conformance: fix kubeadm version when using CI_VERSION 
```