### PR TITLE
feat: add failure domain support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,6 @@ PULL_POLICY ?= Always
 
 CLUSTER_TEMPLATE ?= cluster-template.yaml
 
-# Allow running the manager locally for debugging
-DEBUG_DEPLOY_MANAGER ?= true
-
 ## --------------------------------------
 ## Help
 ## --------------------------------------
@@ -336,7 +333,6 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST)
 	kubectl wait --for=condition=Ready --timeout=5m -n capi-kubeadm-bootstrap-system pod -l cluster.x-k8s.io/provider=bootstrap-kubeadm
 	kubectl wait --for=condition=Ready --timeout=5m -n capi-kubeadm-control-plane-system pod -l cluster.x-k8s.io/provider=control-plane-kubeadm
 
-ifeq ($(DEBUG_DEPLOY_MANAGER), true)
 	# Wait for CAPZ pods
 	kubectl wait --for=condition=Ready --timeout=5m -n capz-system pod -l cluster.x-k8s.io/provider=infrastructure-azure
 
@@ -359,11 +355,6 @@ create-workload-cluster: $(ENVSUBST)
 	kubectl --kubeconfig=./kubeconfig apply -f templates/addons/calico.yaml
 
 	@echo 'run "kubectl --kubeconfig=./kubeconfig ..." to work with the new target cluster'
-else
-	# Delete the deployment and webhooks as we will be running/debugging locally
-	kubectl delete deployment capz-controller-manager -n capz-system
-	kubectl delete ValidatingWebhookConfiguration capz-validating-webhook-configuration 
-endif
 
 .PHONY: create-cluster
 create-cluster: create-management-cluster create-workload-cluster ## Create a workload development Kubernetes cluster on Azure in a kind management cluster.

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ PULL_POLICY ?= Always
 
 CLUSTER_TEMPLATE ?= cluster-template.yaml
 
+# Allow running the manager locally for debugging
+DEBUG_DEPLOY_MANAGER ?= true
+
 ## --------------------------------------
 ## Help
 ## --------------------------------------
@@ -333,6 +336,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST)
 	kubectl wait --for=condition=Ready --timeout=5m -n capi-kubeadm-bootstrap-system pod -l cluster.x-k8s.io/provider=bootstrap-kubeadm
 	kubectl wait --for=condition=Ready --timeout=5m -n capi-kubeadm-control-plane-system pod -l cluster.x-k8s.io/provider=control-plane-kubeadm
 
+ifeq ($(DEBUG_DEPLOY_MANAGER), true)
 	# Wait for CAPZ pods
 	kubectl wait --for=condition=Ready --timeout=5m -n capz-system pod -l cluster.x-k8s.io/provider=infrastructure-azure
 
@@ -355,6 +359,11 @@ create-workload-cluster: $(ENVSUBST)
 	kubectl --kubeconfig=./kubeconfig apply -f templates/addons/calico.yaml
 
 	@echo 'run "kubectl --kubeconfig=./kubeconfig ..." to work with the new target cluster'
+else
+	# Delete the deployment and webhooks as we will be running/debugging locally
+	kubectl delete deployment capz-controller-manager -n capz-system
+	kubectl delete ValidatingWebhookConfiguration capz-validating-webhook-configuration 
+endif
 
 .PHONY: create-cluster
 create-cluster: create-management-cluster create-workload-cluster ## Create a workload development Kubernetes cluster on Azure in a kind management cluster.

--- a/api/v1alpha2/azurecluster_conversion.go
+++ b/api/v1alpha2/azurecluster_conversion.go
@@ -44,6 +44,8 @@ func (src *AzureCluster) ConvertTo(dstRaw conversion.Hub) error { // nolint
 		return err
 	}
 
+	dst.Status.FailureDomains = restored.Status.FailureDomains
+
 	return nil
 }
 

--- a/api/v1alpha2/azuremachine_conversion.go
+++ b/api/v1alpha2/azuremachine_conversion.go
@@ -40,6 +40,8 @@ func (src *AzureMachine) ConvertTo(dstRaw conversion.Hub) error { // nolint
 		dst.Spec.Identity = restored.Spec.Identity
 	}
 
+	dst.Spec.FailureDomain = restored.Spec.FailureDomain
+
 	return nil
 }
 

--- a/api/v1alpha2/azuremachinetemplate_conversion.go
+++ b/api/v1alpha2/azuremachinetemplate_conversion.go
@@ -38,6 +38,8 @@ func (src *AzureMachineTemplate) ConvertTo(dstRaw conversion.Hub) error { // nol
 		dst.Spec.Template.Spec.Identity = restored.Spec.Template.Spec.Identity
 	}
 
+	dst.Spec.Template.Spec.FailureDomain = restored.Spec.Template.Spec.FailureDomain
+
 	return nil
 }
 

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -483,6 +483,7 @@ func autoConvert_v1alpha3_AzureClusterStatus_To_v1alpha2_AzureClusterStatus(in *
 	if err := Convert_v1alpha3_Network_To_v1alpha2_Network(&in.Network, &out.Network, s); err != nil {
 		return err
 	}
+	// WARNING: in.FailureDomains requires manual conversion: does not exist in peer-type
 	if err := Convert_v1alpha3_VM_To_v1alpha2_VM(&in.Bastion, &out.Bastion, s); err != nil {
 		return err
 	}
@@ -622,6 +623,7 @@ func autoConvert_v1alpha2_AzureMachineSpec_To_v1alpha3_AzureMachineSpec(in *Azur
 func autoConvert_v1alpha3_AzureMachineSpec_To_v1alpha2_AzureMachineSpec(in *v1alpha3.AzureMachineSpec, out *AzureMachineSpec, s conversion.Scope) error {
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
 	out.VMSize = in.VMSize
+	// WARNING: in.FailureDomain requires manual conversion: does not exist in peer-type
 	if err := Convert_v1alpha3_AvailabilityZone_To_v1alpha2_AvailabilityZone(&in.AvailabilityZone, &out.AvailabilityZone, s); err != nil {
 		return err
 	}

--- a/api/v1alpha3/azurecluster_types.go
+++ b/api/v1alpha3/azurecluster_types.go
@@ -50,8 +50,12 @@ type AzureClusterSpec struct {
 type AzureClusterStatus struct {
 	Network Network `json:"network,omitempty"`
 
-	// FailureDomains specifies the list of unique failure domains for the location of the cluster.
-	// This list will be used by Cluster API to try and spread the machines across thsese domains.
+	// FailureDomains specifies the list of unique failure domains for the location/region of the cluster.
+	// A FailureDomain maps to Availability Zone with an Azure Region (if the region support them). An
+	// Availability Zone is a separate data center within a region and they can be used to ensure
+	// the cluster is more resilient to failure.
+	// See: https://docs.microsoft.com/en-us/azure/availability-zones/az-overview
+	// This list will be used by Cluster API to try and spread the machines across the failure domains.
 	FailureDomains clusterv1.FailureDomains `json:"failureDomains,omitempty"`
 
 	Bastion VM `json:"bastion,omitempty"`

--- a/api/v1alpha3/azurecluster_types.go
+++ b/api/v1alpha3/azurecluster_types.go
@@ -50,6 +50,10 @@ type AzureClusterSpec struct {
 type AzureClusterStatus struct {
 	Network Network `json:"network,omitempty"`
 
+	// FailureDomains specifies the list of unique failure domains for the location of the cluster.
+	// This list will be used by Cluster API to try and spread the machines across thsese domains.
+	FailureDomains clusterv1.FailureDomains `json:"failureDomains,omitempty"`
+
 	Bastion VM `json:"bastion,omitempty"`
 
 	// Ready is true when the provider resource is ready.

--- a/api/v1alpha3/azuremachine_types.go
+++ b/api/v1alpha3/azuremachine_types.go
@@ -34,7 +34,13 @@ type AzureMachineSpec struct {
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`
 
-	VMSize           string           `json:"vmSize"`
+	VMSize string `json:"vmSize"`
+
+	// FailureDomain is the failure domain unique identifier this Machine should be attached to,
+	// as defined in Cluster API. This relates to an Azure Availability Zone
+	FailureDomain *string `json:"failureDomain,omitempty"`
+
+	// DEPRECATED: use FailureDomain instead
 	AvailabilityZone AvailabilityZone `json:"availabilityZone,omitempty"`
 
 	// Image is used to provide details of an image to use during VM creation.

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha3
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
@@ -138,6 +139,13 @@ func (in *AzureClusterSpec) DeepCopy() *AzureClusterSpec {
 func (in *AzureClusterStatus) DeepCopyInto(out *AzureClusterStatus) {
 	*out = *in
 	in.Network.DeepCopyInto(&out.Network)
+	if in.FailureDomains != nil {
+		in, out := &in.FailureDomains, &out.FailureDomains
+		*out = make(apiv1alpha3.FailureDomains, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
+		}
+	}
 	in.Bastion.DeepCopyInto(&out.Bastion)
 }
 
@@ -232,6 +240,11 @@ func (in *AzureMachineSpec) DeepCopyInto(out *AzureMachineSpec) {
 	*out = *in
 	if in.ProviderID != nil {
 		in, out := &in.ProviderID, &out.ProviderID
+		*out = new(string)
+		**out = **in
+	}
+	if in.FailureDomain != nil {
+		in, out := &in.FailureDomain, &out.FailureDomain
 		*out = new(string)
 		**out = **in
 	}

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -183,3 +183,11 @@ func (s *ClusterScope) APIServerPort() int32 {
 	}
 	return 6443
 }
+
+// SetFailureDomain will set the spec for a for a given key
+func (s *ClusterScope) SetFailureDomain(id string, spec clusterv1.FailureDomainSpec) {
+	if s.AzureCluster.Status.FailureDomains == nil {
+		s.AzureCluster.Status.FailureDomains = make(clusterv1.FailureDomains, 0)
+	}
+	s.AzureCluster.Status.FailureDomains[id] = spec
+}

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -102,8 +102,23 @@ func (m *MachineScope) Location() string {
 }
 
 // AvailabilityZone returns the AzureMachine Availability Zone.
+// Priority for selecting the AZ is
+//   1) Machine.Spec.FailureDomain
+//   2) AzureMachine.Spec.FailureDomain
+//   3) AzureMachine.Spec.AvailabilityZone.ID (This is DEPRECATED)
+//   4) No AZ
 func (m *MachineScope) AvailabilityZone() string {
-	return *m.AzureMachine.Spec.AvailabilityZone.ID
+	if m.Machine.Spec.FailureDomain != nil {
+		return *m.Machine.Spec.FailureDomain
+	}
+	if m.AzureMachine.Spec.FailureDomain != nil {
+		return *m.AzureMachine.Spec.FailureDomain
+	}
+	if m.AzureMachine.Spec.AvailabilityZone.ID != nil {
+		return *m.AzureMachine.Spec.AvailabilityZone.ID
+	}
+
+	return ""
 }
 
 // Name returns the AzureMachine name.

--- a/cloud/services/availabilityzones/availabilityzones.go
+++ b/cloud/services/availabilityzones/availabilityzones.go
@@ -18,6 +18,7 @@ package availabilityzones
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -27,7 +28,7 @@ import (
 
 // Spec input specification for Get/CreateOrUpdate/Delete calls
 type Spec struct {
-	VMSize string
+	VMSize *string
 }
 
 // Get provides information about a availability zones.
@@ -37,26 +38,39 @@ func (s *Service) Get(ctx context.Context, spec interface{}) (interface{}, error
 	if !ok {
 		return zones, errors.New("invalid availability zones specification")
 	}
+
+	filter := fmt.Sprintf("location eq '%s'", s.Scope.Location())
+
 	// Prefer ListComplete() over List() to automatically traverse pages via iterator.
-	res, err := s.Client.ListComplete(ctx, "")
+	res, err := s.Client.ListComplete(ctx, filter)
 	if err != nil {
 		return zones, err
 	}
 
+	if skusSpec.VMSize != nil {
+		return s.filterForVMSizeInLocation(ctx, skusSpec.VMSize, &res)
+	}
+
+	return s.filterUniqueForLocation(ctx, &res)
+}
+
+func (s *Service) filterForVMSizeInLocation(ctx context.Context, vmSize *string, res *compute.ResourceSkusResultIterator) ([]string, error) {
+	var zones []string
+
 	for res.NotDone() {
 		resSku := res.Value()
-		if strings.EqualFold(*resSku.Name, skusSpec.VMSize) {
+		if strings.EqualFold(*resSku.Name, *vmSize) {
 			// Use map for easy deletion and iteration
 			availableZones := make(map[string]bool)
 			for _, locationInfo := range *resSku.LocationInfo {
 				for _, zone := range *locationInfo.Zones {
 					availableZones[zone] = true
 				}
-				if strings.EqualFold(*locationInfo.Location, s.Scope.Location()) {
+				if strings.EqualFold(*locationInfo.Location, s.Scope.Location()) { //NOTE: this should always be true due to the filter
 					for _, restriction := range *resSku.Restrictions {
 						// Can't deploy anything in this subscription in this location. Bail out.
 						if restriction.Type == compute.Location {
-							return []string{}, errors.Errorf("rejecting sku: %s in location: %s due to susbcription restriction", skusSpec.VMSize, s.Scope.Location())
+							return []string{}, errors.Errorf("rejecting sku: %s in location: %s due to susbcription restriction", *vmSize, s.Scope.Location())
 						}
 						// May be able to deploy one or more zones to this location.
 						for _, restrictedZone := range *restriction.RestrictionInfo.Zones {
@@ -74,12 +88,41 @@ func (s *Service) Get(ctx context.Context, spec interface{}) (interface{}, error
 				}
 			}
 		}
-		err = res.NextWithContext(ctx)
+		err := res.NextWithContext(ctx)
 		if err != nil {
 			return zones, errors.Wrap(err, "could not iterate availability zones")
 		}
 	}
 
+	return zones, nil
+}
+
+func (s *Service) filterUniqueForLocation(ctx context.Context, res *compute.ResourceSkusResultIterator) ([]string, error) {
+	zones := make([]string, 0)
+
+	for res.NotDone() {
+		resSku := res.Value()
+		// Use map for easy deletion and iteration
+		availableZones := make(map[string]bool)
+		for _, locationInfo := range *resSku.LocationInfo {
+			for _, zone := range *locationInfo.Zones {
+				availableZones[zone] = true
+			}
+
+			for availableZone := range availableZones {
+				if !contains(zones, availableZone) {
+					zones = append(zones, availableZone)
+				}
+			}
+		}
+		err := res.NextWithContext(ctx)
+		if err != nil {
+			return zones, errors.Wrap(err, "could not iterate availability zones")
+		}
+	}
+
+	// Lexical sort so comparisons work in tests
+	sort.Strings(zones)
 	return zones, nil
 }
 
@@ -93,4 +136,13 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	// Not implemented since there is nothing to delete
 	return nil
+}
+
+func contains(strSlice []string, val string) bool {
+	for _, c := range strSlice {
+		if c == val {
+			return true
+		}
+	}
+	return false
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -755,9 +755,14 @@ spec:
                         is suitable for use by control plane machines.
                       type: boolean
                   type: object
-                description: FailureDomains specifies the list of unique failure domains
-                  for the location of the cluster. This list will be used by Cluster
-                  API to try and spread the machines across thsese domains.
+                description: 'FailureDomains specifies the list of unique failure
+                  domains for the location/region of the cluster. A FailureDomain
+                  maps to Availability Zone with an Azure Region (if the region support
+                  them). An Availability Zone is a separate data center within a region
+                  and they can be used to ensure the cluster is more resilient to
+                  failure. See: https://docs.microsoft.com/en-us/azure/availability-zones/az-overview
+                  This list will be used by Cluster API to try and spread the machines
+                  across the failure domains.'
                 type: object
               network:
                 description: Network encapsulates Azure networking resources.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -738,6 +738,27 @@ spec:
                       in the response.
                     type: string
                 type: object
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains specifies the list of unique failure domains
+                  for the location of the cluster. This list will be used by Cluster
+                  API to try and spread the machines across thsese domains.
+                type: object
               network:
                 description: Network encapsulates Azure networking resources.
                 properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -247,12 +247,18 @@ spec:
                   public ips for machines where this value is true.
                 type: boolean
               availabilityZone:
+                description: 'DEPRECATED: use FailureDomain instead'
                 properties:
                   enabled:
                     type: boolean
                   id:
                     type: string
                 type: object
+              failureDomain:
+                description: FailureDomain is the failure domain unique identifier
+                  this Machine should be attached to, as defined in Cluster API. This
+                  relates to an Azure Availability Zone
+                type: string
               identity:
                 default: None
                 description: Identity is the type of identity used for the virtual

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -184,12 +184,18 @@ spec:
                           dynamic public ips for machines where this value is true.
                         type: boolean
                       availabilityZone:
+                        description: 'DEPRECATED: use FailureDomain instead'
                         properties:
                           enabled:
                             type: boolean
                           id:
                             type: string
                         type: object
+                      failureDomain:
+                        description: FailureDomain is the failure domain unique identifier
+                          this Machine should be attached to, as defined in Cluster
+                          API. This relates to an Azure Availability Zone
+                        type: string
                       identity:
                         default: None
                         description: Identity is the type of identity used for the

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -209,6 +209,18 @@ func (r *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineSco
 		}
 	}
 
+	if machineScope.AzureMachine.Spec.AvailabilityZone.ID != nil {
+		message := "AvailavilityZone is deprecated, use FailureDomain instead"
+		machineScope.Info(message)
+		r.Recorder.Eventf(machineScope.AzureCluster, corev1.EventTypeWarning, "DeprecatedField", message)
+
+		// Set FailureDomain if its not set
+		if machineScope.AzureMachine.Spec.FailureDomain == nil {
+			machineScope.V(2).Info("Failure domain not set, setting with value from AvailabilityZone.ID")
+			machineScope.AzureMachine.Spec.FailureDomain = machineScope.AzureMachine.Spec.AvailabilityZone.ID
+		}
+	}
+
 	ams := newAzureMachineService(machineScope, clusterScope)
 
 	// Get or create the virtual machine.

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -165,7 +165,7 @@ func (s *azureMachineService) getVirtualMachineZone() (string, error) {
 	location := s.machineScope.AzureMachine.Spec.Location
 
 	zonesSpec := &availabilityzones.Spec{
-		VMSize: vmSize,
+		VMSize: to.StringPtr(vmSize),
 	}
 	zonesInterface, err := s.availabilityZonesSvc.Get(s.clusterScope.Context, zonesSpec)
 	if err != nil {
@@ -184,9 +184,11 @@ func (s *azureMachineService) getVirtualMachineZone() (string, error) {
 		return "", nil
 	}
 
-	var zone string
+	zone := s.machineScope.AvailabilityZone()
 	var selectedZone string
-	if s.machineScope.AzureMachine.Spec.AvailabilityZone.ID != nil {
+
+	// DEPRECATED: to support old clients
+	if zone == "" && s.machineScope.AzureMachine.Spec.AvailabilityZone.ID != nil {
 		zone = *s.machineScope.AzureMachine.Spec.AvailabilityZone.ID
 	}
 

--- a/docs/topics/failure-domains.md
+++ b/docs/topics/failure-domains.md
@@ -1,0 +1,54 @@
+# Failure Domains
+
+The Azure provider includes the support for [failure domains](https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#optional-support-failure-domains) introduced as part of v1alpha3.
+
+## Failure domains in Azure
+
+A failure domain in the Azure provider maps to an **availability zone** within an Azure region. In Azure an availability zone is a separate data center within a region that offers redundancy and separation from the other availability zones within a region.
+
+To ensure a cluster (or any application) is resilient to failure its best to spread instances across all the availability zones within a region. If a zone is lost your cluster will continue to run as the other 2 zones are physically separated and can continue to run.
+
+Full details of availability zones, regions can be found in the [Azure docs](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).
+
+## How to use failure domains
+
+### Default Behaviour
+
+The default behaviour of Cluster API is to try and spread machines out across all the failure domains. The controller for the `AzureCluster` queries the Resource Manager API for the availability zones for the **Location** of the cluster. The availability zones are reported back to Cluster API via the **FailureDomains** field in the status of `AzureCluster`.
+
+The Cluster API controller will look for the **FailureDomains** status field and will set the **FailureDomain** field in a `Machine` if a value hasn't already been explicitly set. It will try to ensure that the machines are spread across all the failure domains.
+
+The `AzureMachine` controller looks for a failure domain (i.e. availability zone) to use from the `Machine` first before failure back to the `AzureMachine`. This failure domain is then used when provisioning the virtual machine.
+
+### Explicit Placement
+
+If you would rather control the placement of virtual machines into a failure domain (i.e. availability zones) then you can explicitly state the failure domain. The best way is to specify this using the **FailureDomain** field within the `Machine` (or `MachineDeployment`) spec.
+
+> **DEPRECATION NOTE**: Failure domains where introduced in v1alpha3. Prior to this you might have used the **AvailabilityZone** on the `AzureMachine` and this is now deprecated. Please update your definitions and use **FailureDomain** instead.
+
+For example:
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Machine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: my-cluster
+    cluster.x-k8s.io/control-plane: "true"
+  name: controlplane-0
+  namespace: default
+spec:
+  version: "v1.15.2"
+  clusterName: my-cluster
+  failureDomain: "1"
+  bootstrap:
+    configRef:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+        kind: KubeadmConfigTemplate
+        name: my-cluster-md-0
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: AzureMachineTemplate
+    name: my-cluster-md-0
+
+```


### PR DESCRIPTION

**What this PR does / why we need it**:

Started to add failure domain support.

**Which issue(s) this PR fixes**:
Relates To #439 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for failure domains has been introduced. The list of availability zones for a region will be stored in the status of the AzureCluster and Cluster API will use these to try and spread Machine's across availaibility zones. AvailabilityZone on AzureMachine is deprecated and FailureDomain should be used instead.
```