### PR TITLE
Small fixes in Makefile and kind script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST)
 	@echo 'Set kubectl context to the kind management cluster by running "kubectl config set-context kind-capz"'
 
 .PHONY: create-workload-cluster
-create-workload-cluster: $(KUSTOMIZE) $(ENVSUBST)
+create-workload-cluster: $(ENVSUBST)
 	# Create workload Cluster.
 	$(ENVSUBST) < $(TEMPLATES_DIR)/$(CLUSTER_TEMPLATE) | kubectl apply -f -
 

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 set -o errexit
+set -o nounset
+set -o pipefail
 
 # desired cluster name; default is "kind"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-capz}"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove unused kustomize dependency from create-workload-cluster target
- set nounset and pipefail in kind script to be consistent with other scripts

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```