### PR TITLE
Add workaround to find kubectl binary on MacOS

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -55,14 +55,16 @@ build_k8s() {
     # ensure the e2e script will find our binaries ...
     mkdir -p "${PWD}/_output/bin/"
     cp -f "${PWD}/bazel-bin/test/e2e/e2e.test" "${PWD}/_output/bin/e2e.test"
-    # workaround for mac os
-    cp -f "${PWD}/bazel-bin/vendor/github.com/onsi/ginkgo/ginkgo/darwin_amd64_stripped/ginkgo" "${PWD}/_output/bin/ginkgo" || true
+    # workarounds for mac os
+    cp -f "${PWD}/bazel-bin/vendor/github.com/onsi/ginkgo/ginkgo/darwin_amd64_stripped/ginkgo" "${PWD}/_output/bin/ginkgo" 2>/dev/null || true
+    cp -f "${PWD}/bazel-bin/cmd/kubectl/darwin_amd64_pure_stripped/kubectl" "${PWD}/_output/bin/kubectl" 2>/dev/null || true
+    
     PATH="$(dirname "$(find "${PWD}/bazel-bin/" -name kubectl -type f)"):${PATH}"
     export PATH
 
     # attempt to release some memory after building
     sync || true
-    echo 1 > /proc/sys/vm/drop_caches || true
+    (echo 1 > /proc/sys/vm/drop_caches) 2>/dev/null || true
 
     popd
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Currently, k8s conformance tests are unable to find bazel-bin binaries when running /hack/ginkgo-e2e.sh from MacOS (or in general a platform that uses a BSD version of find which doesn't recognize -executable).

I opened https://github.com/kubernetes/kubernetes/pull/90617 to fix the root issue, adding these workarounds in the meantime. Opened https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/582 to track removing these.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #582 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```