### PR TITLE
Fix 'gen-flavors.sh' to work on Ubuntu 18.04.2

### DIFF
--- a/hack/gen-flavors.sh
+++ b/hack/gen-flavors.sh
@@ -25,9 +25,9 @@ flavors_dir="${root}/templates/flavors/"
 test_dir="${root}/templates/test/"
 
 rm "${root}/templates/cluster-template"*
-find "${flavors_dir}"* -maxdepth 0 -type d -maxdepth 0 -print0 | xargs -0 -I {} basename {} | grep -v base | xargs -I {} sh -c "${kustomize} build ${flavors_dir}{} > ${root}/templates/cluster-template-{}.yaml"
+find "${flavors_dir}"* -maxdepth 0 -type d -print0 | xargs -0 -I {} basename {} | grep -v base | xargs -I {} sh -c "${kustomize} build ${flavors_dir}{} > ${root}/templates/cluster-template-{}.yaml"
 # move the default template to the default file expected by clusterctl
 mv "${root}/templates/cluster-template-default.yaml" "${root}/templates/cluster-template.yaml"
 
 rm -f "${test_dir}cluster-template"*
-find "${test_dir}"* -maxdepth 0 -type d -maxdepth 0 -print0 | xargs -0 -I {} basename {} | xargs -I {} sh -c "${kustomize} build ${test_dir}{} > ${test_dir}cluster-template-{}.yaml"
+find "${test_dir}"* -maxdepth 0 -type d -print0 | xargs -0 -I {} basename {} | xargs -I {} sh -c "${kustomize} build ${test_dir}{} > ${test_dir}cluster-template-{}.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `./hack/gen-flavors.sh` doesn't work on Ubuntu 18.04.2 due to the duplicated option `-maxdepth 0` in the `find` command. This removes the second occurrence of it so that it works.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```