### PR TITLE
Update NSG only if default rules are not present, or else skip the update

### DIFF
--- a/cloud/services/securitygroups/securitygroups_test.go
+++ b/cloud/services/securitygroups/securitygroups_test.go
@@ -48,30 +48,32 @@ func TestReconcileSecurityGroups(t *testing.T) {
 		sgName         string
 		isControlPlane bool
 		vnetSpec       *infrav1.VnetSpec
-		expect         func(m *mock_securitygroups.MockClientMockRecorder)
+		expect         func(m *mock_securitygroups.MockClientMockRecorder, m1 *mock_securitygroups.MockClientMockRecorder)
 	}{
 		{
 			name:           "security group does not exists",
 			sgName:         "my-sg",
 			isControlPlane: true,
 			vnetSpec:       &infrav1.VnetSpec{},
-			expect: func(m *mock_securitygroups.MockClientMockRecorder) {
-				m.CreateOrUpdate(context.TODO(), "my-rg", "my-sg", gomock.AssignableToTypeOf(network.SecurityGroup{}))
+			expect: func(m *mock_securitygroups.MockClientMockRecorder, m1 *mock_securitygroups.MockClientMockRecorder) {
+				m.Get(context.TODO(), "my-rg", "my-sg")
+				m1.CreateOrUpdate(context.TODO(), "my-rg", "my-sg", gomock.AssignableToTypeOf(network.SecurityGroup{}))
 			},
 		}, {
 			name:           "security group does not exist and it's not for a control plane",
 			sgName:         "my-sg",
 			isControlPlane: false,
 			vnetSpec:       &infrav1.VnetSpec{},
-			expect: func(m *mock_securitygroups.MockClientMockRecorder) {
-				m.CreateOrUpdate(context.TODO(), "my-rg", "my-sg", gomock.AssignableToTypeOf(network.SecurityGroup{}))
+			expect: func(m *mock_securitygroups.MockClientMockRecorder, m1 *mock_securitygroups.MockClientMockRecorder) {
+				m.Get(context.TODO(), "my-rg", "my-sg")
+				m1.CreateOrUpdate(context.TODO(), "my-rg", "my-sg", gomock.AssignableToTypeOf(network.SecurityGroup{}))
 			},
 		}, {
 			name:           "skipping network security group reconcile in custom vnet mode",
 			sgName:         "my-sg",
 			isControlPlane: false,
 			vnetSpec:       &infrav1.VnetSpec{ResourceGroup: "custom-vnet-rg", Name: "custom-vnet", ID: "id1"},
-			expect: func(m *mock_securitygroups.MockClientMockRecorder) {
+			expect: func(m *mock_securitygroups.MockClientMockRecorder, m1 *mock_securitygroups.MockClientMockRecorder) {
 
 			},
 		},
@@ -87,7 +89,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 
 			client := fake.NewFakeClient(cluster)
 
-			tc.expect(sgMock.EXPECT())
+			tc.expect(sgMock.EXPECT(), sgMock.EXPECT())
 
 			clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 				AzureClients: scope.AzureClients{


### PR DESCRIPTION
**What this PR does / why we need it**:
The security groups: controlplane-nsg and node-nsg are updated during reconcilation without checking for rules thus resetting the rules added by any other source(like rules added by kube-controller-manager for LoadBalancer service).

Resolution:
Skip NSG updates if default rules are present
The flow will be:
    - Create NSG if does not exist
    - control-plane-nsg: update only if default rules are not present else skip update
    - node-nsg: skip update as no default rules are present for node-nsg
    - Updates will occur with ETAGS set in the header

**Which issue(s) this PR fixes** :
Fixes #578 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
During reconcile, updates to control-plane-nsg will take place only if default rules(ssh-rule and api-server rule) is not present. The update will be skipped otherwise. 
For node-nsg, as node-nsg does not have default rules, updates will be skipped
```