### PR TITLE
Remove conformance script MacOS workaround

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -55,9 +55,6 @@ build_k8s() {
     # ensure the e2e script will find our binaries ...
     mkdir -p "${PWD}/_output/bin/"
     cp -f "${PWD}/bazel-bin/test/e2e/e2e.test" "${PWD}/_output/bin/e2e.test"
-    # workarounds for mac os
-    cp -f "${PWD}/bazel-bin/vendor/github.com/onsi/ginkgo/ginkgo/darwin_amd64_stripped/ginkgo" "${PWD}/_output/bin/ginkgo" 2>/dev/null || true
-    cp -f "${PWD}/bazel-bin/cmd/kubectl/darwin_amd64_pure_stripped/kubectl" "${PWD}/_output/bin/kubectl" 2>/dev/null || true
     
     PATH="$(dirname "$(find "${PWD}/bazel-bin/" -name kubectl -type f)"):${PATH}"
     export PATH


### PR DESCRIPTION
**What this PR does / why we need it**: Removing the workaround for running conformance locally on MacOS since https://github.com/kubernetes/kubernetes/pull/90617 merged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #582 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```