### PR TITLE
validate azure cluster vnet when people bring their own

### DIFF
--- a/api/v1alpha3/azurecluster_validation.go
+++ b/api/v1alpha3/azurecluster_validation.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"regexp"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+const (
+	// obtained from https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/createorupdate#uri-parameters
+	resourceGroupRegex = `^[-\w\._\(\)]+$`
+	// described in https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+	subnetRegex = `^[-\w\._]+$`
+	ipv4Regex   = `^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`
+)
+
+// validateCluster validates a cluster
+func (c *AzureCluster) validateCluster() error {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, c.validateClusterSpec()...)
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "infrastructure.cluster.x-k8s.io", Kind: "AzureCluster"},
+		c.Name, allErrs)
+}
+
+// validateClusterSpec validates a ClusterSpec
+func (c *AzureCluster) validateClusterSpec() field.ErrorList {
+	return validateNetworkSpec(
+		c.Spec.NetworkSpec,
+		field.NewPath("spec").Child("networkSpec"))
+}
+
+// validateNetworkSpec validates a NetworkSpec
+func validateNetworkSpec(networkSpec NetworkSpec, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	// If the user specifies a resourceGroup for vnet, it means
+	// that she intends to use a pre-existing vnet. In this case,
+	// we need to verify the information she provides
+	if networkSpec.Vnet.ResourceGroup != "" {
+		if err := validateResourceGroup(networkSpec.Vnet.ResourceGroup,
+			fldPath.Child("vnet").Child("resourceGroup")); err != nil {
+			allErrs = append(allErrs, err)
+		}
+		allErrs = append(allErrs, validateSubnets(networkSpec.Subnets, fldPath.Child("subnets"))...)
+	}
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return allErrs
+}
+
+// validateResourceGroup validates a ResourceGroup
+func validateResourceGroup(resourceGroup string, fldPath *field.Path) *field.Error {
+	if success, _ := regexp.Match(resourceGroupRegex, []byte(resourceGroup)); !success {
+		return field.Invalid(fldPath, resourceGroup,
+			fmt.Sprintf("resourceGroup doesn't match regex %s", resourceGroupRegex))
+	}
+	return nil
+}
+
+// validateSubnets validates a list of Subnets
+func validateSubnets(subnets Subnets, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	requiredSubnetRoles := map[string]bool{
+		"control-plane": false,
+		"node":          false,
+	}
+	for i, subnet := range subnets {
+		if err := validateSubnetName(subnet.Name, fldPath.Index(i).Child("name")); err != nil {
+			allErrs = append(allErrs, err)
+		}
+		if subnet.InternalLBIPAddress != "" {
+			if err := validateInternalLBIPAddress(subnet.InternalLBIPAddress,
+				fldPath.Index(i).Child("internalLBIPAddress")); err != nil {
+				allErrs = append(allErrs, err)
+			}
+		}
+		for role := range requiredSubnetRoles {
+			if role == string(subnet.Role) {
+				requiredSubnetRoles[role] = true
+			}
+		}
+	}
+	for k, v := range requiredSubnetRoles {
+		if v == false {
+			allErrs = append(allErrs, field.Required(fldPath,
+				fmt.Sprintf("required role %s not included in provided subnets", k)))
+		}
+	}
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return allErrs
+}
+
+// validateSubnetName validates the Name of a Subnet
+func validateSubnetName(name string, fldPath *field.Path) *field.Error {
+	if success, _ := regexp.Match(subnetRegex, []byte(name)); !success {
+		return field.Invalid(fldPath, name,
+			fmt.Sprintf("name of subnet doesn't match regex %s", subnetRegex))
+	}
+	return nil
+}
+
+// validateInternalLBIPAddress validates a InternalLBIPAddress
+func validateInternalLBIPAddress(address string, fldPath *field.Path) *field.Error {
+	if success, _ := regexp.Match(ipv4Regex, []byte(address)); !success {
+		return field.Invalid(fldPath, address,
+			fmt.Sprintf("internalLBIPAddress doesn't match regex %s", ipv4Regex))
+	}
+	return nil
+}

--- a/api/v1alpha3/azurecluster_validation_test.go
+++ b/api/v1alpha3/azurecluster_validation_test.go
@@ -1,0 +1,492 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestClusterWithPreexistingVnetValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		cluster *AzureCluster
+	}
+
+	testCase := test{
+		name:    "azurecluster with pre-existing vnet - valid",
+		cluster: createValidCluster(),
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		err := testCase.cluster.validateCluster()
+		g.Expect(err).To(BeNil())
+	})
+}
+
+func TestClusterWithPreexistingVnetInvalid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		cluster *AzureCluster
+	}
+
+	testCase := test{
+		name:    "azurecluster with pre-existing vnet - invalid",
+		cluster: createValidCluster(),
+	}
+
+	// invalid because it doesn't specify a controlplane subnet
+	testCase.cluster.Spec.NetworkSpec.Subnets[0] = &SubnetSpec{
+		Name: "random-subnet",
+		Role: "random",
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		err := testCase.cluster.validateCluster()
+		g.Expect(err).ToNot(BeNil())
+	})
+}
+
+func TestClusterWithoutPreexistingVnetValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		cluster *AzureCluster
+	}
+
+	testCase := test{
+		name:    "azurecluster without pre-existing vnet - valid",
+		cluster: createValidCluster(),
+	}
+
+	// When ResourceGroup is an empty string, the cluster doesn't
+	// have a pre-existing vnet.
+	testCase.cluster.Spec.NetworkSpec.Vnet.ResourceGroup = ""
+
+	t.Run(testCase.name, func(t *testing.T) {
+		err := testCase.cluster.validateCluster()
+		g.Expect(err).To(BeNil())
+	})
+}
+
+func TestClusterSpecWithPreexistingVnetValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		cluster *AzureCluster
+	}
+
+	testCase := test{
+		name:    "azurecluster spec with pre-existing vnet - valid",
+		cluster: createValidCluster(),
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := testCase.cluster.validateClusterSpec()
+		g.Expect(errs).To(BeNil())
+	})
+}
+
+func TestClusterSpecWithPreexistingVnetInvalid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		cluster *AzureCluster
+	}
+
+	testCase := test{
+		name:    "azurecluster spec with pre-existing vnet - invalid",
+		cluster: createValidCluster(),
+	}
+
+	// invalid because it doesn't specify a controlplane subnet
+	testCase.cluster.Spec.NetworkSpec.Subnets[0] = &SubnetSpec{
+		Name: "random-subnet",
+		Role: "random",
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := testCase.cluster.validateClusterSpec()
+		g.Expect(len(errs)).To(BeNumerically(">", 0))
+	})
+}
+
+func TestClusterSpecWithoutPreexistingVnetValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		cluster *AzureCluster
+	}
+
+	testCase := test{
+		name:    "azurecluster spec without pre-existing vnet - valid",
+		cluster: createValidCluster(),
+	}
+
+	// When ResourceGroup is an empty string, the cluster doesn't
+	// have a pre-existing vnet.
+	testCase.cluster.Spec.NetworkSpec.Vnet.ResourceGroup = ""
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := testCase.cluster.validateClusterSpec()
+		g.Expect(errs).To(BeNil())
+	})
+}
+
+func TestNetworkSpecWithPreexistingVnetValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name        string
+		networkSpec NetworkSpec
+	}
+
+	testCase := test{
+		name:        "azurecluster networkspec with pre-existing vnet - valid",
+		networkSpec: createValidNetworkSpec(),
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := validateNetworkSpec(testCase.networkSpec, field.NewPath("spec").Child("networkSpec"))
+		g.Expect(errs).To(BeNil())
+	})
+}
+
+func TestNetworkSpecWithPreexistingVnetLackRequiredSubnets(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name        string
+		networkSpec NetworkSpec
+	}
+
+	testCase := test{
+		name:        "azurecluster networkspec with pre-existing vnet - lack required subnets",
+		networkSpec: createValidNetworkSpec(),
+	}
+
+	// invalid because it doesn't specify a node subnet
+	testCase.networkSpec.Subnets = testCase.networkSpec.Subnets[:1]
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := validateNetworkSpec(testCase.networkSpec, field.NewPath("spec").Child("networkSpec"))
+		g.Expect(errs).To(HaveLen(1))
+		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+		g.Expect(errs[0].Field).To(Equal("spec.networkSpec.subnets"))
+		g.Expect(errs[0].Error()).To(ContainSubstring("required role node not included"))
+	})
+}
+
+func TestNetworkSpecWithPreexistingVnetInvalidResourceGroup(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name        string
+		networkSpec NetworkSpec
+	}
+
+	testCase := test{
+		name:        "azurecluster networkspec with pre-existing vnet - invalid resource group",
+		networkSpec: createValidNetworkSpec(),
+	}
+
+	testCase.networkSpec.Vnet.ResourceGroup = "invalid-name###"
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := validateNetworkSpec(testCase.networkSpec, field.NewPath("spec").Child("networkSpec"))
+		g.Expect(errs).To(HaveLen(1))
+		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
+		g.Expect(errs[0].Field).To(Equal("spec.networkSpec.vnet.resourceGroup"))
+		g.Expect(errs[0].BadValue).To(BeEquivalentTo(testCase.networkSpec.Vnet.ResourceGroup))
+	})
+}
+
+func TestNetworkSpecWithoutPreexistingVnetValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name        string
+		networkSpec NetworkSpec
+	}
+
+	testCase := test{
+		name:        "azurecluster networkspec without pre-existing vnet - valid",
+		networkSpec: createValidNetworkSpec(),
+	}
+
+	testCase.networkSpec.Vnet.ResourceGroup = ""
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := validateNetworkSpec(testCase.networkSpec, field.NewPath("spec").Child("networkSpec"))
+		g.Expect(errs).To(BeNil())
+	})
+}
+
+func TestResourceGroupValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name          string
+		resourceGroup string
+	}
+
+	testCase := test{
+		name:          "resourcegroup name - valid",
+		resourceGroup: "custom-vnet",
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		err := validateResourceGroup(testCase.resourceGroup,
+			field.NewPath("spec").Child("networkSpec").Child("vnet").Child("resourceGroup"))
+		g.Expect(err).To(BeNil())
+	})
+}
+
+func TestResourceGroupInvalid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name          string
+		resourceGroup string
+	}
+
+	testCase := test{
+		name:          "resourcegroup name - invalid",
+		resourceGroup: "inv@lid-rg",
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		err := validateResourceGroup(testCase.resourceGroup,
+			field.NewPath("spec").Child("networkSpec").Child("vnet").Child("resourceGroup"))
+		g.Expect(err).NotTo(BeNil())
+		g.Expect(err.Type).To(Equal(field.ErrorTypeInvalid))
+		g.Expect(err.Field).To(Equal("spec.networkSpec.vnet.resourceGroup"))
+		g.Expect(err.BadValue).To(BeEquivalentTo(testCase.resourceGroup))
+	})
+}
+
+func TestSubnetsValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		subnets Subnets
+	}
+
+	testCase := test{
+		name:    "subnets - valid",
+		subnets: createValidSubnets(),
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := validateSubnets(testCase.subnets,
+			field.NewPath("spec").Child("networkSpec").Child("subnets"))
+		g.Expect(errs).To(BeNil())
+	})
+}
+
+func TestSubnetsInvalidSubnetName(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		subnets Subnets
+	}
+
+	testCase := test{
+		name:    "subnets - invalid subnet name",
+		subnets: createValidSubnets(),
+	}
+
+	testCase.subnets[0].Name = "invalid-subnet-name-due-to-bracket)"
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := validateSubnets(testCase.subnets,
+			field.NewPath("spec").Child("networkSpec").Child("subnets"))
+		g.Expect(errs).To(HaveLen(1))
+		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
+		g.Expect(errs[0].Field).To(Equal("spec.networkSpec.subnets[0].name"))
+		g.Expect(errs[0].BadValue).To(BeEquivalentTo("invalid-subnet-name-due-to-bracket)"))
+	})
+}
+
+func TestSubnetsInvalidInternalLBIPAddress(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		subnets Subnets
+	}
+
+	testCase := test{
+		name:    "subnets - invalid internal load balancer ip address",
+		subnets: createValidSubnets(),
+	}
+
+	testCase.subnets[0].InternalLBIPAddress = "2550.1.1.1"
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := validateSubnets(testCase.subnets,
+			field.NewPath("spec").Child("networkSpec").Child("subnets"))
+		g.Expect(errs).To(HaveLen(1))
+		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
+		g.Expect(errs[0].Field).To(Equal("spec.networkSpec.subnets[0].internalLBIPAddress"))
+		g.Expect(errs[0].BadValue).To(BeEquivalentTo("2550.1.1.1"))
+	})
+}
+
+func TestSubnetsInvalidLackRequiredSubnet(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name    string
+		subnets Subnets
+	}
+
+	testCase := test{
+		name:    "subnets - lack required subnet",
+		subnets: createValidSubnets(),
+	}
+
+	testCase.subnets[0].Role = "random-role"
+
+	t.Run(testCase.name, func(t *testing.T) {
+		errs := validateSubnets(testCase.subnets,
+			field.NewPath("spec").Child("networkSpec").Child("subnets"))
+		g.Expect(errs).To(HaveLen(1))
+		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
+		g.Expect(errs[0].Field).To(Equal("spec.networkSpec.subnets"))
+		g.Expect(errs[0].Detail).To(ContainSubstring("required role control-plane not included"))
+	})
+}
+
+func TestSubnetNameValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name       string
+		subnetName string
+	}
+
+	testCase := test{
+		name:       "subnet name - valid",
+		subnetName: "control-plane-subnet",
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		err := validateSubnetName(testCase.subnetName,
+			field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("name"))
+		g.Expect(err).To(BeNil())
+	})
+}
+
+func TestSubnetNameInvalid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name       string
+		subnetName string
+	}
+
+	testCase := test{
+		name:       "subnet name - invalid",
+		subnetName: "inv@lid-subnet-name",
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		err := validateSubnetName(testCase.subnetName,
+			field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("name"))
+		g.Expect(err).NotTo(BeNil())
+		g.Expect(err.Type).To(Equal(field.ErrorTypeInvalid))
+		g.Expect(err.Field).To(Equal("spec.networkSpec.subnets[0].name"))
+		g.Expect(err.BadValue).To(BeEquivalentTo(testCase.subnetName))
+	})
+}
+
+func TestInternalLBIPAddressValid(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		name                string
+		internalLBIPAddress string
+	}
+
+	testCase := test{
+		name:                "subnet name - invalid",
+		internalLBIPAddress: "1.1.1.1",
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		err := validateInternalLBIPAddress(testCase.internalLBIPAddress,
+			field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("internalLBIPAddress"))
+		g.Expect(err).To(BeNil())
+	})
+}
+
+func TestInternalLBIPAddressInvalid(t *testing.T) {
+	g := NewWithT(t)
+
+	internalLBIPAddress := "1.1.1"
+
+	err := validateInternalLBIPAddress(internalLBIPAddress,
+		field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("internalLBIPAddress"))
+	g.Expect(err).NotTo(BeNil())
+	g.Expect(err.Type).To(Equal(field.ErrorTypeInvalid))
+	g.Expect(err.Field).To(Equal("spec.networkSpec.subnets[0].internalLBIPAddress"))
+	g.Expect(err.BadValue).To(BeEquivalentTo(internalLBIPAddress))
+}
+
+func createValidCluster() *AzureCluster {
+	return &AzureCluster{
+		Spec: AzureClusterSpec{
+			NetworkSpec: createValidNetworkSpec(),
+		},
+	}
+}
+
+func createValidNetworkSpec() NetworkSpec {
+	return NetworkSpec{
+		Vnet: VnetSpec{
+			ResourceGroup: "custom-vnet",
+			Name:          "my-vnet",
+		},
+		Subnets: createValidSubnets(),
+	}
+}
+
+func createValidSubnets() Subnets {
+	return Subnets{
+		{
+			Name: "control-plane-subnet",
+			Role: "control-plane",
+		},
+		{
+			Name: "node-subnet",
+			Role: "node",
+		},
+	}
+}

--- a/api/v1alpha3/azurecluster_webhook.go
+++ b/api/v1alpha3/azurecluster_webhook.go
@@ -17,15 +17,42 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 // log is for logging in this package.
-var _ = logf.Log.WithName("azurecluster-resource")
+var clusterlog = logf.Log.WithName("azurecluster-resource")
 
-func (r *AzureCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (c *AzureCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(c).
 		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update;delete,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha3-azurecluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=azurecluster,versions=v1alpha3,name=validation.azurecluster.infrastructure.cluster.x-k8s.io
+
+var _ webhook.Validator = &AzureCluster{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (c *AzureCluster) ValidateCreate() error {
+	clusterlog.Info("validate create", "name", c.Name)
+
+	return c.validateCluster()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (c *AzureCluster) ValidateUpdate(old runtime.Object) error {
+	clusterlog.Info("validate update", "name", c.Name)
+
+	return c.validateCluster()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (c *AzureCluster) ValidateDelete() error {
+	clusterlog.Info("validate delete", "name", c.Name)
+
+	return nil
 }

--- a/api/v1alpha3/azurecluster_webhook_test.go
+++ b/api/v1alpha3/azurecluster_webhook_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAzureCluster_ValidateCreate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name    string
+		cluster *AzureCluster
+		wantErr bool
+	}{
+		{
+			name: "azurecluster with pre-existing vnet - valid spec",
+			cluster: func() *AzureCluster {
+				return createValidCluster()
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "azurecluster without pre-existing vnet - valid spec",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Vnet.ResourceGroup = ""
+				return cluster
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - lack control plane subnet",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[1:]
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - lack node subnet",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[:1]
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - invalid resourcegroup name",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Vnet.ResourceGroup = "invalid-rg-name###"
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - invalid subnet name",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets = append(cluster.Spec.NetworkSpec.Subnets,
+					&SubnetSpec{Name: "invalid-subnet-name###", Role: "random-role"})
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - invalid internal load balancer ip address",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets[0].InternalLBIPAddress = "1000.1.1.1"
+				return cluster
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cluster.ValidateCreate()
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestAzureCluster_ValidateUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name    string
+		cluster *AzureCluster
+		wantErr bool
+	}{
+		{
+			name: "azurecluster with pre-existing vnet - valid spec",
+			cluster: func() *AzureCluster {
+				return createValidCluster()
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "azurecluster without pre-existing vnet - valid spec",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Vnet.ResourceGroup = ""
+				return cluster
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - lack control plane subnet",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[1:]
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - lack node subnet",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[:1]
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - invalid resourcegroup name",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Vnet.ResourceGroup = "invalid-name###"
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - invalid subnet name",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets = append(cluster.Spec.NetworkSpec.Subnets,
+					&SubnetSpec{Name: "invalid-name###", Role: "random-role"})
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "azurecluster with pre-existing vnet - invalid internal load balancer ip address",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.NetworkSpec.Subnets[0].InternalLBIPAddress = "1000.1.1.1"
+				return cluster
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cluster.ValidateUpdate(createValidCluster())
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -38,6 +38,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha3-azurecluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.azurecluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - azurecluster
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha3-azuremachine
   failurePolicy: Fail
   matchPolicy: Equivalent


### PR DESCRIPTION
**What this PR does / why we need it**:

We didn't have webhook validation for existing vnet and subnet

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #556

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
1. Adding validation for existing vnet and subnet according to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/topics/custom-vnet.md#pre-existing-vnet-and-subnets
```