### PR TITLE
🏃 Add ci-apidiff job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ KUBECTL=$(TOOLS_BIN_DIR)/kubectl
 KUSTOMIZE := $(TOOLS_BIN_DIR)/kustomize
 MOCKGEN := $(TOOLS_BIN_DIR)/mockgen
 RELEASE_NOTES := $(TOOLS_BIN_DIR)/release-notes
+GO_APIDIFF := $(TOOLS_BIN_DIR)/go-apidiff
 EXP_DIR := exp
 
 # Define Docker related variables. Releases should modify and double check these vars.
@@ -147,6 +148,9 @@ $(MOCKGEN): ## Build mockgen from tools folder.
 $(RELEASE_NOTES): ## Build release notes
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) sigs.k8s.io/cluster-api/hack/tools/release
 	mv $(TOOLS_BIN_DIR)/release $(RELEASE_NOTES)
+
+$(GO_APIDIFF): ## Build go-apidiff.
+	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/joelanford/go-apidiff
 
 ## --------------------------------------
 ## Linting

--- a/scripts/ci-apidiff.sh
+++ b/scripts/ci-apidiff.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}"
+
+APIDIFF="${PWD}/hack/tools/bin/go-apidiff"
+PULL_BASE_SHA=${PULL_BASE_SHA:-$(git rev-parse origin/master)}
+
+make ${APIDIFF}
+echo "*** Running go-apidiff ***"
+
+${APIDIFF} "${PULL_BASE_SHA}" --print-compatible


### PR DESCRIPTION
**What this PR does / why we need it**: This is mostly copy paste from https://github.com/kubernetes-sigs/cluster-api/pull/2923. Will follow up with a test-infra PR to enable the job.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #605

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```