### PR TITLE
🐛 fix: allow nil image in AzureMachine webhook validation

### DIFF
--- a/api/v1alpha3/azureimage_validation.go
+++ b/api/v1alpha3/azureimage_validation.go
@@ -25,7 +25,7 @@ func ValidateImage(image *Image, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if image == nil {
-		allErrs = append(allErrs, field.Required(fldPath, "an image must be specified"))
+		// allow empty image as it is defaulted in the AzureMachine controller
 		return allErrs
 	}
 

--- a/api/v1alpha3/azureimage_validation_test.go
+++ b/api/v1alpha3/azureimage_validation_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func TestImageRequired(t *testing.T) {
+func TestImageOptional(t *testing.T) {
 	g := NewWithT(t)
 
 	type test struct {
@@ -34,10 +34,7 @@ func TestImageRequired(t *testing.T) {
 	extension := test{}
 
 	errs := ValidateImage(extension.Image, field.NewPath("image"))
-	g.Expect(errs).To(HaveLen(1))
-	g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
-	g.Expect(errs[0].Field).To(Equal("image"))
-	g.Expect(errs[0].Detail).NotTo(BeEmpty())
+	g.Expect(errs).To(HaveLen(0))
 }
 
 func TestImageTooManyDetails(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**: After #621 merged, AzureMachine validation is failing if the image is not explicitly specified. This is wrong since the image gets defaulted in the AzureMachine controller. Change the webhook to only validate the image if it is specified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #623 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: allow nil image in AzureMachine webhook validation
```