### PR TITLE
🐛 Remove errant space that broke "make tilt-up"

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -9,7 +9,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v0.3.6 ",
+    "capi_version": "v0.3.6",
     "cert_manager_version": "v0.11.0",
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I started getting errors with `make tilt-up` after #625 merged because a space was accidentally introduced into the value for `"capi-version"`.

```
Error: command ["sh" "-c" "kubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.6​​​​​​​                
/cluster-api-components.yaml"] failed. 
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove errant space that broke "make tilt-up"
```