### PR TITLE
Refactor: Move node public IP creation/deletion to NIC service

### DIFF
--- a/cloud/defaults.go
+++ b/cloud/defaults.go
@@ -116,6 +116,11 @@ func GeneratePublicIPName(clusterName, hash string) string {
 	return fmt.Sprintf("%s-%s", clusterName, hash)
 }
 
+// GenerateNodePublicIPName generates a node public IP name, based on the NIC name.
+func GenerateNodePublicIPName(nicName string) string {
+	return fmt.Sprintf("%s-public-ip", nicName)
+}
+
 // GenerateFQDN generates a fully qualified domain name, based on the public IP name and cluster location.
 func GenerateFQDN(publicIPName, location string) string {
 	return fmt.Sprintf("%s.%s.%s", publicIPName, location, DefaultAzureDNSZone)

--- a/cloud/services/networkinterfaces/networkinterfaces.go
+++ b/cloud/services/networkinterfaces/networkinterfaces.go
@@ -19,6 +19,7 @@ package networkinterfaces
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -113,6 +114,10 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	nicConfig.LoadBalancerBackendAddressPools = &backendAddressPools
 
 	if nicSpec.PublicIPName != "" {
+		iperr := s.createNodePublicIP(ctx, nicSpec.PublicIPName)
+		if iperr != nil {
+			return errors.Wrap(iperr, "failed to create node public IP")
+		}
 		publicIP, err := s.PublicIPsClient.Get(ctx, s.Scope.ResourceGroup(), nicSpec.PublicIPName)
 		if err != nil {
 			return errors.Wrap(err, "failed to get publicIP")
@@ -149,6 +154,13 @@ func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	if !ok {
 		return errors.New("invalid network interface specification")
 	}
+	if nicSpec.PublicIPName != "" {
+		err := s.PublicIPsClient.Delete(ctx, s.Scope.ResourceGroup(), nicSpec.PublicIPName)
+		if err != nil && !azure.ResourceNotFound(err) {
+			return errors.Wrapf(err, "failed to delete public IP %s", nicSpec.PublicIPName)
+		}
+		klog.V(2).Infof("successfully deleted IP %s", nicSpec.PublicIPName)
+	}
 	klog.V(2).Infof("deleting nic %s", nicSpec.Name)
 	err := s.Client.Delete(ctx, s.Scope.ResourceGroup(), nicSpec.Name)
 	if err != nil && !azure.ResourceNotFound(err) {
@@ -159,7 +171,7 @@ func (s *Service) Delete(ctx context.Context, spec interface{}) error {
 	if err != nil && !azure.ResourceNotFound(err) {
 		return errors.Wrapf(err, "failed to delete inbound NAT rule %s in load balancer %s", NATRuleName, nicSpec.PublicLoadBalancerName)
 	}
-	klog.V(2).Infof("successfully deleted nic %s and NAT rule %s", nicSpec.Name, NATRuleName)
+	klog.V(2).Infof("successfully deleted NIC %s and NAT rule %s", nicSpec.Name, NATRuleName)
 	return nil
 }
 
@@ -206,4 +218,26 @@ func (s *Service) createInboundNatRule(ctx context.Context, lb network.LoadBalan
 	}
 	klog.V(3).Infof("Creating rule %s using port %d", ruleName, sshFrontendPort)
 	return s.InboundNATRulesClient.CreateOrUpdate(ctx, s.Scope.ResourceGroup(), to.String(lb.Name), ruleName, rule)
+}
+
+func (s *Service) createNodePublicIP(ctx context.Context, ipName string) error {
+	klog.V(2).Infof("creating public IP %s", ipName)
+
+	return s.PublicIPsClient.CreateOrUpdate(
+		ctx,
+		s.Scope.ResourceGroup(),
+		ipName,
+		network.PublicIPAddress{
+			Sku:      &network.PublicIPAddressSku{Name: network.PublicIPAddressSkuNameStandard},
+			Name:     to.StringPtr(ipName),
+			Location: to.StringPtr(s.Scope.Location()),
+			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+				PublicIPAddressVersion:   network.IPv4,
+				PublicIPAllocationMethod: network.Static,
+				DNSSettings: &network.PublicIPAddressDNSSettings{
+					DomainNameLabel: to.StringPtr(strings.ToLower(ipName)),
+				},
+			},
+		},
+	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**: This is in preparation for #627, specifically to solve  https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/627#issuecomment-629556702. When node public IPs were added in #327, it reused the existing `Reconcile()` function for the cluster public IP. This worked as node public IPs and the cluster public IP happened to have similar properties. However, with #627, we are trying to get away from the controller -> reconcile -> service -> Azure client model and instead just have controller -> service -> Azure client (and potentially CRD in the future, see #416). In order to do that, each type of Azure resource should have it's own `Reconcile()`. The idea of this PR is to move the node public IP lifecycle to network interfaces since they are a sub resource of network interfaces in this case, similar to how network interfaces "own" NAT rules. The alternative I considered was to have a second  `Reconcile` function in the public IP service that would dedicated to node IPs but there was some friction in having the public IP service reconcile both AzureCluster resources and AzureMachine resources (similar to the NAT rule case) so I think the NIC service is more appropriate in this case. I think we can also decide to separate it out again later if that works better once we've refactored the reconcilers. This also allows for better unit testing since we can test the behavior of AllocatePublicIP actually triggers the creation of the node IP.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates to #627

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Refactor: Move node public IP creation/deletion to NIC service
```