### PR TITLE
📖 Add front-page link to flavors documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ hybrid deployments of Kubernetes.
 
 Check out the [Cluster API Quick Start][quickstart] to create your first Kubernetes cluster on Azure using Cluster API.
 
+## Flavors
+
+See the [flavors documentation][flavors_doc] to know which cluster templates are provided by CAPZ.
+
 ------
 
 ## Support Policy
@@ -125,3 +129,4 @@ We also use the issue tracker to track features. If you have an idea for a featu
 [slack_info]: https://github.com/kubernetes/community/blob/master/communication.md#social-media
 [cluster_api]: https://github.com/kubernetes-sigs/cluster-api
 [quickstart]: https://cluster-api.sigs.k8s.io/user/quick-start.html
+[flavors_doc]: ./templates/flavors/README.md


### PR DESCRIPTION
**What this PR does / why we need it**:

In the [Cluster API docs](https://cluster-api.sigs.k8s.io/clusterctl/commands/config-cluster.html#flavors), it says this about flavors:

> Please refer to the providers [sic] documentation for more info about available flavors.

I didn't see any obvious documentation about CAPZ flavors other than running `make generate-flavors` and then poking around to find the templates/flavors/ directory. This links directly from the main README.md, but let me know if there's a better way to advertize our flavors. 

**Which issue(s) this PR fixes**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
📖 Add front-page link to flavors documentation
```