### PR TITLE
🐛 add ClusterRole and ClusterRoleBinding for Azure File

### DIFF
--- a/templates/addons/azurefile-role.yaml
+++ b/templates/addons/azurefile-role.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:azure-file
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: system:azure-file
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: system:azure-file
+subjects:
+  - kind: ServiceAccount
+    name: persistent-volume-binder
+    namespace: kube-system


### PR DESCRIPTION
**What this PR does / why we need it**:

https://testgrid.k8s.io/provider-azure-upstream#k8s-e2e-azure-file-1-16-capz is failing due to 

```
Couldn't create secret secrets is forbidden: User "system:serviceaccount:kube-system:persistent-volume-binder" cannot create resource "secrets" in API group "" in the namespace "azurefile-1211"
```

This is because the service account `persistent-volume-binder` is missing the proper role assignment.

ref: https://github.com/Azure/AKS/issues/525

/test pull-cluster-api-provider-azure-conformance-v1alpha3-master
/test pull-cluster-api-provider-azure-conformance-v1alpha3-1-18
/assign @CecileRobertMichon

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```