### PR TITLE
Adds version info to manager startup logs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 !/exp/**
 !/feature/**
 !/pkg/**
+!/version/**
 !/main.go
 !/go.mod
 !/go.sum

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,9 @@ E2E_CONF_FILE_ENVSUBST := $(ROOT_DIR)/test/e2e/config/azure-dev-envsubst.yaml
 SKIP_CLEANUP ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= false
 
+# Build time versioning details.
+LDFLAGS := $(shell hack/version.sh)
+
 CLUSTER_TEMPLATE ?= cluster-template.yaml
 MANAGED_CLUSTER_TEMPLATE ?= cluster-template-aks.yaml
 
@@ -130,7 +133,7 @@ binaries: manager ## Builds and installs all binaries
 
 .PHONY: manager
 manager: ## Build manager binary.
-	go build -o $(BIN_DIR)/manager .
+	go build -ldflags "$(LDFLAGS)" -o $(BIN_DIR)/manager .
 
 ## --------------------------------------
 ## Tooling Binaries
@@ -310,7 +313,7 @@ release-binary: $(RELEASE_DIR)
 		-v "$$(pwd):/workspace" \
 		-w /workspace \
 		golang:1.13.8 \
-		go build -a -ldflags '-extldflags "-static"' \
+		go build -a -ldflags '$(LDFLAGS) -extldflags "-static"' \
 		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(RELEASE_BINARY)
 
 .PHONY: release-staging

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+version::get_version_vars() {
+    GIT_COMMIT="$(git rev-parse HEAD^{commit})"
+
+    if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+        GIT_TREE_STATE="clean"
+    else
+        GIT_TREE_STATE="dirty"
+    fi
+
+    # borrowed from k8s.io/hack/lib/version.sh
+    # Use git describe to find the version based on tags.
+    if GIT_VERSION=$(git describe --tags --abbrev=14 2>/dev/null); then
+        # This translates the "git describe" to an actual semver.org
+        # compatible semantic version that looks something like this:
+        #   v1.1.0-alpha.0.6+84c76d1142ea4d
+        DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
+        if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+            # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+            GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\-\2/")
+        elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+            # We have distance to base tag (v1.1.0-1-gCommitHash)
+            GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/-\1/")
+        fi
+        if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
+            # git describe --dirty only considers changes to existing files, but
+            # that is problematic since new untracked .go files affect the build,
+            # so use our idea of "dirty" from git status instead.
+            GIT_VERSION+="-dirty"
+        fi
+
+
+        # Try to match the "git describe" output to a regex to try to extract
+        # the "major" and "minor" versions and whether this is the exact tagged
+        # version or whether the tree is between two tagged versions.
+        if [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+            GIT_MAJOR=${BASH_REMATCH[1]}
+            GIT_MINOR=${BASH_REMATCH[2]}
+        fi
+
+        # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+        if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+            echo "Please see more details here: https://semver.org"
+            exit 1
+        fi
+    fi
+
+    GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags)
+}
+
+# borrowed from k8s.io/hack/lib/version.sh and modified
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+version::ldflags() {
+    version::get_version_vars
+
+    local -a ldflags
+    function add_ldflag() {
+        local key=${1}
+        local val=${2}
+        ldflags+=(
+            "-X 'sigs.k8s.io/cluster-api-provider-azure/version.${key}=${val}'"
+        )
+    }
+
+    add_ldflag "buildDate" "$(date ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} -u +'%Y-%m-%dT%H:%M:%SZ')"
+    add_ldflag "gitCommit" "${GIT_COMMIT}"
+    add_ldflag "gitTreeState" "${GIT_TREE_STATE}"
+    add_ldflag "gitMajor" "${GIT_MAJOR}"
+    add_ldflag "gitMinor" "${GIT_MINOR}"
+    add_ldflag "gitVersion" "${GIT_VERSION}"
+
+  # The -ldflags parameter takes a single string, so join the output.
+  echo "${ldflags[*]-}"
+}
+
+version::ldflags

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1alpha3exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	infrav1controllersexp "sigs.k8s.io/cluster-api-provider-azure/exp/controllers"
+	version "sigs.k8s.io/cluster-api-provider-azure/version"
 	capifeature "sigs.k8s.io/cluster-api/feature"
 
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
@@ -278,7 +279,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("starting manager")
+	setupLog.Info("starting manager", "version", version.Get().String())
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	azuresdkversion "github.com/Azure/azure-sdk-for-go/version"
+)
+
+var (
+	gitMajor     string // major version, always numeric
+	gitMinor     string // minor version, numeric possibly followed by "+"
+	gitVersion   string // semantic version, derived by build scripts
+	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState string // state of git tree, either "clean" or "dirty"
+	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)
+
+type Info struct {
+	Major           string `json:"major,omitempty"`
+	Minor           string `json:"minor,omitempty"`
+	GitVersion      string `json:"gitVersion,omitempty"`
+	GitCommit       string `json:"gitCommit,omitempty"`
+	GitTreeState    string `json:"gitTreeState,omitempty"`
+	BuildDate       string `json:"buildDate,omitempty"`
+	GoVersion       string `json:"goVersion,omitempty"`
+	Compiler        string `json:"compiler,omitempty"`
+	Platform        string `json:"platform,omitempty"`
+	AzureSdkVersion string `json:"azureSdkVersion,omitempty"`
+}
+
+func Get() Info {
+	return Info{
+		Major:           gitMajor,
+		Minor:           gitMinor,
+		GitVersion:      gitVersion,
+		GitCommit:       gitCommit,
+		GitTreeState:    gitTreeState,
+		BuildDate:       buildDate,
+		GoVersion:       runtime.Version(),
+		Compiler:        runtime.Compiler,
+		Platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		AzureSdkVersion: fmt.Sprintf("v%s", azuresdkversion.Number),
+	}
+}
+
+// String returns info as a human-friendly version string.
+func (info Info) String() string {
+	return info.GitVersion
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds version information to the manager startup logs. This would make debugging issues a lot more simpler.

**Which issue(s) this PR fixes** :
fixes #561 

**Special notes for your reviewer**:
Borrowed the format from the cluster-api project. 

**Release note**:
```release-note
Adds versioning info to startup logs
```