### PR TITLE
Added namespace override to all kustomize files

### DIFF
--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -21,6 +21,7 @@ apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureManagedControlPlane
 metadata:
   name: ${CLUSTER_NAME}-control-plane
+  namespace: default
 spec:
   defaultPoolRef:
     name: agentpool0
@@ -34,6 +35,7 @@ apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureManagedCluster
 metadata:
   name: ${CLUSTER_NAME}
+  namespace: default
 spec:
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
@@ -41,6 +43,7 @@ apiVersion: exp.cluster.x-k8s.io/v1alpha3
 kind: MachinePool
 metadata:
   name: agentpool0
+  namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}
@@ -61,6 +64,7 @@ apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureManagedMachinePool
 metadata:
   name: agentpool0
+  namespace: default
 spec:
   osDiskSizeGB: 512
   sku: ${AZURE_NODE_MACHINE_TYPE}
@@ -69,6 +73,7 @@ apiVersion: exp.cluster.x-k8s.io/v1alpha3
 kind: MachinePool
 metadata:
   name: agentpool1
+  namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}
@@ -89,6 +94,7 @@ apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureManagedMachinePool
 metadata:
   name: agentpool1
+  namespace: default
 spec:
   osDiskSizeGB: 1024
   sku: ${AZURE_NODE_MACHINE_TYPE}

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -124,6 +124,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}
@@ -147,6 +148,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   template:
     spec:
@@ -163,6 +165,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   template:
     spec:

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -124,6 +124,7 @@ apiVersion: exp.cluster.x-k8s.io/v1alpha3
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
+  namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}
@@ -145,6 +146,7 @@ apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachinePool
 metadata:
   name: ${CLUSTER_NAME}-mp-0
+  namespace: default
 spec:
   location: ${AZURE_LOCATION}
   template:
@@ -160,6 +162,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: ${CLUSTER_NAME}-mp-0
+  namespace: default
 spec:
   files:
   - content: |

--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -125,6 +125,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}
@@ -148,6 +149,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   template:
     spec:
@@ -165,6 +167,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   template:
     spec:

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -127,6 +127,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}
@@ -150,6 +151,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   template:
     spec:
@@ -169,6 +171,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   template:
     spec:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -124,6 +124,7 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}
@@ -147,6 +148,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   template:
     spec:
@@ -163,6 +165,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
+  namespace: default
 spec:
   template:
     spec:

--- a/templates/flavors/aks/kustomization.yaml
+++ b/templates/flavors/aks/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: default
 resources:
 - cluster-template.yaml

--- a/templates/flavors/default/kustomization.yaml
+++ b/templates/flavors/default/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: default
 resources:
   - ../base
   - machine-deployment.yaml

--- a/templates/flavors/external-cloud-provider/kustomization.yaml
+++ b/templates/flavors/external-cloud-provider/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: default
 resources:
   - ../default
 patchesStrategicMerge:

--- a/templates/flavors/machinepool/kustomization.yaml
+++ b/templates/flavors/machinepool/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: default
 resources:
   - ../base
   - machine-pool-deployment.yaml

--- a/templates/flavors/system-assigned-identity/kustomization.yaml
+++ b/templates/flavors/system-assigned-identity/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: default
 resources:
   - ../base
   - system-assigned-identity-md.yaml

--- a/templates/flavors/user-assigned-identity/kustomization.yaml
+++ b/templates/flavors/user-assigned-identity/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: default
 resources:
   - ../base
   - user-assigned-identity-md.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for #641 when deployment templates using kustomize and on non default namespace


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#641 

**Special notes for your reviewer**:
Could also set this value in ENV and override like others but this felt more native to kustomize.  I ran `make generate-flavors` to fix the generated files.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added namespace override to kustomize files
```