### PR TITLE
📖 clarify that either python 2.7 or 3.x is ok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ tilt-settings.json
 test/e2e/junit.e2e_suite.*.xml
 test/e2e/logs/*
 _artifacts
+
+# boilerplate_test output
+hack/boilerplate/__pycache__
+hack/boilerplate/*.pyc

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,7 +55,7 @@
    - `brew install kustomize` on macOS.
    - `choco install kustomize` on Windows.
    - [install instructions][kustomizelinux] on Linux
-6. Configure Python 2.7+ with [pyenv][pyenv] if your default is Python 3.x.
+6. Install Python 3.x or 2.7.x, if neither is already installed.
 7. Install make.
 8. Install [timeout][timeout]
    - `brew install coreutils` on macOS.
@@ -388,7 +388,6 @@ export SKIP_UPSTREAM_E2E_TESTS="false"
 [kind]: https://sigs.k8s.io/kind
 [azure_cli]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
 [manifests]: /docs/manifests.md
-[pyenv]: https://github.com/pyenv/pyenv
 [kustomize]: https://github.com/kubernetes-sigs/kustomize
 [kustomizelinux]: https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md
 [gomock]: https://github.com/golang/mock

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -218,6 +218,8 @@ def main():
 
     for filename in filenames:
         if not file_passes(filename, refs, regexs):
+            if sys.version_info[0] < 3:
+                filename = unicode(filename)
             print(filename, file=sys.stdout)
 
     return 0

--- a/hack/boilerplate/boilerplate_test.py
+++ b/hack/boilerplate/boilerplate_test.py
@@ -16,7 +16,7 @@
 
 import boilerplate
 import unittest
-import StringIO
+from io import StringIO
 import os
 import sys
 
@@ -39,7 +39,7 @@ class TestBoilerplate(unittest.TestCase):
 
     # capture stdout
     old_stdout = sys.stdout
-    sys.stdout = StringIO.StringIO()
+    sys.stdout = StringIO()
 
     boilerplate.args = Args()
     ret = boilerplate.main()
@@ -48,5 +48,5 @@ class TestBoilerplate(unittest.TestCase):
 
     sys.stdout = old_stdout
 
-    self.assertEquals(
+    self.assertEqual(
         output, ['././fail.go', '././fail.py'])


### PR DESCRIPTION
**What this PR does / why we need it**:

Clarifies that either Python 2.7 or 3.x are ok for the development environment, and makes some small changes to the `boilerplate_test.py` script that ensure that is true.

**Which issue(s) this PR fixes**:

Fixes #515 

**Special notes for your reviewer**:

Based on looking for `.py` files in the project, I think the only python code lives here under ./hack/boilerplate, but let me know if I missed something. I then reviewed the code and ran the test harness under `python2.7` and `python3` (3.7) until it behaved.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
📖 clarify that either python 2.7 or 3.x is ok
```