### PR TITLE
🐛 Check all chained errors for 404

### DIFF
--- a/cloud/errors.go
+++ b/cloud/errors.go
@@ -17,13 +17,13 @@ limitations under the License.
 package azure
 
 import (
+	"errors"
+
 	"github.com/Azure/go-autorest/autorest"
 )
 
 // ResourceNotFound parses the error to check if it's a resource not found
 func ResourceNotFound(err error) bool {
-	if derr, ok := err.(autorest.DetailedError); ok && derr.StatusCode == 404 {
-		return true
-	}
-	return false
+	derr := autorest.DetailedError{}
+	return errors.As(err, &derr) && derr.StatusCode == 404
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Checks that an error in the chain represents a 404 with [errors.As](https://golang.org/pkg/errors/#As), a more robust approach than a type assertion.

**Which issue(s) this PR fixes**:

Fixes #563

**Special notes for your reviewer**:

Trying to reproduce the bug, I saw that the `ResourceNotFound()` func was returning false for an error whose text contained "404". Using the more robust `errors.As` func returns true in this case, which allows the AzureCluster to be deleted successfully when its Resource Group is already gone.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
🐛 Check all chained errors for 404
```