### PR TITLE
⚒️ eliminate plain text credentials

### DIFF
--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -54,7 +54,29 @@ if ! [ -n "$SSH_KEY_FILE" ]; then
     ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N '' 1>/dev/null
     echo "Machine SSH key generated in ${SSH_KEY_FILE}"
 fi
-export AZURE_SSH_PUBLIC_KEY=$(cat "${SSH_KEY_FILE}.pub" | base64 | tr -d '\r\n')
+export AZURE_SSH_PUBLIC_KEY=$(cat "${SSH_KEY_FILE}.pub" | base64 | tr -d '\n')
+
+export AZURE_STANDARD_JSON_B64=$(echo '{
+      "cloud": "${AZURE_ENVIRONMENT}",
+      "tenantId": "${AZURE_TENANT_ID}",
+      "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
+      "aadClientId": "${AZURE_CLIENT_ID}",
+      "aadClientSecret": "${AZURE_CLIENT_SECRET}",
+      "resourceGroup": "${CLUSTER_NAME}",
+      "securityGroupName": "${CLUSTER_NAME}-node-nsg",
+      "location": "${AZURE_LOCATION}",
+      "vmType": "standard",
+      "vnetName": "${CLUSTER_NAME}-vnet",
+      "vnetResourceGroup": "${CLUSTER_NAME}",
+      "subnetName": "${CLUSTER_NAME}-node-subnet",
+      "routeTableName": "${CLUSTER_NAME}-node-routetable",
+      "loadBalancerSku": "standard",
+      "maximumLoadBalancerRuleCount": 250,
+      "useManagedIdentityExtension": false,
+      "useInstanceMetadata": true
+}' | envsubst |  base64 | tr -d '\n')
+
+export AZURE_VMSS_JSON_B64=$(echo "$AZURE_STANDARD_JSON_B64" | base64 -d | jq '.vmType = "vmss"' | base64 | tr -d '\n')
 
 echo "================ DOCKER BUILD ==============="
 PULL_POLICY=IfNotPresent make modules docker-build

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -121,6 +121,15 @@ spec:
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
 ---
+apiVersion: v1
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}
+kind: Secret
+metadata:
+  name: azure-secret
+  namespace: default
+---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -64,30 +64,12 @@ spec:
           name: cloud-config
           readOnly: true
     files:
-    - content: |
-        {
-          "cloud": "AzurePublicCloud",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          key: standard
+          name: azure-secret
       owner: root:root
       path: /etc/kubernetes/azure.json
-      permissions: "0644"
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -120,6 +102,15 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: v1
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}
+kind: Secret
+metadata:
+  name: azure-secret
+  namespace: default
 ---
 apiVersion: exp.cluster.x-k8s.io/v1alpha3
 kind: MachinePool
@@ -166,26 +157,10 @@ metadata:
   namespace: default
 spec:
   files:
-  - content: |
-      {
-        "cloud": "${AZURE_ENVIRONMENT}",
-        "tenantId": "${AZURE_TENANT_ID}",
-        "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-        "aadClientId": "${AZURE_CLIENT_ID}",
-        "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-        "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-        "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-        "location": "${AZURE_LOCATION}",
-        "vmType": "vmss",
-        "vnetName": "${CLUSTER_NAME}-vnet",
-        "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-        "subnetName": "${CLUSTER_NAME}-node-subnet",
-        "routeTableName": "${CLUSTER_NAME}-node-routetable",
-        "loadBalancerSku": "standard",
-        "maximumLoadBalancerRuleCount": 250,
-        "useManagedIdentityExtension": false,
-        "useInstanceMetadata": true
-      }
+  - contentFrom:
+      secret:
+        key: vmss
+        name: azure-secret
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"

--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -64,27 +64,10 @@ spec:
           name: cloud-config
           readOnly: true
     files:
-    - content: |
-        {
-          "cloud": "${AZURE_ENVIRONMENT}",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          key: standard
+          name: azure-secret
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
@@ -121,6 +104,15 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: v1
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}
+kind: Secret
+metadata:
+  name: azure-secret
+  namespace: default
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -64,27 +64,10 @@ spec:
           name: cloud-config
           readOnly: true
     files:
-    - content: |
-        {
-          "cloud": "${AZURE_ENVIRONMENT}",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          key: standard
+          name: azure-secret
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
@@ -123,6 +106,15 @@ spec:
       userAssignedIdentities:
       - providerID: ${USER_ASSIGNED_IDENTITY_PROVIDER_ID}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: v1
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}
+kind: Secret
+metadata:
+  name: azure-secret
+  namespace: default
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -64,27 +64,10 @@ spec:
           name: cloud-config
           readOnly: true
     files:
-    - content: |
-        {
-          "cloud": "${AZURE_ENVIRONMENT}",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          key: standard
+          name: azure-secret
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
@@ -120,6 +103,15 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: v1
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}
+kind: Secret
+metadata:
+  name: azure-secret
+  namespace: default
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
@@ -171,26 +163,10 @@ spec:
   template:
     spec:
       files:
-      - content: |
-          {
-            "cloud": "${AZURE_ENVIRONMENT}",
-            "tenantId": "${AZURE_TENANT_ID}",
-            "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-            "aadClientId": "${AZURE_CLIENT_ID}",
-            "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-            "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-            "location": "${AZURE_LOCATION}",
-            "vmType": "vmss",
-            "vnetName": "${CLUSTER_NAME}-vnet",
-            "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "subnetName": "${CLUSTER_NAME}-node-subnet",
-            "routeTableName": "${CLUSTER_NAME}-node-routetable",
-            "loadBalancerSku": "standard",
-            "maximumLoadBalancerRuleCount": 250,
-            "useManagedIdentityExtension": false,
-            "useInstanceMetadata": true
-          }
+      - contentFrom:
+          secret:
+            key: standard
+            name: azure-secret
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"

--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -75,30 +75,13 @@ spec:
             name: cloud-config
             readOnly: true
     files:
-      - path: /etc/kubernetes/azure.json
-        owner: "root:root"
-        permissions: "0644"
-        content: |
-          {
-            "cloud": "${AZURE_ENVIRONMENT}",
-            "tenantId": "${AZURE_TENANT_ID}",
-            "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-            "aadClientId": "${AZURE_CLIENT_ID}",
-            "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-            "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-            "location": "${AZURE_LOCATION}",
-            "vmType": "vmss",
-            "vnetName": "${CLUSTER_NAME}-vnet",
-            "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "subnetName": "${CLUSTER_NAME}-node-subnet",
-            "routeTableName": "${CLUSTER_NAME}-node-routetable",
-            "userAssignedID": "${CLUSTER_NAME}",
-            "loadBalancerSku": "standard",
-            "maximumLoadBalancerRuleCount": 250,
-            "useManagedIdentityExtension": false,
-            "useInstanceMetadata": true
-          }
+    - contentFrom:
+        secret:
+          name: azure-secret
+          key: standard
+      owner: root:root
+      path: /etc/kubernetes/azure.json
+      permissions: "0644"
   version: "${KUBERNETES_VERSION}"
 ---
 kind: AzureMachineTemplate
@@ -116,3 +99,11 @@ spec:
         managedDisk:
           storageAccountType: "Premium_LRS"
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-secret
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}

--- a/templates/flavors/default/machine-deployment.yaml
+++ b/templates/flavors/default/machine-deployment.yaml
@@ -52,26 +52,10 @@ spec:
             cloud-provider: azure
             cloud-config: /etc/kubernetes/azure.json
       files:
-        - path: /etc/kubernetes/azure.json
-          owner: "root:root"
-          permissions: "0644"
-          content: |
-            {
-              "cloud": "${AZURE_ENVIRONMENT}",
-              "tenantId": "${AZURE_TENANT_ID}",
-              "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-              "aadClientId": "${AZURE_CLIENT_ID}",
-              "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-              "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-              "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-              "location": "${AZURE_LOCATION}",
-              "vmType": "vmss",
-              "vnetName": "${CLUSTER_NAME}-vnet",
-              "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-              "subnetName": "${CLUSTER_NAME}-node-subnet",
-              "routeTableName": "${CLUSTER_NAME}-node-routetable",
-              "loadBalancerSku": "standard",
-              "maximumLoadBalancerRuleCount": 250,
-              "useManagedIdentityExtension": false,
-              "useInstanceMetadata": true
-            }
+      - contentFrom:
+          secret:
+            name: azure-secret
+            key: standard
+        owner: root:root
+        path: /etc/kubernetes/azure.json
+        permissions: "0644"

--- a/templates/flavors/machinepool/machine-pool-deployment.yaml
+++ b/templates/flavors/machinepool/machine-pool-deployment.yaml
@@ -48,26 +48,10 @@ spec:
         cloud-provider: azure
         cloud-config: /etc/kubernetes/azure.json
   files:
-  - path: /etc/kubernetes/azure.json
-    owner: "root:root"
+  - contentFrom:
+      secret:
+        name: azure-secret
+        key: vmss
+    owner: root:root
+    path: /etc/kubernetes/azure.json
     permissions: "0644"
-    content: |
-      {
-        "cloud": "${AZURE_ENVIRONMENT}",
-        "tenantId": "${AZURE_TENANT_ID}",
-        "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-        "aadClientId": "${AZURE_CLIENT_ID}",
-        "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-        "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-        "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-        "location": "${AZURE_LOCATION}",
-        "vmType": "vmss",
-        "vnetName": "${CLUSTER_NAME}-vnet",
-        "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-        "subnetName": "${CLUSTER_NAME}-node-subnet",
-        "routeTableName": "${CLUSTER_NAME}-node-routetable",
-        "loadBalancerSku": "standard",
-        "maximumLoadBalancerRuleCount": 250,
-        "useManagedIdentityExtension": false,
-        "useInstanceMetadata": true
-      }

--- a/templates/flavors/machinepool/patches/control-plane-azure-file.yaml
+++ b/templates/flavors/machinepool/patches/control-plane-azure-file.yaml
@@ -7,27 +7,9 @@ metadata:
 spec:
   kubeadmConfigSpec:
     files:
-    - content: |
-        {
-          "cloud": "AzurePublicCloud",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          name: azure-secret
+          key: standard
       owner: root:root
       path: /etc/kubernetes/azure.json
-      permissions: "0644"

--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -207,6 +207,15 @@ spec:
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
 ---
+apiVersion: v1
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}
+kind: Secret
+metadata:
+  name: azure-secret
+  namespace: default
+---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -207,6 +207,15 @@ spec:
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
 ---
+apiVersion: v1
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}
+kind: Secret
+metadata:
+  name: azure-secret
+  namespace: default
+---
 apiVersion: exp.cluster.x-k8s.io/v1alpha3
 kind: MachinePool
 metadata:

--- a/templates/test/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/cluster-template-prow-machine-pool.yaml
@@ -67,30 +67,12 @@ spec:
           name: cloud-config
           readOnly: true
     files:
-    - content: |
-        {
-          "cloud": "AzurePublicCloud",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          key: standard
+          name: azure-secret
       owner: root:root
       path: /etc/kubernetes/azure.json
-      permissions: "0644"
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -123,6 +105,15 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: v1
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}
+kind: Secret
+metadata:
+  name: azure-secret
+  namespace: default
 ---
 apiVersion: exp.cluster.x-k8s.io/v1alpha3
 kind: MachinePool
@@ -169,26 +160,10 @@ metadata:
   namespace: default
 spec:
   files:
-  - content: |
-      {
-        "cloud": "${AZURE_ENVIRONMENT}",
-        "tenantId": "${AZURE_TENANT_ID}",
-        "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-        "aadClientId": "${AZURE_CLIENT_ID}",
-        "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-        "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-        "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-        "location": "${AZURE_LOCATION}",
-        "vmType": "vmss",
-        "vnetName": "${CLUSTER_NAME}-vnet",
-        "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-        "subnetName": "${CLUSTER_NAME}-node-subnet",
-        "routeTableName": "${CLUSTER_NAME}-node-routetable",
-        "loadBalancerSku": "standard",
-        "maximumLoadBalancerRuleCount": 250,
-        "useManagedIdentityExtension": false,
-        "useInstanceMetadata": true
-      }
+  - contentFrom:
+      secret:
+        key: vmss
+        name: azure-secret
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"

--- a/templates/test/cluster-template-prow.yaml
+++ b/templates/test/cluster-template-prow.yaml
@@ -67,27 +67,10 @@ spec:
           name: cloud-config
           readOnly: true
     files:
-    - content: |
-        {
-          "cloud": "${AZURE_ENVIRONMENT}",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          key: standard
+          name: azure-secret
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
@@ -123,6 +106,15 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: v1
+data:
+  standard: ${AZURE_STANDARD_JSON_B64}
+  vmss: ${AZURE_VMSS_JSON_B64}
+kind: Secret
+metadata:
+  name: azure-secret
+  namespace: default
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
@@ -174,26 +166,10 @@ spec:
   template:
     spec:
       files:
-      - content: |
-          {
-            "cloud": "${AZURE_ENVIRONMENT}",
-            "tenantId": "${AZURE_TENANT_ID}",
-            "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-            "aadClientId": "${AZURE_CLIENT_ID}",
-            "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-            "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-            "location": "${AZURE_LOCATION}",
-            "vmType": "vmss",
-            "vnetName": "${CLUSTER_NAME}-vnet",
-            "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "subnetName": "${CLUSTER_NAME}-node-subnet",
-            "routeTableName": "${CLUSTER_NAME}-node-routetable",
-            "loadBalancerSku": "standard",
-            "maximumLoadBalancerRuleCount": 250,
-            "useManagedIdentityExtension": false,
-            "useInstanceMetadata": true
-          }
+      - contentFrom:
+          secret:
+            key: standard
+            name: azure-secret
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -35,12 +35,12 @@ import (
 
 var _ = Describe("Workoad cluster creation", func() {
 	var (
-		ctx           = context.TODO()
-		specName      = "create-workload-cluster"
-		namespace     *corev1.Namespace
-		cancelWatches context.CancelFunc
-		cluster       *clusterv1.Cluster
-		clusterName   string
+		ctx                                               = context.TODO()
+		specName                                          = "create-workload-cluster"
+		namespace                                         *corev1.Namespace
+		cancelWatches                                     context.CancelFunc
+		cluster                                           *clusterv1.Cluster
+		clusterName, standardCloudConfig, vmssCloudConfig string
 	)
 
 	BeforeEach(func() {
@@ -59,6 +59,16 @@ var _ = Describe("Workoad cluster creation", func() {
 		clusterName = fmt.Sprintf("capz-e2e-%s", util.RandomString(6))
 		Expect(os.Setenv(AzureResourceGroup, clusterName)).NotTo(HaveOccurred())
 		Expect(os.Setenv(AzureVNetName, fmt.Sprintf("%s-vnet", clusterName))).NotTo(HaveOccurred())
+
+		var err error
+		standardCloudConfig, err = getCloudProviderConfig(clusterName, "standard")
+		Expect(err).NotTo(HaveOccurred())
+
+		vmssCloudConfig, err = getCloudProviderConfig(clusterName, "vmss")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.Setenv(AzureStandardJson, standardCloudConfig)).NotTo(HaveOccurred())
+		Expect(os.Setenv(AzureVMSSJson, vmssCloudConfig)).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoids storing plain text credentials in text now that CAPBK supports secrets. This won't work on a tagged release until CAPI v0.3.7 (next release).

```release-note
Eliminate plain text credentials.
```

/hold

for capi v0.3.7