### PR TITLE
✨Make machine providerID consistent with node

### DIFF
--- a/api/v1alpha3/azuremachine_webhook_test.go
+++ b/api/v1alpha3/azuremachine_webhook_test.go
@@ -79,7 +79,7 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "azuremachine with list of user-assigned identities",
-			machine: createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:////123"}, {ProviderID: "azure:////456"}}),
+			machine: createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:///123"}, {ProviderID: "azure:///456"}}),
 			wantErr: false,
 		},
 		{
@@ -129,13 +129,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name:       "azuremachine with user assigned identities",
-			oldMachine: createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:////123"}}),
-			machine:    createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:////123"}, {ProviderID: "azure:////456"}}),
+			oldMachine: createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:///123"}}),
+			machine:    createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:///123"}, {ProviderID: "azure:///456"}}),
 			wantErr:    false,
 		},
 		{
 			name:       "azuremachine with empty user assigned identities",
-			oldMachine: createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:////123"}}),
+			oldMachine: createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:///123"}}),
 			machine:    createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{}),
 			wantErr:    true,
 		},

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -294,7 +294,7 @@ const (
 // by the user to be assigned to Azure resources.
 type UserAssignedIdentity struct {
 	// ProviderID is the identification ID of the user-assigned Identity, the format of an identity is:
-	// 'azure:////subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'
+	// 'azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'
 	ProviderID string `json:"providerID"`
 }
 

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -499,7 +499,7 @@ func TestReconcileVM(t *testing.T) {
 				Location:               "eastus",
 				Image:                  image,
 				Identity:               "UserAssigned",
-				UserAssignedIdentities: []infrav1.UserAssignedIdentity{{ProviderID: "azure:////subscriptions/123/resourcegroups/456/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"}},
+				UserAssignedIdentities: []infrav1.UserAssignedIdentity{{ProviderID: "azure:///subscriptions/123/resourcegroups/456/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1"}},
 			},
 			azureCluster: &infrav1.AzureCluster{
 				Spec: infrav1.AzureClusterSpec{

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -395,7 +395,7 @@ spec:
                   properties:
                     providerID:
                       description: 'ProviderID is the identification ID of the user-assigned
-                        Identity, the format of an identity is: ''azure:////subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'''
+                        Identity, the format of an identity is: ''azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'''
                       type: string
                   required:
                   - providerID

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -342,7 +342,7 @@ spec:
                             providerID:
                               description: 'ProviderID is the identification ID of
                                 the user-assigned Identity, the format of an identity
-                                is: ''azure:////subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'''
+                                is: ''azure:///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'''
                               type: string
                           required:
                           - providerID

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -230,7 +230,7 @@ func (r *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineSco
 	}
 
 	// Make sure Spec.ProviderID is always set.
-	machineScope.SetProviderID(fmt.Sprintf("azure:////%s", vm.ID))
+	machineScope.SetProviderID(fmt.Sprintf("azure:///%s", vm.ID))
 
 	machineScope.SetAnnotation("cluster-api-provider-azure", "true")
 

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -235,11 +235,11 @@ func (r *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, machin
 	}
 
 	// Make sure Spec.ProviderID is always set.
-	machinePoolScope.AzureMachinePool.Spec.ProviderID = fmt.Sprintf("azure:////%s", vmss.ID)
+	machinePoolScope.AzureMachinePool.Spec.ProviderID = fmt.Sprintf("azure:///%s", vmss.ID)
 	providerIDList := make([]string, len(vmss.Instances))
 	var readyCount int32
 	for i, vm := range vmss.Instances {
-		providerIDList[i] = fmt.Sprintf("azure:////%s", vm.ID)
+		providerIDList[i] = fmt.Sprintf("azure:///%s", vm.ID)
 		if vm.State == infrav1.VMStateSucceeded {
 			readyCount++
 		}


### PR DESCRIPTION
This PR makes machine providerID consistent with node providerID and fixes the similar issue that was in CAPA - https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1693


https://github.com/kubernetes/kubernetes/blob/323f34858de18b862d43c40b2cced65ad8e24052/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go#L289

**Release note:**
```release-note
✨ Make machine providerID consistent with node providerID
```