### PR TITLE
🏃 Add cluster-name to kubeadm controllerManager args

### DIFF
--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -57,6 +57,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: external
+          cluster-name: ${CLUSTER_NAME}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -57,6 +57,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
+          cluster-name: ${CLUSTER_NAME}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -57,6 +57,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
+          cluster-name: ${CLUSTER_NAME}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -57,6 +57,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
+          cluster-name: ${CLUSTER_NAME}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -57,6 +57,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
+          cluster-name: ${CLUSTER_NAME}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -68,6 +68,7 @@ spec:
           cloud-provider: azure
           cloud-config: /etc/kubernetes/azure.json
           allocate-node-cidrs: "false"
+          cluster-name: ${CLUSTER_NAME}
         extraVolumes:
           - hostPath: /etc/kubernetes/azure.json
             mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -60,6 +60,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
+          cluster-name: ${CLUSTER_NAME}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow.yaml
+++ b/templates/test/cluster-template-prow.yaml
@@ -60,6 +60,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
+          cluster-name: ${CLUSTER_NAME}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json


### PR DESCRIPTION
**What this PR does / why we need it**: Without this explicitly set, kubeadm will use the default name "kubernetes": https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults.go#L46:1

This is used, for example, by cloud-provider to name resources created such as Load Balancers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ClusterName to kubeadm ClusterConfiguration
```