### PR TITLE
✨ Spin flavor clusters as tilt resources

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -20,6 +20,7 @@
     - [Tilt for dev in CAPZ](#tilt-for-dev-in-capz)
     - [Tilt for dev in both CAPZ and CAPI](#tilt-for-dev-in-both-capz-and-capi)
     - [Deploying a workload cluster](#deploying-a-workload-cluster)
+    - [Deploying a flavor cluster as a local tilt resource](../templates/flavors/README.md#Running-flavor-clusters-as-a-tilt-resource)
   - [Manual Testing](#manual-testing)
     - [Creating a dev cluster](#creating-a-dev-cluster)
       - [Building and pushing dev images](#building-and-pushing-dev-images)
@@ -144,6 +145,8 @@ By default, the Cluster API components deployed by Tilt have experimental featur
 If you would like to enable these features, add `extra_args` as specified in [The Cluster API Book](https://cluster-api.sigs.k8s.io/developer/tilt.html#create-a-tilt-settingsjson-file).
 
 Once your kind management cluster is up and running, you can [deploy a workload cluster](#deploying-a-workload-cluster).
+
+You can also [deploy a flavor cluster as a local tilt resource](../templates/flavors/README.md#Running-flavor-clusters-as-a-tilt-resource).
 
 To tear down the kind cluster built by the command above, just run:
 

--- a/templates/flavors/README.md
+++ b/templates/flavors/README.md
@@ -14,3 +14,76 @@ appended to the end of the cluster-template.yaml, e.g cluster-template-{director
 flavor can be used by specifying `--flavor {directory-name}`.
 
 To generate all CAPZ flavors, run `make generate-flavors`.
+
+
+## Running flavor clusters as a tilt resource
+
+#### From CLI
+run ```tilt up ${flavors}``` to spin up worker clusters in Azure represented by a Tilt local resource.  You can also modify flavors while Tilt is up by running ```tilt args ${flavors}```
+
+#### From Tilt Config
+Add your desired flavors to tilt_config.json:
+```json
+{
+    "worker-flavors": ["default", "aks", "external-cloud-provider", "machinepool", "system-assigned-identity", "user-assigned-identity"]
+}
+```
+
+#### Requirements
+Please note your tilt-settings.json must contain at minimum the following fields when using tilt resources to deploy cluster flavors:
+```json
+{
+    "kustomize_substitutions": {
+        "AZURE_SUBSCRIPTION_ID_B64": "******",
+        "AZURE_TENANT_ID_B64": "******",
+        "AZURE_CLIENT_SECRET_B64": "******",
+        "AZURE_CLIENT_ID_B64": "******",
+        "AZURE_SUBSCRIPTION_ID": "******",
+        "AZURE_TENANT_ID": "******",
+        "AZURE_CLIENT_ID": "******",
+        "AZURE_CLIENT_SECRET": "******",
+        "AZURE_SSH_PUBLIC_KEY": "********"
+    }
+}
+```
+
+#### Defining Variable Overrides
+If you wish to override the default variables for flavor workers, you can specify them as part of your tilt-settings.json as seen in the example below.  Please note, the precedence of variables is as follows:
+
+1. explicitly defined vars for each flavor i.e. worker-templates.flavors[0].AZURE_VNET_NAME
+2. vars defined at 'metadata' level-- spans workers i.e. metadata.AZURE_VNET_NAME
+3. programmatically defined default vars i.e. everything except azure tenant, client, subscription
+
+
+```json
+{
+    "kustomize_substitutions": {
+        "AZURE_SUBSCRIPTION_ID_B64": "****",
+        "AZURE_TENANT_ID_B64": "****",
+        "AZURE_CLIENT_SECRET_B64": "****",
+        "AZURE_CLIENT_ID_B64": "****"
+    },
+    "worker-templates": {
+        "flavors": [{
+            "default": {
+                "CLUSTER_NAME": "example-default-cluster-name",
+                "AZURE_VNET_NAME": "example-vnet-one"
+            },
+            "system-assigned-identity": {
+                "CLUSTER_NAME": "example-SAI-cluster-name",
+                "AZURE_LOCATION": "westus",
+                "AZURE_VNET_NAME": "example-vnet-two"
+            }
+        }],
+        "metadata": {
+            "AZURE_LOCATION": "eastus",
+            "AZURE_RESOURCE_GROUP": "test-resource-group-name",
+            "CONTROL_PLANE_MACHINE_COUNT": "1",
+            "KUBERNETES_VERSION": "v1.18.3",
+            "AZURE_CONTROL_PLANE_MACHINE_TYPE": "Standard_D2s_v3",
+            "WORKER_MACHINE_COUNT": "2",
+            "AZURE_NODE_MACHINE_TYPE": "Standard_D2s_v3"
+        }
+    }
+}
+```


### PR DESCRIPTION
parent 5a7bedf05cb574a7825608561192d35b535abb9c
author James Oden <joden1995@gmail.com> 1591073777 -0400
committer James Oden <joden1995@gmail.com> 1591153490 -0400

✨ Spin flavor clusters as tilt resources

**What this PR does / why we need it**:
This is for feature #542.  This allows users to spin up worker clusters of different flavors that are represented by tilt as local resources.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #542

**Special notes for your reviewer**:
This is my first PR, thanks for the help :) 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Users can now spin up worker clusters of a particular flavor using Tilt, with the clusters being represented as a local resource.  Users can also specify custom variable overrides for the clusters in tilt-settings.json
```