### PR TITLE
🐛 Fix nodes outbound connectivity with SLB

### DIFF
--- a/api/v1alpha3/tags.go
+++ b/api/v1alpha3/tags.go
@@ -104,20 +104,23 @@ const (
 	// dedicated to this cluster api provider implementation.
 	NameAzureClusterAPIRole = NameAzureProviderPrefix + "role"
 
-	// APIServerRoleTagValue describes the value for the apiserver role
-	APIServerRoleTagValue = "apiserver"
+	// APIServerRole describes the value for the apiserver role
+	APIServerRole = "apiserver"
 
-	// BastionRoleTagValue describes the value for the bastion role
-	BastionRoleTagValue = "bastion"
+	// NodeOutboundRole describes the value for the node outbound LB role
+	NodeOutboundRole = "nodeOutbound"
 
-	// CommonRoleTagValue describes the value for the common role
-	CommonRoleTagValue = "common"
+	// BastionRole describes the value for the bastion role
+	BastionRole = "bastion"
 
-	// PublicRoleTagValue describes the value for the public role
-	PublicRoleTagValue = "public"
+	// CommonRole describes the value for the common role
+	CommonRole = "common"
 
-	// PrivateRoleTagValue describes the value for the private role
-	PrivateRoleTagValue = "private"
+	// PublicRole describes the value for the public role
+	PublicRole = "public"
+
+	// PrivateRole describes the value for the private role
+	PrivateRole = "private"
 )
 
 // ClusterTagKey generates the key for resources associated with a cluster.

--- a/cloud/defaults.go
+++ b/cloud/defaults.go
@@ -79,6 +79,11 @@ func GeneratePublicIPName(clusterName, hash string) string {
 	return fmt.Sprintf("%s-%s", clusterName, hash)
 }
 
+// GenerateNodeOutboundIPName generates a public IP name, based on the cluster name.
+func GenerateNodeOutboundIPName(clusterName string) string {
+	return fmt.Sprintf("pip-%s-node-outbound", clusterName)
+}
+
 // GenerateNodePublicIPName generates a node public IP name, based on the NIC name.
 func GenerateNodePublicIPName(nicName string) string {
 	return fmt.Sprintf("%s-public-ip", nicName)

--- a/cloud/services/groups/groups.go
+++ b/cloud/services/groups/groups.go
@@ -51,7 +51,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			ClusterName: s.Scope.Name(),
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			Name:        to.StringPtr(s.Scope.ResourceGroup()),
-			Role:        to.StringPtr(infrav1.CommonRoleTagValue),
+			Role:        to.StringPtr(infrav1.CommonRole),
 			Additional:  s.Scope.AdditionalTags(),
 		})),
 	}

--- a/cloud/services/scalesets/service.go
+++ b/cloud/services/scalesets/service.go
@@ -17,19 +17,22 @@ package scalesets
 
 import (
 	"github.com/Azure/go-autorest/autorest"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/publicloadbalancers"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/resourceskus"
 )
 
 // Service provides operations on azure resources
 type Service struct {
 	Client
-	ResourceSkusClient resourceskus.Client
+	ResourceSkusClient        resourceskus.Client
+	PublicLoadBalancersClient publicloadbalancers.Client
 }
 
 // NewService creates a new service.
 func NewService(authorizer autorest.Authorizer, subscriptionID string) *Service {
 	return &Service{
-		Client:             NewClient(subscriptionID, authorizer),
-		ResourceSkusClient: resourceskus.NewClient(subscriptionID, authorizer),
+		Client:                    NewClient(subscriptionID, authorizer),
+		ResourceSkusClient:        resourceskus.NewClient(subscriptionID, authorizer),
+		PublicLoadBalancersClient: publicloadbalancers.NewClient(subscriptionID, authorizer),
 	}
 }

--- a/cloud/services/virtualnetworks/virtualnetworks.go
+++ b/cloud/services/virtualnetworks/virtualnetworks.go
@@ -98,7 +98,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			ClusterName: s.Scope.Name(),
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			Name:        to.StringPtr(vnetSpec.Name),
-			Role:        to.StringPtr(infrav1.CommonRoleTagValue),
+			Role:        to.StringPtr(infrav1.CommonRole),
 			Additional:  s.Scope.AdditionalTags(),
 		})),
 		Location: to.StringPtr(s.Scope.Location()),

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -490,20 +490,21 @@ func (s *azureMachinePoolService) CreateOrUpdate() (*infrav1exp.VMSS, error) {
 	}
 
 	vmssSpec := &scalesets.Spec{
-		Name:                  s.machinePoolScope.Name(),
-		ResourceGroup:         s.clusterScope.ResourceGroup(),
-		Location:              s.clusterScope.Location(),
-		ClusterName:           s.clusterScope.Name(),
-		MachinePoolName:       s.machinePoolScope.Name(),
-		Sku:                   ampSpec.Template.VMSize,
-		Capacity:              replicas,
-		SSHKeyData:            string(decoded),
-		Image:                 image,
-		OSDisk:                ampSpec.Template.OSDisk,
-		CustomData:            bootstrapData,
-		AdditionalTags:        s.machinePoolScope.AdditionalTags(),
-		SubnetID:              s.clusterScope.AzureCluster.Spec.NetworkSpec.Subnets[0].ID,
-		AcceleratedNetworking: ampSpec.Template.AcceleratedNetworking,
+		Name:                   s.machinePoolScope.Name(),
+		ResourceGroup:          s.clusterScope.ResourceGroup(),
+		Location:               s.clusterScope.Location(),
+		ClusterName:            s.clusterScope.Name(),
+		MachinePoolName:        s.machinePoolScope.Name(),
+		Sku:                    ampSpec.Template.VMSize,
+		Capacity:               replicas,
+		SSHKeyData:             string(decoded),
+		Image:                  image,
+		OSDisk:                 ampSpec.Template.OSDisk,
+		CustomData:             bootstrapData,
+		AdditionalTags:         s.machinePoolScope.AdditionalTags(),
+		SubnetID:               s.clusterScope.AzureCluster.Spec.NetworkSpec.Subnets[0].ID,
+		PublicLoadBalancerName: s.clusterScope.Name(),
+		AcceleratedNetworking:  ampSpec.Template.AcceleratedNetworking,
 	}
 
 	err = s.virtualMachinesScaleSetSvc.Reconcile(context.TODO(), vmssSpec)


### PR DESCRIPTION
**What this PR does / why we need it**: This implements outbound connectivity for all nodes as described in https://github.com/kubernetes-sigs/cloud-provider-azure/tree/master/docs/services#standard-loadbalancer. For each Azure cluster, a new node outbound public IP and public Load Balancer will be created. The Load Balancer's name is the cluster name so that cloud provider can detect the LB exists and reuse the same LB for exposing services. This LB will be created with a backend pool and each node machine (all VMs that are not control-planes) will be added to this backend pool on its creation.  The LB will also have outbound rules defined to allow UDP and TCP outbound traffic from all nodes, as described in[ Azure docs](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections#proto).

See also:
https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially addresses #648 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix nodes outbound connectivity with Standard Load Balancer
```