### PR TITLE
🐛 MachinePool template must have vmType vmss in control plane azure.json

### DIFF
--- a/docs/topics/machinepools.md
+++ b/docs/topics/machinepools.md
@@ -36,6 +36,8 @@ Cluster API Provider Azure (CAPZ) has experimental support for `MachinePool` tho
 type `AzureMachinePool`. An `AzureMachinePool` corresponds to an [Azure Virtual Machine Scale Set](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/overview),
 which provides the cloud provider specific resource for orchestrating a group of Virtual Machines.
 
+⚠️ Cloud provider for Azure does not currently support clusters in mixed mode (both vmss and vmas node pools), so it is not supported to have both `AzureMachinePools` and `AzureMachines` in the same workload cluster.
+
 ### Using `clusterctl` to deploy
 To deploy a MachinePool / AzureMachinePool via `clusterctl config` there's a [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/config-cluster.html#flavors) 
 for that.

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -74,7 +74,7 @@ spec:
           "resourceGroup": "${AZURE_RESOURCE_GROUP}",
           "securityGroupName": "${CLUSTER_NAME}-node-nsg",
           "location": "${AZURE_LOCATION}",
-          "vmType": "standard",
+          "vmType": "vmss",
           "vnetName": "${CLUSTER_NAME}-vnet",
           "vnetResourceGroup": "${CLUSTER_NAME}",
           "subnetName": "${CLUSTER_NAME}-node-subnet",

--- a/templates/flavors/machinepool/kustomization.yaml
+++ b/templates/flavors/machinepool/kustomization.yaml
@@ -2,3 +2,5 @@ namespace: default
 resources:
   - ../base
   - machine-pool-deployment.yaml
+patchesStrategicMerge:
+  - patches/control-plane-azure-file.yaml

--- a/templates/flavors/machinepool/patches/control-plane-azure-file.yaml
+++ b/templates/flavors/machinepool/patches/control-plane-azure-file.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  kubeadmConfigSpec:
+    files:
+    - content: |
+        {
+          "cloud": "AzurePublicCloud",
+          "tenantId": "${AZURE_TENANT_ID}",
+          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
+          "aadClientId": "${AZURE_CLIENT_ID}",
+          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
+          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
+          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
+          "location": "${AZURE_LOCATION}",
+          "vmType": "vmss",
+          "vnetName": "${CLUSTER_NAME}-vnet",
+          "vnetResourceGroup": "${CLUSTER_NAME}",
+          "subnetName": "${CLUSTER_NAME}-node-subnet",
+          "routeTableName": "${CLUSTER_NAME}-node-routetable",
+          "userAssignedID": "${CLUSTER_NAME}",
+          "loadBalancerSku": "standard",
+          "maximumLoadBalancerRuleCount": 250,
+          "useManagedIdentityExtension": false,
+          "useInstanceMetadata": true
+        }
+      owner: root:root
+      path: /etc/kubernetes/azure.json
+      permissions: "0644"

--- a/templates/test/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/cluster-template-prow-machine-pool.yaml
@@ -77,7 +77,7 @@ spec:
           "resourceGroup": "${AZURE_RESOURCE_GROUP}",
           "securityGroupName": "${CLUSTER_NAME}-node-nsg",
           "location": "${AZURE_LOCATION}",
-          "vmType": "standard",
+          "vmType": "vmss",
           "vnetName": "${CLUSTER_NAME}-vnet",
           "vnetResourceGroup": "${CLUSTER_NAME}",
           "subnetName": "${CLUSTER_NAME}-node-subnet",


### PR DESCRIPTION
**What this PR does / why we need it**: This fixes an issue where the cloud provider is unable to find vmss instances when using MachinePool because it tries to find them as availability sets:

```
Warning  SyncLoadBalancerFailed  10m (x19 over 75m)  service-controller  Error syncing load balancer: failed to ensure load balancer: ensure(ingress-nginx/ingress-nginx-controller): backendPoolID(/subscriptions/85d99e6d-f6d6-408f-a9f1-b7a97237d5c4/resourceGroups/capz-vmss/providers/Microsoft.Network/loadBalancers/capz-vmss/backendAddressPools/capz-vmss) - failed to ensure host in pool: "instance not found"
``` 

As a follow up, I'd like to investigate if and how Azure cloud provider could support vmss and vmas in the same cluster (https://github.com/kubernetes-sigs/cloud-provider-azure/issues/338)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially addresses #648 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change MachinePool template vmType to "vmss" in control plane azure.json
⚠️ Cloud provider for Azure does not currently support clusters in mixed mode (both vmss and vmas node pools), so it is not supported to have both `AzureMachinePools` and `AzureMachines` in the same workload cluster.
```