### PR TITLE
feat: tilt flavors with b64 secrets and default pub key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ bazel-*
 .tiltbuild
 /tilt.d
 tilt-settings.json
+tilt_config.json
 
 # e2e output
 test/e2e/junit.e2e_suite.*.xml

--- a/templates/flavors/README.md
+++ b/templates/flavors/README.md
@@ -38,11 +38,6 @@ Please note your tilt-settings.json must contain at minimum the following fields
         "AZURE_TENANT_ID_B64": "******",
         "AZURE_CLIENT_SECRET_B64": "******",
         "AZURE_CLIENT_ID_B64": "******",
-        "AZURE_SUBSCRIPTION_ID": "******",
-        "AZURE_TENANT_ID": "******",
-        "AZURE_CLIENT_ID": "******",
-        "AZURE_CLIENT_SECRET": "******",
-        "AZURE_SSH_PUBLIC_KEY": "********"
     }
 }
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

I started using the new tilt flavors and ran into an issue where we are duplicating kustomize substitutions for Azure secrets and public key data. I thought it would be nice to use the existing base64 encoded secrets from `tilt-settings.json`.

Also added `tilt_config.json` to the `.gitignore`.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reuse base64 encoded secrets and default public key when deploying template flavors with Tilt.
```