### PR TITLE
🐛  do not use 'source' to call log dump script & fix 1.17 test failure

### DIFF
--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -40,8 +40,8 @@ verify_kind_version() {
   fi
 
   local kind_version
-  kind_version=$(kind version)
-   if ! [[ "${kind_version}" =~ ${MINIMUM_KIND_VERSION} ]]; then
+  IFS=" " read -ra kind_version <<< "$(kind version)"
+  if [[ "${MINIMUM_KIND_VERSION}" != $(echo -e "${MINIMUM_KIND_VERSION}\n${kind_version[1]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
     cat <<EOF
 Detected kind version: ${kind_version}.
 Requires ${MINIMUM_KIND_VERSION} or greater.

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -36,10 +36,6 @@ source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 # shellcheck source=../hack/parse-prow-creds.sh
 source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 
-random-string() {
-    cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1
-}
-
 # build Kubernetes E2E binaries
 build_k8s() {
     # possibly enable bazel build caching before building kubernetes
@@ -138,10 +134,7 @@ run_upstream_e2e_tests() {
 
 # cleanup all resources we use
 cleanup() {
-    timeout 600 kubectl \
-        delete cluster "${CLUSTER_NAME}" || true
-        timeout 600 kubectl \
-        wait --for=delete cluster/"${CLUSTER_NAME}" || true
+    timeout 1800 kubectl delete cluster "${CLUSTER_NAME}" || true
     make kind-reset || true
     # clean up e2e.test symlink
     (cd "$(go env GOPATH)/src/k8s.io/kubernetes" && rm -f _output/bin/e2e.test) || true
@@ -149,7 +142,7 @@ cleanup() {
 
 on_exit() {
     unset KUBECONFIG
-    source "${REPO_ROOT}/hack/log/log-dump.sh"
+    ${REPO_ROOT}/hack/log/log-dump.sh || true
     # cleanup
     if [[ -z "${SKIP_CLEANUP:-}" ]]; then
         cleanup

--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -113,7 +113,10 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
               $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"
@@ -305,7 +308,10 @@ spec:
                 DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
               done
             else
-              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+              CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+              if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
+                CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+              fi
               for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
                 echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
                 $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -113,7 +113,10 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
               $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"
@@ -300,7 +303,10 @@ spec:
             DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
           done
         else
-          CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+          CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+          if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
+            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+          fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
             $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"

--- a/templates/test/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -58,7 +58,10 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
               $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"
@@ -164,7 +167,10 @@ spec:
                   DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
                 done
               else
-                CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+                CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+                if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
+                  CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+                fi
                 for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
                   echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
                   $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"

--- a/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -58,7 +58,10 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
               $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"
@@ -162,7 +165,10 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
               $${GSUTIL} cp "$$CI_URL/$$CI_PACKAGE" "$$CI_DIR/$$CI_PACKAGE"


### PR DESCRIPTION
**What this PR does / why we need it**:

- fix `ensure-kind.sh` to properly compare user's kind version with the minimum kind version.
- `cleanup` function in `ci-entrypoint.sh` isn't executed, causing a quota issue in the upstream test subscription. This is fixed by calling `./hack/log/log-dump.sh` directly instead of using `source`.
- use `gs://kubernetes-release-dev/ci-periodic` for downloading specific ci version of K8s. If the bucket does not exist, use `gs://kubernetes-release-dev/ci` instead. This will fix the 1.17 test issue where `gs://kubernetes-release-dev/ci/v1.17.7-rc.0.22+8885823091bd64` does not exist due to a build failure.

/test pull-cluster-api-provider-azure-conformance-v1alpha3
/test pull-cluster-api-provider-azure-conformance-machine-pool-v1alpha3

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```