### PR TITLE
🌱 remove extra image validation in the Azure Machine controller

### DIFF
--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -24,8 +24,6 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/scope"
@@ -196,17 +194,6 @@ func (r *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineSco
 	if machineScope.Machine.Spec.Bootstrap.DataSecretName == nil {
 		machineScope.Info("Bootstrap data secret reference is not yet available")
 		return reconcile.Result{}, nil
-	}
-
-	// Check that the image is valid
-	// NOTE: this validation logic is also in the validating webhook
-	if machineScope.AzureMachine.Spec.Image != nil {
-		if errs := infrav1.ValidateImage(machineScope.AzureMachine.Spec.Image, field.NewPath("image")); len(errs) > 0 {
-			agg := kerrors.NewAggregate(errs.ToAggregate().Errors())
-			machineScope.Info("Invalid image: %s", agg.Error())
-			r.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "InvalidImage", "Invalid image: %s", agg.Error())
-			return reconcile.Result{}, nil
-		}
 	}
 
 	if machineScope.AzureMachine.Spec.AvailabilityZone.ID != nil {

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -199,16 +199,15 @@ func (s *azureMachineService) getVirtualMachineZone() (string, error) {
 
 func (s *azureMachineService) reconcileNetworkInterface(nicName string) error {
 	networkInterfaceSpec := &networkinterfaces.Spec{
-		Name:        nicName,
-		VnetName:    s.clusterScope.Vnet().Name,
-		MachineRole: s.machineScope.Role(),
+		Name:                  nicName,
+		VnetName:              s.clusterScope.Vnet().Name,
+		MachineRole:           s.machineScope.Role(),
+		AcceleratedNetworking: s.machineScope.AzureMachine.Spec.AcceleratedNetworking,
 	}
 
 	if s.machineScope.AzureMachine.Spec.AllocatePublicIP == true {
 		networkInterfaceSpec.PublicIPName = azure.GenerateNodePublicIPName(nicName)
 	}
-
-	networkInterfaceSpec.AcceleratedNetworking = s.machineScope.AzureMachine.Spec.AcceleratedNetworking
 
 	switch role := s.machineScope.Role(); role {
 	case infrav1.Node:

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -25,13 +25,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -212,18 +209,6 @@ func (r *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, machin
 	if machinePoolScope.MachinePool.Spec.Template.Spec.Bootstrap.DataSecretName == nil {
 		machinePoolScope.Info("Bootstrap data secret reference is not yet available")
 		return reconcile.Result{}, nil
-	}
-
-	// Check that the image is valid
-	// NOTE: this validation logic is also in the validating webhook
-	if machinePoolScope.AzureMachinePool.Spec.Template.Image != nil {
-		image := machinePoolScope.AzureMachinePool.Spec.Template.Image
-		if errs := infrav1.ValidateImage(image, field.NewPath("image")); len(errs) > 0 {
-			agg := kerrors.NewAggregate(errs.ToAggregate().Errors())
-			machinePoolScope.Info("Invalid image: %s", agg.Error())
-			r.Recorder.Eventf(machinePoolScope.AzureMachinePool, corev1.EventTypeWarning, "InvalidImage", "Invalid image: %s", agg.Error())
-			return reconcile.Result{}, nil
-		}
 	}
 
 	ams := newAzureMachinePoolService(machinePoolScope, clusterScope)


### PR DESCRIPTION
**What this PR does / why we need it**: The AzureMachine webhook is already validating `Spec.Image` [here](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/4a0b011a5c2ac8e0b106f4863850761f805a5916/api/v1alpha3/azuremachine_webhook.go#L47). This duplicate validation in the controller was added at the time where the defaulting webhooks were not working properly, removing now that it isn't the case anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```