### PR TITLE
Fix route table reconciliation

### DIFF
--- a/cloud/services/routetables/routetables.go
+++ b/cloud/services/routetables/routetables.go
@@ -18,7 +18,6 @@ package routetables
 
 import (
 	"context"
-
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -41,8 +40,27 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	if !ok {
 		return errors.New("invalid Route Table Specification")
 	}
+
+	existingRouteTable, err := s.Get(ctx, s.Scope.ResourceGroup(), routeTableSpec.Name)
+	if !azure.ResourceNotFound(err) {
+		if err != nil {
+			return errors.Wrapf(err, "failed to get route table %s in %s", routeTableSpec.Name, s.Scope.ResourceGroup())
+		}
+
+		// route table already exists
+		// currently don't support:
+		//  1. creating separate control plane and node (#718) so update both
+		//  2. can not specify your own routes via spec
+		s.Scope.NodeSubnet().RouteTable.Name = to.String(existingRouteTable.Name)
+		s.Scope.NodeSubnet().RouteTable.ID = to.String(existingRouteTable.ID)
+		s.Scope.ControlPlaneSubnet().RouteTable.Name = to.String(existingRouteTable.Name)
+		s.Scope.ControlPlaneSubnet().RouteTable.ID = to.String(existingRouteTable.ID)
+
+		return nil
+	}
+
 	klog.V(2).Infof("creating route table %s", routeTableSpec.Name)
-	err := s.Client.CreateOrUpdate(
+	err = s.Client.CreateOrUpdate(
 		ctx,
 		s.Scope.ResourceGroup(),
 		routeTableSpec.Name,

--- a/cloud/services/routetables/routetables.go
+++ b/cloud/services/routetables/routetables.go
@@ -50,7 +50,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 		// route table already exists
 		// currently don't support:
 		//  1. creating separate control plane and node (#718) so update both
-		//  2. can not specify your own routes via spec
+		//  2. specifying your own routes via spec
 		s.Scope.NodeSubnet().RouteTable.Name = to.String(existingRouteTable.Name)
 		s.Scope.NodeSubnet().RouteTable.ID = to.String(existingRouteTable.ID)
 		s.Scope.ControlPlaneSubnet().RouteTable.Name = to.String(existingRouteTable.Name)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:
When create the route table it pushes updates to the route table on every reconciliation which conflicts with the cloud controller manager.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #682 

**Special notes for your reviewer**:
Originally thought we might use etags, but since we don't set any other properties beyond the name of the route, once created we can avoid updating.  If in the future we want to be able to create specific routes via the spec we could update the spec to add routes and use etags to push the updates. I am not sure there is a use case (wasn't something you could do in aks-engine as far as I could tell) so will forgo for now. 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
route table is created once and works with route creation turned on for controller manager
```