### PR TITLE
fix internallb subnet addressing

### DIFF
--- a/cloud/services/internalloadbalancers/internalloadbalancers.go
+++ b/cloud/services/internalloadbalancers/internalloadbalancers.go
@@ -19,6 +19,7 @@ package internalloadbalancers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -171,7 +172,8 @@ func (s *Service) getAvailablePrivateIP(ctx context.Context, resourceGroup, vnet
 		ip = azure.DefaultInternalLBIPAddress
 		if subnetCIDR != infrav1.DefaultControlPlaneSubnetCIDR {
 			// If the user provided a custom subnet CIDR without providing a private IP, try finding an available IP in the subnet space
-			ip = subnetCIDR[0:7] + "0"
+			index := strings.LastIndex(subnetCIDR, ".")
+			ip = subnetCIDR[0:(index+1)] + "0"
 		}
 	}
 	result, err := s.VirtualNetworksClient.CheckIPAddressAvailability(ctx, resourceGroup, vnetName, ip)


### PR DESCRIPTION
This fixes assumptions in the controlplane cidr when selecting the address for the internal load balancer.

Fixes #723


**Release Note:**

```release-note
Default internal loadbalancer address selection broken for CIDR not 8 characters in length.
```
