### PR TITLE
🐛 Use node-subnet for AzureMachinePool VMSS

### DIFF
--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -524,7 +524,7 @@ func (s *azureMachinePoolService) CreateOrUpdate(ctx context.Context) (*infrav1e
 		OSDisk:                 ampSpec.Template.OSDisk,
 		CustomData:             bootstrapData,
 		AdditionalTags:         s.machinePoolScope.AdditionalTags(),
-		SubnetID:               s.clusterScope.AzureCluster.Spec.NetworkSpec.Subnets[0].ID,
+		SubnetID:               s.clusterScope.AzureCluster.Spec.NetworkSpec.GetNodeSubnet().ID,
 		PublicLoadBalancerName: s.clusterScope.Name(),
 		AcceleratedNetworking:  ampSpec.Template.AcceleratedNetworking,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When deploying a cluster with `AzureMachinePool`, the VMSS is incorrectly deployed to control plane subnet. This fixes the issue by using node-subnet for VMSS.

**Which issue(s) this PR fixes**:
Fixes #712

**Release note**:

```release-note
When using machine pools VMSS is now deployed to *-node-subnet.
```
