### PR TITLE
:bug: Add resource group to the spec of the AzureMachinePool delete

### DIFF
--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -560,7 +560,8 @@ func (s *azureMachinePoolService) CreateOrUpdate(ctx context.Context) (*infrav1e
 // Delete reconciles all the services in pre determined order
 func (s *azureMachinePoolService) Delete(ctx context.Context) error {
 	vmssSpec := &scalesets.Spec{
-		Name: s.machinePoolScope.Name(),
+		Name:          s.machinePoolScope.Name(),
+		ResourceGroup: s.clusterScope.ResourceGroup(),
 	}
 
 	err := s.virtualMachinesScaleSetSvc.Delete(ctx, vmssSpec)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

This PR fixes the error where `AzureMachinePool` delete would throw an error complaining about missing the latest Azure API version. The issue stems from the Virtual Machine Scale Set resource group being omitted from the SDK request. That's not 100% accurate, the value of the resource group was actually `""`, so when the SDK added that to the URI it uses to address Azure, the resource provider didn't understand the resource the SDK was addressing, thus the incorrect API version b/c Azure didn't know of the resource within that API version.

/cc @mboersma 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #635

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix incorrect API version error when deleting an `AzureMachinePool`
```