### PR TITLE
🐛 fix AzureCluster reconcile loop cycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifneq ($(abspath $(ROOT_DIR)),$(GOPATH)/src/sigs.k8s.io/cluster-api-provider-azu
 endif
 
 # Binaries.
-CONTROLLER_GEN_VER := v0.2.9
+CONTROLLER_GEN_VER := v0.3.0
 CONTROLLER_GEN_BIN := controller-gen
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER)
 

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: azuremachinepools.exp.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedclusters.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: azuremanagedclusters.exp.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: azuremanagedcontrolplanes.exp.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: azuremanagedmachinepools.exp.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: azureclusters.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: azuremachines.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: azuremachinetemplates.infrastructure.cluster.x-k8s.io
 spec:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

With the update to watches in the controllers in #691, the `AzureClusterReconciler` causes a reconcile cycle. That is to say, when the `AzureCluster` reconciles, it constantly mutates its spec, which then causes `AzureMachine` to reconcile, which then causes `AzureCluster` to reconcile, ad infinitum.

~~Why would the `AzureClusterReconciler` keep updating itself if there is no mutated data being changed in the spec? Well, inadvertently, we are mutating the [`Subnets` slice](https://github.com/devigned/cluster-api-provider-azure/blob/5a528aafb2cf5812a3f498cf5f0b7709ce254462/api/v1alpha3/types.go#L53), because in the current state, the array is wholly replaced atomically in the server side patch.~~

~~This PR adds a more granular approach to patching the slice through the use of [`listType` decorator](https://kubernetes.io/docs/reference/using-api/api-concepts/#merge-strategy). This should allow a server side merge patch rather than a complete replace of the Subnets array.~~

This PR simply sets the name of the security group and route table to the spec provided name, because the GET request to Azure only includes the ID for the sub resources of the subnet.


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix reconcile cycle in `AzureClusterReconciler` caused by setting an empty string for security group and route table name.
```