### PR TITLE
bug: replaced deprecated NewFakeClient with NewFakeClientWithScheme

### DIFF
--- a/cloud/services/availabilityzones/availabilityzones_test.go
+++ b/cloud/services/availabilityzones/availabilityzones_test.go
@@ -125,7 +125,7 @@ func TestGetAvailabilityZones(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(azMock.EXPECT())
 

--- a/cloud/services/disks/disks_test.go
+++ b/cloud/services/disks/disks_test.go
@@ -54,7 +54,7 @@ func TestInvalidDiskSpec(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 	}
 
-	client := fake.NewFakeClient(cluster)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 		AzureClients: scope.AzureClients{
@@ -138,7 +138,7 @@ func TestDeleteDisk(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(disksMock.EXPECT())
 

--- a/cloud/services/groups/groups_test.go
+++ b/cloud/services/groups/groups_test.go
@@ -132,7 +132,7 @@ func TestReconcileGroups(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(groupsMock.EXPECT())
 
@@ -316,7 +316,7 @@ func TestDeleteGroups(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(groupsMock.EXPECT())
 

--- a/cloud/services/internalloadbalancers/internalloadbalancers_test.go
+++ b/cloud/services/internalloadbalancers/internalloadbalancers_test.go
@@ -58,7 +58,7 @@ func TestInvalidInternalLBSpec(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 	}
 
-	client := fake.NewFakeClient(cluster)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 		AzureClients: scope.AzureClients{
@@ -215,7 +215,7 @@ func TestReconcileInternalLoadBalancer(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(internalLBMock.EXPECT(), vnetMock.EXPECT(), subnetMock.EXPECT())
 
@@ -324,7 +324,7 @@ func TestDeleteInternalLB(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(internalLBMock.EXPECT())
 

--- a/cloud/services/networkinterfaces/networkinterfaces_test.go
+++ b/cloud/services/networkinterfaces/networkinterfaces_test.go
@@ -64,7 +64,7 @@ func TestInvalidNetworkInterface(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 	}
 
-	client := fake.NewFakeClient(cluster)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 		AzureClients: scope.AzureClients{
@@ -581,7 +581,7 @@ func TestReconcileNetworkInterface(t *testing.T) {
 			cluster := &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 				AzureClients: scope.AzureClients{
@@ -789,7 +789,7 @@ func TestDeleteNetworkInterface(t *testing.T) {
 			cluster := &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 				AzureClients: scope.AzureClients{

--- a/cloud/services/publicips/publicips_test.go
+++ b/cloud/services/publicips/publicips_test.go
@@ -55,7 +55,7 @@ func TestInvalidPublicIPSpec(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 	}
 
-	client := fake.NewFakeClient(cluster)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 		AzureClients: scope.AzureClients{
@@ -133,7 +133,7 @@ func TestReconcilePublicLoadBalancer(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(publicIPsMock.EXPECT())
 
@@ -224,7 +224,7 @@ func TestDeletePublicIP(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(publicIPsMock.EXPECT())
 

--- a/cloud/services/publicloadbalancers/publicloadbalancers_test.go
+++ b/cloud/services/publicloadbalancers/publicloadbalancers_test.go
@@ -58,7 +58,7 @@ func TestInvalidPublicLBSpec(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 	}
 
-	client := fake.NewFakeClient(cluster)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 		AzureClients: scope.AzureClients{
@@ -310,7 +310,7 @@ func TestReconcilePublicLoadBalancer(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(publicLBMock.EXPECT(), publicIPsMock.EXPECT())
 
@@ -405,7 +405,7 @@ func TestDeletePublicLB(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(publicLBMock.EXPECT())
 

--- a/cloud/services/routetables/routetables_test.go
+++ b/cloud/services/routetables/routetables_test.go
@@ -56,7 +56,7 @@ func TestInvalidRouteTableSpec(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 	}
 
-	client := fake.NewFakeClient(cluster)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 		AzureClients: scope.AzureClients{
@@ -200,7 +200,7 @@ func TestReconcileRouteTables(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(routetableMock.EXPECT())
 
@@ -334,7 +334,7 @@ func TestDeleteRouteTable(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(routetableMock.EXPECT())
 

--- a/cloud/services/securitygroups/securitygroups_test.go
+++ b/cloud/services/securitygroups/securitygroups_test.go
@@ -91,7 +91,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(sgMock.EXPECT(), sgMock.EXPECT())
 
@@ -161,7 +161,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(sgMock.EXPECT())
 

--- a/cloud/services/subnets/subnets_test.go
+++ b/cloud/services/subnets/subnets_test.go
@@ -153,7 +153,7 @@ func TestReconcileSubnets(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(subnetMock.EXPECT(), rtMock.EXPECT(), sgMock.EXPECT())
 
@@ -261,7 +261,7 @@ func TestDeleteSubnets(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(subnetMock.EXPECT())
 

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -61,7 +61,7 @@ func TestInvalidVM(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 	}
 
-	client := fake.NewFakeClient(cluster)
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 		AzureClients: scope.AzureClients{
@@ -295,7 +295,7 @@ func TestGetVM(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(vmMock.EXPECT(), interfaceMock.EXPECT(), publicIPMock.EXPECT())
 
@@ -624,7 +624,7 @@ func TestReconcileVM(t *testing.T) {
 				},
 			}
 
-			client := fake.NewFakeClient(secret, cluster, &tc.machine)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, secret, cluster, &tc.machine)
 
 			machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
 				Client:  client,
@@ -732,7 +732,7 @@ func TestDeleteVM(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(publicIPsMock.EXPECT())
 

--- a/cloud/services/virtualnetworks/virtualnetworks_test.go
+++ b/cloud/services/virtualnetworks/virtualnetworks_test.go
@@ -136,7 +136,7 @@ func TestReconcileVnet(t *testing.T) {
 				Spec:       clusterv1.ClusterSpec{},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(vnetMock.EXPECT())
 
@@ -228,7 +228,7 @@ func TestDeleteVnet(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
 			}
 
-			client := fake.NewFakeClient(cluster)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, cluster)
 
 			tc.expect(vnetMock.EXPECT())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR address code changes that replace NewFakeClient() which is deprecated with NewFakeCleintWithSchema() with schema passed as explicit parameter in go unit test files.

**Which issue(s) this PR fixes** 
https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/726

**Special notes for your reviewer**:
verified : make test in local setup.

**Release Note**:
```release-note
NONE
``` 