### PR TITLE
🐛 tests: add missing mockCtrl.Finish()

### DIFF
--- a/cloud/services/agentpools/agentpools_test.go
+++ b/cloud/services/agentpools/agentpools_test.go
@@ -38,6 +38,8 @@ func TestInvalidAgentPoolsSpec(t *testing.T) {
 	g := NewWithT(t)
 
 	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	agentpoolsMock := mock_agentpools.NewMockClient(mockCtrl)
 
 	s := &Service{
@@ -104,6 +106,8 @@ func TestReconcile(t *testing.T) {
 				g := NewWithT(t)
 
 				mockCtrl := gomock.NewController(t)
+				defer mockCtrl.Finish()
+
 				agentpoolsMock := mock_agentpools.NewMockClient(mockCtrl)
 
 				tc.expect(agentpoolsMock.EXPECT(), provisioningstate)
@@ -118,7 +122,6 @@ func TestReconcile(t *testing.T) {
 					g.Expect(err).To(MatchError(tc.expectedError))
 				} else {
 					g.Expect(err).NotTo(HaveOccurred())
-					mockCtrl.Finish()
 				}
 			})
 		}
@@ -250,6 +253,8 @@ func TestReconcile(t *testing.T) {
 			g := NewWithT(t)
 
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			agentpoolsMock := mock_agentpools.NewMockClient(mockCtrl)
 
 			tc.expect(agentpoolsMock.EXPECT())
@@ -264,7 +269,6 @@ func TestReconcile(t *testing.T) {
 				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
-				mockCtrl.Finish()
 			}
 		})
 	}
@@ -322,6 +326,8 @@ func TestDeleteAgentPools(t *testing.T) {
 			g := NewWithT(t)
 
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			agentPoolsMock := mock_agentpools.NewMockClient(mockCtrl)
 
 			tc.expect(agentPoolsMock.EXPECT())

--- a/cloud/services/availabilityzones/availabilityzones_test.go
+++ b/cloud/services/availabilityzones/availabilityzones_test.go
@@ -51,6 +51,8 @@ func TestInvalidAvailabilityZonesSpec(t *testing.T) {
 	g := NewWithT(t)
 
 	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	agentpoolsMock := mock_availabilityzones.NewMockClient(mockCtrl)
 
 	s := &Service{
@@ -119,6 +121,8 @@ func TestGetAvailabilityZones(t *testing.T) {
 			g := NewWithT(t)
 
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			azMock := mock_availabilityzones.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/cloud/services/disks/disks_test.go
+++ b/cloud/services/disks/disks_test.go
@@ -48,6 +48,8 @@ func TestInvalidDiskSpec(t *testing.T) {
 	g := NewWithT(t)
 
 	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	disksMock := mock_disks.NewMockClient(mockCtrl)
 
 	cluster := &clusterv1.Cluster{
@@ -89,8 +91,6 @@ func TestInvalidDiskSpec(t *testing.T) {
 }
 
 func TestDeleteDisk(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name          string
 		disksSpec     Spec
@@ -131,7 +131,11 @@ func TestDeleteDisk(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			disksMock := mock_disks.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/cloud/services/groups/groups_test.go
+++ b/cloud/services/groups/groups_test.go
@@ -46,8 +46,6 @@ const (
 )
 
 func TestReconcileGroups(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name               string
 		clusterScopeParams scope.ClusterScopeParams
@@ -73,7 +71,6 @@ func TestReconcileGroups(t *testing.T) {
 			},
 			expectedError: "",
 			expect: func(m *mock_groups.MockClientMockRecorder) {
-				m.CreateOrUpdate(context.TODO(), "my-rg", gomock.AssignableToTypeOf(resources.Group{}))
 				m.Get(context.TODO(), "my-rg").Return(resources.Group{}, nil)
 			},
 		},
@@ -125,7 +122,11 @@ func TestReconcileGroups(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			groupsMock := mock_groups.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{
@@ -158,8 +159,6 @@ func TestReconcileGroups(t *testing.T) {
 }
 
 func TestDeleteGroups(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name               string
 		clusterScopeParams scope.ClusterScopeParams
@@ -185,7 +184,6 @@ func TestDeleteGroups(t *testing.T) {
 			},
 			expectedError: "could not get resource group management state: #: Internal Server Error: StatusCode=500",
 			expect: func(m *mock_groups.MockClientMockRecorder) {
-				m.Delete(context.TODO(), "my-rg")
 				m.Get(context.TODO(), "my-rg").Return(resources.Group{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 			},
 		},
@@ -205,7 +203,6 @@ func TestDeleteGroups(t *testing.T) {
 			},
 			expectedError: "",
 			expect: func(m *mock_groups.MockClientMockRecorder) {
-				m.Delete(context.TODO(), "my-rg")
 				m.Get(context.TODO(), "my-rg").Return(resources.Group{}, nil)
 			},
 		},
@@ -309,7 +306,11 @@ func TestDeleteGroups(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			groupsMock := mock_groups.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/cloud/services/internalloadbalancers/internalloadbalancers_test.go
+++ b/cloud/services/internalloadbalancers/internalloadbalancers_test.go
@@ -52,6 +52,8 @@ func TestInvalidInternalLBSpec(t *testing.T) {
 	g := NewWithT(t)
 
 	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	internalLBMock := mock_internalloadbalancers.NewMockClient(mockCtrl)
 
 	cluster := &clusterv1.Cluster{
@@ -97,8 +99,6 @@ func TestInvalidInternalLBSpec(t *testing.T) {
 }
 
 func TestReconcileInternalLoadBalancer(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name           string
 		internalLBSpec Spec
@@ -162,7 +162,6 @@ func TestReconcileInternalLoadBalancer(t *testing.T) {
 								FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{},
 							},
 						}}}, nil)
-				mVnet.CheckIPAddressAvailability(context.TODO(), "my-rg", "my-vnet", "10.0.0.10").Return(network.IPAddressAvailabilityResult{Available: to.BoolPtr(true)}, nil)
 				mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil)
 				m.CreateOrUpdate(context.TODO(), "my-rg", "my-lb", gomock.AssignableToTypeOf(network.LoadBalancer{}))
 			},
@@ -206,7 +205,11 @@ func TestReconcileInternalLoadBalancer(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			internalLBMock := mock_internalloadbalancers.NewMockClient(mockCtrl)
 			subnetMock := mock_subnets.NewMockClient(mockCtrl)
 			vnetMock := mock_virtualnetworks.NewMockClient(mockCtrl)
@@ -261,8 +264,6 @@ func TestReconcileInternalLoadBalancer(t *testing.T) {
 }
 
 func TestDeleteInternalLB(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name           string
 		internalLBSpec Spec
@@ -317,7 +318,11 @@ func TestDeleteInternalLB(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			internalLBMock := mock_internalloadbalancers.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/cloud/services/managedclusters/managedclusters_test.go
+++ b/cloud/services/managedclusters/managedclusters_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestReconcile(t *testing.T) {
-	g := NewWithT(t)
-
 	provisioningstatetestcases := []struct {
 		name                     string
 		managedclusterspec       Spec
@@ -73,7 +71,11 @@ func TestReconcile(t *testing.T) {
 		for _, provisioningstate := range tc.provisioningStatesToTest {
 			t.Logf("Testing managedcluster provision state: " + provisioningstate)
 			t.Run(tc.name, func(t *testing.T) {
+				g := NewWithT(t)
+
 				mockCtrl := gomock.NewController(t)
+				defer mockCtrl.Finish()
+
 				managedclusterMock := mock_managedclusters.NewMockClient(mockCtrl)
 
 				tc.expect(managedclusterMock.EXPECT(), provisioningstate)
@@ -88,7 +90,6 @@ func TestReconcile(t *testing.T) {
 					g.Expect(err).To(MatchError(tc.expectedError))
 				} else {
 					g.Expect(err).NotTo(HaveOccurred())
-					mockCtrl.Finish()
 				}
 			})
 		}
@@ -117,7 +118,11 @@ func TestReconcile(t *testing.T) {
 	for _, tc := range testcases {
 		t.Logf("Testing " + tc.name)
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			managedclusterMock := mock_managedclusters.NewMockClient(mockCtrl)
 
 			tc.expect(managedclusterMock.EXPECT())
@@ -132,9 +137,7 @@ func TestReconcile(t *testing.T) {
 				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
-				mockCtrl.Finish()
 			}
 		})
 	}
-
 }

--- a/cloud/services/networkinterfaces/networkinterfaces_test.go
+++ b/cloud/services/networkinterfaces/networkinterfaces_test.go
@@ -58,6 +58,8 @@ func TestInvalidNetworkInterface(t *testing.T) {
 	g := NewWithT(t)
 
 	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	netInterfaceMock := mock_networkinterfaces.NewMockClient(mockCtrl)
 
 	cluster := &clusterv1.Cluster{
@@ -103,8 +105,6 @@ func TestInvalidNetworkInterface(t *testing.T) {
 }
 
 func TestReconcileNetworkInterface(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name             string
 		netInterfaceSpec Spec
@@ -559,7 +559,6 @@ func TestReconcileNetworkInterface(t *testing.T) {
 				gomock.InOrder(
 					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil),
 					mPublicLoadBalancer.Get(context.TODO(), "my-rg", "my-cluster").Return(getFakeNodeOutboundLoadBalancer(), nil),
-					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomock.AssignableToTypeOf(network.Interface{})),
 				)
 			},
 		},
@@ -567,7 +566,11 @@ func TestReconcileNetworkInterface(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			netInterfaceMock := mock_networkinterfaces.NewMockClient(mockCtrl)
 			subnetMock := mock_subnets.NewMockClient(mockCtrl)
 			publicLoadBalancerMock := mock_publicloadbalancers.NewMockClient(mockCtrl)
@@ -659,8 +662,6 @@ func TestReconcileNetworkInterface(t *testing.T) {
 }
 
 func TestDeleteNetworkInterface(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name             string
 		netInterfaceSpec Spec
@@ -734,7 +735,11 @@ func TestDeleteNetworkInterface(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			netInterfaceMock := mock_networkinterfaces.NewMockClient(mockCtrl)
 			inboundNatRulesMock := mock_inboundnatrules.NewMockClient(mockCtrl)
 			publicIPMock := mock_publicips.NewMockClient(mockCtrl)

--- a/cloud/services/publicips/publicips_test.go
+++ b/cloud/services/publicips/publicips_test.go
@@ -39,8 +39,6 @@ func init() {
 }
 
 func TestReconcilePublicIP(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name          string
 		expectedError string
@@ -89,6 +87,8 @@ func TestReconcilePublicIP(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			t.Parallel()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
@@ -114,8 +114,6 @@ func TestReconcilePublicIP(t *testing.T) {
 }
 
 func TestDeletePublicIP(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name          string
 		expectedError string
@@ -170,6 +168,8 @@ func TestDeletePublicIP(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			t.Parallel()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()

--- a/cloud/services/publicloadbalancers/publicloadbalancers_test.go
+++ b/cloud/services/publicloadbalancers/publicloadbalancers_test.go
@@ -52,6 +52,8 @@ func TestInvalidPublicLBSpec(t *testing.T) {
 	g := NewWithT(t)
 
 	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	publicLBMock := mock_publicloadbalancers.NewMockClient(mockCtrl)
 
 	cluster := &clusterv1.Cluster{
@@ -97,8 +99,6 @@ func TestInvalidPublicLBSpec(t *testing.T) {
 }
 
 func TestReconcilePublicLoadBalancer(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name          string
 		publicLBSpec  Spec
@@ -115,7 +115,6 @@ func TestReconcilePublicLoadBalancer(t *testing.T) {
 			expectedError: "public ip my-publicip not found in RG my-rg: #: Not found: StatusCode=404",
 			expect: func(m *mock_publicloadbalancers.MockClientMockRecorder,
 				publicIP *mock_publicips.MockClientMockRecorder) {
-				m.CreateOrUpdate(context.TODO(), "my-rg", "my-publiclb", gomock.AssignableToTypeOf(network.LoadBalancer{}))
 				publicIP.Get(context.TODO(), "my-rg", "my-publicip").Return(network.PublicIPAddress{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
 		},
@@ -128,7 +127,6 @@ func TestReconcilePublicLoadBalancer(t *testing.T) {
 			expectedError: "failed to look for existing public IP: #: Internal Server Error: StatusCode=500",
 			expect: func(m *mock_publicloadbalancers.MockClientMockRecorder,
 				publicIP *mock_publicips.MockClientMockRecorder) {
-				m.CreateOrUpdate(context.TODO(), "my-rg", "my-publiclb", gomock.AssignableToTypeOf(network.LoadBalancer{}))
 				publicIP.Get(context.TODO(), "my-rg", "my-publicip").Return(network.PublicIPAddress{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 			},
 		},
@@ -302,7 +300,11 @@ func TestReconcilePublicLoadBalancer(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			publicLBMock := mock_publicloadbalancers.NewMockClient(mockCtrl)
 			publicIPsMock := mock_publicips.NewMockClient(mockCtrl)
 
@@ -351,8 +353,6 @@ func TestReconcilePublicLoadBalancer(t *testing.T) {
 }
 
 func TestDeletePublicLB(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name          string
 		publicLBSpec  Spec
@@ -398,7 +398,11 @@ func TestDeletePublicLB(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			publicLBMock := mock_publicloadbalancers.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/cloud/services/routetables/routetables_test.go
+++ b/cloud/services/routetables/routetables_test.go
@@ -18,9 +18,10 @@ package routetables
 
 import (
 	"context"
-	"github.com/Azure/go-autorest/autorest/to"
 	"net/http"
 	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
 
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/routetables/mock_routetables"
@@ -50,6 +51,8 @@ func TestInvalidRouteTableSpec(t *testing.T) {
 	g := NewWithT(t)
 
 	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	routetableMock := mock_routetables.NewMockClient(mockCtrl)
 
 	cluster := &clusterv1.Cluster{
@@ -95,8 +98,6 @@ func TestInvalidRouteTableSpec(t *testing.T) {
 }
 
 func TestReconcileRouteTables(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name           string
 		routetableSpec Spec
@@ -191,6 +192,8 @@ func TestReconcileRouteTables(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
@@ -254,8 +257,6 @@ func TestReconcileRouteTables(t *testing.T) {
 }
 
 func TestDeleteRouteTable(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name           string
 		routetableSpec Spec
@@ -275,7 +276,6 @@ func TestDeleteRouteTable(t *testing.T) {
 			},
 			expectedError: "",
 			expect: func(m *mock_routetables.MockClientMockRecorder) {
-				m.Delete(context.TODO(), "my-rg", "my-routetable")
 			},
 		},
 		{
@@ -327,7 +327,11 @@ func TestDeleteRouteTable(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			routetableMock := mock_routetables.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/cloud/services/securitygroups/securitygroups_test.go
+++ b/cloud/services/securitygroups/securitygroups_test.go
@@ -45,8 +45,6 @@ func init() {
 }
 
 func TestReconcileSecurityGroups(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name           string
 		sgName         string
@@ -84,7 +82,11 @@ func TestReconcileSecurityGroups(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			sgMock := mock_securitygroups.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{
@@ -129,8 +131,6 @@ func TestReconcileSecurityGroups(t *testing.T) {
 }
 
 func TestDeleteSecurityGroups(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name   string
 		sgName string
@@ -154,7 +154,11 @@ func TestDeleteSecurityGroups(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			sgMock := mock_securitygroups.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/cloud/services/subnets/subnets_test.go
+++ b/cloud/services/subnets/subnets_test.go
@@ -48,8 +48,6 @@ func init() {
 }
 
 func TestReconcileSubnets(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name          string
 		subnetSpec    Spec
@@ -144,7 +142,11 @@ func TestReconcileSubnets(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			subnetMock := mock_subnets.NewMockClient(mockCtrl)
 			rtMock := mock_routetables.NewMockClient(mockCtrl)
 			sgMock := mock_securitygroups.NewMockClient(mockCtrl)
@@ -196,8 +198,6 @@ func TestReconcileSubnets(t *testing.T) {
 }
 
 func TestDeleteSubnets(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name       string
 		subnetSpec Spec
@@ -254,7 +254,11 @@ func TestDeleteSubnets(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			subnetMock := mock_subnets.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -55,6 +55,8 @@ func TestInvalidVM(t *testing.T) {
 	g := NewWithT(t)
 
 	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	vmMock := mock_virtualmachines.NewMockClient(mockCtrl)
 
 	cluster := &clusterv1.Cluster{
@@ -100,8 +102,6 @@ func TestInvalidVM(t *testing.T) {
 }
 
 func TestGetVM(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name          string
 		vmSpec        Spec
@@ -169,8 +169,6 @@ func TestGetVM(t *testing.T) {
 			},
 			expectedError: "VM my-vm not found: #: Not found: StatusCode=404",
 			expect: func(m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				mpip.Get(context.TODO(), "my-rg", "my-publicIP-id").Return(network.PublicIPAddress{}, nil)
-				mnic.Get(context.TODO(), "my-rg", gomock.Any()).Return(network.Interface{}, nil)
 				m.Get(context.TODO(), "my-rg", "my-vm").Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
 		},
@@ -181,8 +179,6 @@ func TestGetVM(t *testing.T) {
 			},
 			expectedError: "#: Internal Server Error: StatusCode=500",
 			expect: func(m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				mpip.Get(context.TODO(), "my-rg", "my-publicIP-id").Return(network.PublicIPAddress{}, nil)
-				mnic.Get(context.TODO(), "my-rg", gomock.Any()).Return(network.Interface{}, nil)
 				m.Get(context.TODO(), "my-rg", "my-vm").Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 			},
 		},
@@ -286,7 +282,11 @@ func TestGetVM(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			vmMock := mock_virtualmachines.NewMockClient(mockCtrl)
 			interfaceMock := mock_networkinterfaces.NewMockClient(mockCtrl)
 			publicIPMock := mock_publicips.NewMockClient(mockCtrl)
@@ -455,7 +455,6 @@ func TestReconcileVM(t *testing.T) {
 			expect: func(g *WithT, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder, mra *mock_roleassignments.MockClientMockRecorder) {
 				mnic.Get(gomock.Any(), gomock.Any(), gomock.Any())
 				m.CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-				mra.Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			},
 			expectedError: "",
 		},
@@ -502,7 +501,6 @@ func TestReconcileVM(t *testing.T) {
 			expect: func(g *WithT, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder, mra *mock_roleassignments.MockClientMockRecorder) {
 				mnic.Get(gomock.Any(), gomock.Any(), gomock.Any())
 				m.CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-				mra.Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			},
 			expectedError: "",
 		},
@@ -606,6 +604,8 @@ func TestReconcileVM(t *testing.T) {
 			g := NewWithT(t)
 
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			vmMock := mock_virtualmachines.NewMockClient(mockCtrl)
 			interfaceMock := mock_networkinterfaces.NewMockClient(mockCtrl)
 			publicIPMock := mock_publicips.NewMockClient(mockCtrl)
@@ -699,8 +699,6 @@ func TestReconcileVM(t *testing.T) {
 }
 
 func TestDeleteVM(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name          string
 		vmSpec        Spec
@@ -743,7 +741,10 @@ func TestDeleteVM(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
 			vmMock := mock_virtualmachines.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/cloud/services/virtualnetworks/virtualnetworks_test.go
+++ b/cloud/services/virtualnetworks/virtualnetworks_test.go
@@ -48,8 +48,6 @@ func init() {
 }
 
 func TestReconcileVnet(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name   string
 		input  *infrav1.VnetSpec
@@ -128,7 +126,11 @@ func TestReconcileVnet(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			vnetMock := mock_virtualnetworks.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{
@@ -183,8 +185,6 @@ func TestReconcileVnet(t *testing.T) {
 }
 
 func TestDeleteVnet(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name   string
 		input  *infrav1.VnetSpec
@@ -221,7 +221,11 @@ func TestDeleteVnet(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
 			vnetMock := mock_virtualnetworks.NewMockClient(mockCtrl)
 
 			cluster := &clusterv1.Cluster{

--- a/controllers/azurecluster_controller_test.go
+++ b/controllers/azurecluster_controller_test.go
@@ -70,7 +70,10 @@ var _ = Describe("AzureClusterReconciler", func() {
 		})
 
 		It("should fail with context timeout error if context expires", func() {
-			log := mock_log.NewMockLogger(gomock.NewController(GinkgoT()))
+			mockCtrl := gomock.NewController(GinkgoT())
+			defer mockCtrl.Finish()
+
+			log := mock_log.NewMockLogger(mockCtrl)
 			log.EXPECT().WithValues(gomock.Any()).DoAndReturn(func(args ...interface{}) logr.Logger {
 				time.Sleep(3 * time.Second)
 				return log

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -46,7 +46,10 @@ func TestAzureClusterToAzureMachinesMapper(t *testing.T) {
 	}
 	client := fake.NewFakeClientWithScheme(scheme, initObjects...)
 
-	log := mock_log.NewMockLogger(gomock.NewController(t))
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	log := mock_log.NewMockLogger(mockCtrl)
 	log.EXPECT().WithValues("AzureCluster", "my-cluster", "Namespace", "default")
 	mapper, err := AzureClusterToAzureMachinesMapper(client, scheme, log)
 	g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing `defer mockCtrl.Finish()` in the services tests
Also move the `g := NewWithT(t)` to be instantiated when will be used and not in the beginning 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 - Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/720

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```