### PR TITLE
💎 Remove use of deprecated cluster scope Name() in favor of ClusterName()

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -147,12 +147,6 @@ func (s *ClusterScope) ClusterName() string {
 	return s.Cluster.Name
 }
 
-// Name returns the cluster name.
-// DEPRECATED: use ClusterName() instead
-func (s *ClusterScope) Name() string {
-	return s.Cluster.Name
-}
-
 // Namespace returns the cluster namespace.
 func (s *ClusterScope) Namespace() string {
 	return s.Cluster.Namespace

--- a/cloud/services/groups/groups.go
+++ b/cloud/services/groups/groups.go
@@ -38,7 +38,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	group := resources.Group{
 		Location: to.StringPtr(s.Scope.Location()),
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
-			ClusterName: s.Scope.Name(),
+			ClusterName: s.Scope.ClusterName(),
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			Name:        to.StringPtr(s.Scope.ResourceGroup()),
 			Role:        to.StringPtr(infrav1.CommonRole),
@@ -81,5 +81,5 @@ func (s *Service) isGroupManaged(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	tags := converters.MapToTags(group.Tags)
-	return tags.HasOwned(s.Scope.Name()), nil
+	return tags.HasOwned(s.Scope.ClusterName()), nil
 }

--- a/cloud/services/publicloadbalancers/publicloadbalancers.go
+++ b/cloud/services/publicloadbalancers/publicloadbalancers.go
@@ -65,7 +65,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 		Sku:      &network.LoadBalancerSku{Name: network.LoadBalancerSkuNameStandard},
 		Location: to.StringPtr(s.Scope.Location()),
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
-			ClusterName: s.Scope.Name(),
+			ClusterName: s.Scope.ClusterName(),
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			Role:        to.StringPtr(publicLBSpec.Role),
 			Additional:  s.Scope.AdditionalTags(),

--- a/cloud/services/routetables/routetables.go
+++ b/cloud/services/routetables/routetables.go
@@ -32,7 +32,7 @@ type Spec struct {
 
 // Reconcile gets/creates/updates a route table.
 func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
-	if !s.Scope.Vnet().IsManaged(s.Scope.Name()) {
+	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping route tables reconcile in custom vnet mode")
 		return nil
 	}
@@ -79,7 +79,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 
 // Delete deletes the route table with the provided name.
 func (s *Service) Delete(ctx context.Context, spec interface{}) error {
-	if !s.Scope.Vnet().IsManaged(s.Scope.Name()) {
+	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping route table deletion in custom vnet mode")
 		return nil
 	}

--- a/cloud/services/securitygroups/securitygroups.go
+++ b/cloud/services/securitygroups/securitygroups.go
@@ -41,7 +41,7 @@ type Spec struct {
 
 // Reconcile gets/creates/updates a network security group.
 func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
-	if !s.Scope.Vnet().IsManaged(s.Scope.Name()) {
+	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping network security group reconcile in custom vnet mode")
 		return nil
 	}

--- a/cloud/services/subnets/subnets.go
+++ b/cloud/services/subnets/subnets.go
@@ -88,7 +88,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			return errors.Wrap(err, "failed to get subnet")
 		}
 	}
-	if !s.Scope.Vnet().IsManaged(s.Scope.Name()) {
+	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		// if the vnet is unmanaged, we expect all subnets to be created as well
 		return fmt.Errorf("vnet was provided but subnet %s is missing", subnetSpec.Name)
 	}
@@ -135,7 +135,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 
 // Delete deletes the subnet with the provided name.
 func (s *Service) Delete(ctx context.Context, spec interface{}) error {
-	if !s.Scope.Vnet().IsManaged(s.Scope.Name()) {
+	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping subnets deletion in custom vnet mode")
 		return nil
 	}

--- a/cloud/services/virtualmachines/virtualmachines.go
+++ b/cloud/services/virtualmachines/virtualmachines.go
@@ -111,7 +111,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	virtualMachine := compute.VirtualMachine{
 		Location: to.StringPtr(s.Scope.Location()),
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
-			ClusterName: s.Scope.Name(),
+			ClusterName: s.Scope.ClusterName(),
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			Name:        to.StringPtr(s.MachineScope.Name()),
 			Role:        to.StringPtr(s.MachineScope.Role()),

--- a/cloud/services/virtualnetworks/virtualnetworks.go
+++ b/cloud/services/virtualnetworks/virtualnetworks.go
@@ -81,7 +81,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			return errors.Wrap(err, "failed to get VNet")
 		}
 
-		if !existingVnet.IsManaged(s.Scope.Name()) {
+		if !existingVnet.IsManaged(s.Scope.ClusterName()) {
 			s.Scope.V(2).Info("Working on custom VNet", "vnet-id", existingVnet.ID)
 		}
 		// vnet already exists, cannot update since it's immutable
@@ -91,7 +91,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	klog.V(2).Infof("creating VNet %s ", vnetSpec.Name)
 	vnetProperties := network.VirtualNetwork{
 		Tags: converters.TagsToMap(infrav1.Build(infrav1.BuildParams{
-			ClusterName: s.Scope.Name(),
+			ClusterName: s.Scope.ClusterName(),
 			Lifecycle:   infrav1.ResourceLifecycleOwned,
 			Name:        to.StringPtr(vnetSpec.Name),
 			Role:        to.StringPtr(infrav1.CommonRole),
@@ -115,7 +115,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 
 // Delete deletes the virtual network with the provided name.
 func (s *Service) Delete(ctx context.Context, spec interface{}) error {
-	if !s.Scope.Vnet().IsManaged(s.Scope.Name()) {
+	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping VNet deletion in custom vnet mode")
 		return nil
 	}

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -327,7 +327,7 @@ func (r *AzureMachineReconciler) reconcileDelete(ctx context.Context, machineSco
 	machineScope.Info("Handling deleted AzureMachine")
 
 	if err := newAzureMachineService(machineScope, clusterScope).Delete(ctx); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "error deleting AzureCluster %s/%s", clusterScope.Namespace(), clusterScope.Name())
+		return reconcile.Result{}, errors.Wrapf(err, "error deleting AzureCluster %s/%s", clusterScope.Namespace(), clusterScope.ClusterName())
 	}
 
 	defer func() {

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -104,9 +104,9 @@ func (s *azureMachineService) Delete(ctx context.Context) error {
 	}
 
 	if s.machineScope.Role() == infrav1.ControlPlane {
-		networkInterfaceSpec.PublicLoadBalancerName = azure.GeneratePublicLBName(s.clusterScope.Name())
+		networkInterfaceSpec.PublicLoadBalancerName = azure.GeneratePublicLBName(s.clusterScope.ClusterName())
 	} else if s.machineScope.Role() == infrav1.Node {
-		networkInterfaceSpec.PublicLoadBalancerName = s.clusterScope.Name()
+		networkInterfaceSpec.PublicLoadBalancerName = s.clusterScope.ClusterName()
 	}
 
 	err = s.networkInterfacesSvc.Delete(ctx, networkInterfaceSpec)
@@ -222,11 +222,11 @@ func (s *azureMachineService) reconcileNetworkInterface(ctx context.Context, nic
 	switch role := s.machineScope.Role(); role {
 	case infrav1.Node:
 		networkInterfaceSpec.SubnetName = s.clusterScope.NodeSubnet().Name
-		networkInterfaceSpec.PublicLoadBalancerName = s.clusterScope.Name()
+		networkInterfaceSpec.PublicLoadBalancerName = s.clusterScope.ClusterName()
 	case infrav1.ControlPlane:
 		networkInterfaceSpec.SubnetName = s.clusterScope.ControlPlaneSubnet().Name
-		networkInterfaceSpec.PublicLoadBalancerName = azure.GeneratePublicLBName(s.clusterScope.Name())
-		networkInterfaceSpec.InternalLoadBalancerName = azure.GenerateInternalLBName(s.clusterScope.Name())
+		networkInterfaceSpec.PublicLoadBalancerName = azure.GeneratePublicLBName(s.clusterScope.ClusterName())
+		networkInterfaceSpec.InternalLoadBalancerName = azure.GenerateInternalLBName(s.clusterScope.ClusterName())
 	default:
 		return errors.Errorf("unknown value %s for label `set` on machine %s, skipping machine creation", role, s.machineScope.Name())
 	}

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -297,7 +297,7 @@ func (r *AzureMachinePoolReconciler) reconcileDelete(ctx context.Context, machin
 	machinePoolScope.Info("Handling deleted AzureMachinePool")
 
 	if err := newAzureMachinePoolService(machinePoolScope, clusterScope).Delete(ctx); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "error deleting AzureCluster %s/%s", clusterScope.Namespace(), clusterScope.Name())
+		return reconcile.Result{}, errors.Wrapf(err, "error deleting AzureCluster %s/%s", clusterScope.Namespace(), clusterScope.ClusterName())
 	}
 
 	defer func() {
@@ -514,7 +514,7 @@ func (s *azureMachinePoolService) CreateOrUpdate(ctx context.Context) (*infrav1e
 		Name:                   s.machinePoolScope.Name(),
 		ResourceGroup:          s.clusterScope.ResourceGroup(),
 		Location:               s.clusterScope.Location(),
-		ClusterName:            s.clusterScope.Name(),
+		ClusterName:            s.clusterScope.ClusterName(),
 		MachinePoolName:        s.machinePoolScope.Name(),
 		Sku:                    ampSpec.Template.VMSize,
 		Capacity:               replicas,
@@ -524,7 +524,7 @@ func (s *azureMachinePoolService) CreateOrUpdate(ctx context.Context) (*infrav1e
 		CustomData:             bootstrapData,
 		AdditionalTags:         s.machinePoolScope.AdditionalTags(),
 		SubnetID:               s.clusterScope.AzureCluster.Spec.NetworkSpec.GetNodeSubnet().ID,
-		PublicLoadBalancerName: s.clusterScope.Name(),
+		PublicLoadBalancerName: s.clusterScope.ClusterName(),
 		AcceleratedNetworking:  ampSpec.Template.AcceleratedNetworking,
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: clusterScope.Name() is deprecated since #716 as it might conflict with machine scope Name() (machine name vs cluster name). This replaces all remaining uses of Name() in the context of cluster name with ClusterName() and deletes the cluster Name() function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removed use of deprecated cluster scope Name() in favor of ClusterName()
```