### PR TITLE
🔧  eliminate plain text creds for additional template files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,9 @@ $(CONVERSION_GEN): ## Build conversion-gen.
 $(ENVSUBST): ## Build envsubst from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/a8m/envsubst/cmd/envsubst $(ENVSUBST_BIN) $(ENVSUBST_VER)
 
+.PHONY: $(ENVSUBST_BIN)
+$(ENVSUBST_BIN): $(ENVSUBST) ## Build envsubst from tools folder.
+
 $(GOLANGCI_LINT): ## Build golangci-lint from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -278,31 +278,31 @@ SSH_KEY_FILE=.sshkey
 rm -f "${SSH_KEY_FILE}" 2>/dev/null
 ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N '' 1>/dev/null
 echo "Machine SSH key generated in ${SSH_KEY_FILE}"
-export AZURE_SSH_PUBLIC_KEY=$(cat "${SSH_KEY_FILE}.pub" | base64 | tr -d '\n')
+export AZURE_SSH_PUBLIC_KEY=$(cat "${SSH_KEY_FILE}.pub" | base64 | tr -d '\r\n')
 
 # To populate secret in azure.json file.
 export AZURE_STANDARD_JSON_B64=$(echo '{
-      "cloud": "${AZURE_ENVIRONMENT}",
-      "tenantId": "${AZURE_TENANT_ID}",
-      "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-      "aadClientId": "${AZURE_CLIENT_ID}",
-      "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-      "resourceGroup": "${CLUSTER_NAME}",
-      "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-      "location": "${AZURE_LOCATION}",
-      "vmType": "standard",
-      "vnetName": "${CLUSTER_NAME}-vnet",
-      "vnetResourceGroup": "${CLUSTER_NAME}",
-      "subnetName": "${CLUSTER_NAME}-node-subnet",
-      "routeTableName": "${CLUSTER_NAME}-node-routetable",
-      "loadBalancerSku": "standard",
-      "maximumLoadBalancerRuleCount": 250,
-      "useManagedIdentityExtension": false,
-      "useInstanceMetadata": true
-}' | envsubst | base64 | tr -d '\n')
+    "cloud": "${AZURE_ENVIRONMENT}",
+    "tenantId": "${AZURE_TENANT_ID}",
+    "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
+    "aadClientId": "${AZURE_CLIENT_ID}",
+    "aadClientSecret": "${AZURE_CLIENT_SECRET}",
+    "resourceGroup": "${CLUSTER_NAME}",
+    "securityGroupName": "${CLUSTER_NAME}-node-nsg",
+    "location": "${AZURE_LOCATION}",
+    "vmType": "standard",
+    "vnetName": "${CLUSTER_NAME}-vnet",
+    "vnetResourceGroup": "${CLUSTER_NAME}",
+    "subnetName": "${CLUSTER_NAME}-node-subnet",
+    "routeTableName": "${CLUSTER_NAME}-node-routetable",
+    "loadBalancerSku": "standard",
+    "maximumLoadBalancerRuleCount": 250,
+    "useManagedIdentityExtension": false,
+    "useInstanceMetadata": true
+}' | envsubst | base64 | tr -d '\r\n')
 
 # VMSS requires different values
-export AZURE_VMSS_JSON_B64=$(echo "$AZURE_STANDARD_JSON_B64" | base64 -d | jq '.vmType = "vmss"' | base64 | tr -d '\n')
+export AZURE_VMSS_JSON_B64=$(echo "$AZURE_STANDARD_JSON_B64" | base64 -d | jq '.vmType = "vmss"' | base64 | tr -d '\r\n')
 ```
 
 ##### Creating the cluster

--- a/hack/log/redact.sh
+++ b/hack/log/redact.sh
@@ -18,26 +18,20 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Verify the required Environment Variables are present.
-: "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
-: "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
-: "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
-: "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
-
 echo "================ REDACTING LOGS ================"
 
 log_files=( $(find "${ARTIFACTS:-${PWD}/_artifacts}" -type f) )
 redact_vars=(
-    "${AZURE_CLIENT_ID}"
-    "${AZURE_CLIENT_SECRET}"
-    "${AZURE_SUBSCRIPTION_ID}"
-    "${AZURE_TENANT_ID}"
+    "${AZURE_CLIENT_ID:-}"
+    "${AZURE_CLIENT_SECRET:-}"
+    "${AZURE_SUBSCRIPTION_ID:-}"
+    "${AZURE_TENANT_ID:-}"
     "${AZURE_STANDARD_JSON_B64:-}"
     "${AZURE_VMSS_JSON_B64:-}"
-    "$(echo -n "$AZURE_SUBSCRIPTION_ID" | base64 | tr -d '\n')"
-    "$(echo -n "$AZURE_TENANT_ID" | base64 | tr -d '\n')"
-    "$(echo -n "$AZURE_CLIENT_ID" | base64 | tr -d '\n')"
-    "$(echo -n "$AZURE_CLIENT_SECRET" | base64 | tr -d '\n')"
+    "$(echo -n "${AZURE_SUBSCRIPTION_ID:-}" | base64 | tr -d '\n')"
+    "$(echo -n "${AZURE_TENANT_ID:-}" | base64 | tr -d '\n')"
+    "$(echo -n "${AZURE_CLIENT_ID:-}" | base64 | tr -d '\n')"
+    "$(echo -n "${AZURE_CLIENT_SECRET:-}" | base64 | tr -d '\n')"
 )
 
 for log_file in "${log_files[@]}"; do
@@ -45,9 +39,9 @@ for log_file in "${log_files[@]}"; do
         # LC_CTYPE=C and LANG=C will prevent "illegal byte sequence" error from sed
         if [[ "$(uname)" == "Darwin" ]]; then
             # sed on Mac OS requires an empty string for -i flag
-            LC_CTYPE=C LANG=C sed -i "" "s|${redact_var}|===REDACTED===|g" "${log_file}" || true
+            LC_CTYPE=C LANG=C sed -i "" "s|${redact_var}|===REDACTED===|g" "${log_file}" &> /dev/null || true
         else
-            LC_CTYPE=C LANG=C sed -i "s|${redact_var}|===REDACTED===|g" "${log_file}" || true
+            LC_CTYPE=C LANG=C sed -i "s|${redact_var}|===REDACTED===|g" "${log_file}" &> /dev/null || true
         fi
     done
 done

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -64,27 +64,10 @@ spec:
           name: cloud-config
           readOnly: true
     files:
-    - content: |
-        {
-          "cloud": "${AZURE_ENVIRONMENT}",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          key: vmss
+          name: azure-secret
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
@@ -180,26 +163,10 @@ spec:
   template:
     spec:
       files:
-      - content: |
-          {
-            "cloud": "${AZURE_ENVIRONMENT}",
-            "tenantId": "${AZURE_TENANT_ID}",
-            "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-            "aadClientId": "${AZURE_CLIENT_ID}",
-            "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-            "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-            "location": "${AZURE_LOCATION}",
-            "vmType": "vmss",
-            "vnetName": "${CLUSTER_NAME}-vnet",
-            "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "subnetName": "${CLUSTER_NAME}-node-subnet",
-            "routeTableName": "${CLUSTER_NAME}-node-routetable",
-            "loadBalancerSku": "standard",
-            "maximumLoadBalancerRuleCount": 250,
-            "useManagedIdentityExtension": false,
-            "useInstanceMetadata": true
-          }
+      - contentFrom:
+          secret:
+            key: vmss
+            name: azure-secret
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"

--- a/templates/flavors/external-cloud-provider/patches/external-cloud-provider.yaml
+++ b/templates/flavors/external-cloud-provider/patches/external-cloud-provider.yaml
@@ -29,27 +29,10 @@ spec:
       - path: /etc/kubernetes/azure.json
         owner: "root:root"
         permissions: "0644"
-        content: |
-          {
-            "cloud": "${AZURE_ENVIRONMENT}",
-            "tenantId": "${AZURE_TENANT_ID}",
-            "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-            "aadClientId": "${AZURE_CLIENT_ID}",
-            "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-            "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-            "location": "${AZURE_LOCATION}",
-            "vmType": "vmss",
-            "vnetName": "${CLUSTER_NAME}-vnet",
-            "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-            "subnetName": "${CLUSTER_NAME}-node-subnet",
-            "routeTableName": "${CLUSTER_NAME}-node-routetable",
-            "userAssignedID": "${CLUSTER_NAME}",
-            "loadBalancerSku": "standard",
-            "maximumLoadBalancerRuleCount": 250,
-            "useManagedIdentityExtension": false,
-            "useInstanceMetadata": true
-          }
+        contentFrom:
+          secret:
+            name: azure-secret
+            key: vmss
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
@@ -67,23 +50,7 @@ spec:
         - path: /etc/kubernetes/azure.json
           owner: "root:root"
           permissions: "0644"
-          content: |
-            {
-              "cloud": "${AZURE_ENVIRONMENT}",
-              "tenantId": "${AZURE_TENANT_ID}",
-              "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-              "aadClientId": "${AZURE_CLIENT_ID}",
-              "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-              "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-              "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-              "location": "${AZURE_LOCATION}",
-              "vmType": "vmss",
-              "vnetName": "${CLUSTER_NAME}-vnet",
-              "vnetResourceGroup": "${AZURE_RESOURCE_GROUP}",
-              "subnetName": "${CLUSTER_NAME}-node-subnet",
-              "routeTableName": "${CLUSTER_NAME}-node-routetable",
-              "loadBalancerSku": "standard",
-              "maximumLoadBalancerRuleCount": 250,
-              "useManagedIdentityExtension": false,
-              "useInstanceMetadata": true
-            }
+          contentFrom:
+            secret:
+              name: azure-secret
+              key: vmss

--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -142,27 +142,10 @@ spec:
       owner: root:root
       path: /tmp/kubeadm-bootstrap.sh
       permissions: "0744"
-    - content: |
-        {
-          "cloud": "AzurePublicCloud",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${CLUSTER_NAME}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          key: vmss
+          name: azure-secret
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
@@ -346,26 +329,10 @@ spec:
         owner: root:root
         path: /tmp/kubeadm-bootstrap.sh
         permissions: "0744"
-      - content: |
-          {
-            "cloud": "AzurePublicCloud",
-            "tenantId": "${AZURE_TENANT_ID}",
-            "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-            "aadClientId": "${AZURE_CLIENT_ID}",
-            "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-            "resourceGroup": "${CLUSTER_NAME}",
-            "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-            "location": "${AZURE_LOCATION}",
-            "vmType": "vmss",
-            "vnetName": "${CLUSTER_NAME}-vnet",
-            "vnetResourceGroup": "${CLUSTER_NAME}",
-            "subnetName": "${CLUSTER_NAME}-node-subnet",
-            "routeTableName": "${CLUSTER_NAME}-node-routetable",
-            "loadBalancerSku": "standard",
-            "maximumLoadBalancerRuleCount": 250,
-            "useManagedIdentityExtension": false,
-            "useInstanceMetadata": true
-          }
+      - contentFrom:
+          secret:
+            key: vmss
+            name: azure-secret
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -142,27 +142,10 @@ spec:
       owner: root:root
       path: /tmp/kubeadm-bootstrap.sh
       permissions: "0744"
-    - content: |
-        {
-          "cloud": "AzurePublicCloud",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${CLUSTER_NAME}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+    - contentFrom:
+        secret:
+          key: vmss
+          name: azure-secret
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
@@ -341,26 +324,10 @@ spec:
     owner: root:root
     path: /tmp/kubeadm-bootstrap.sh
     permissions: "0744"
-  - content: |
-      {
-        "cloud": "AzurePublicCloud",
-        "tenantId": "${AZURE_TENANT_ID}",
-        "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-        "aadClientId": "${AZURE_CLIENT_ID}",
-        "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-        "resourceGroup": "${CLUSTER_NAME}",
-        "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-        "location": "${AZURE_LOCATION}",
-        "vmType": "vmss",
-        "vnetName": "${CLUSTER_NAME}-vnet",
-        "vnetResourceGroup": "${CLUSTER_NAME}",
-        "subnetName": "${CLUSTER_NAME}-node-subnet",
-        "routeTableName": "${CLUSTER_NAME}-node-routetable",
-        "loadBalancerSku": "standard",
-        "maximumLoadBalancerRuleCount": 250,
-        "useManagedIdentityExtension": false,
-        "useInstanceMetadata": true
-      }
+  - contentFrom:
+      secret:
+        key: vmss
+        name: azure-secret
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"

--- a/templates/test/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -87,27 +87,10 @@ spec:
     - path: /etc/kubernetes/azure.json
       owner: "root:root"
       permissions: "0644"
-      content: |
-        {
-          "cloud": "AzurePublicCloud",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${CLUSTER_NAME}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+      contentFrom:
+        secret:
+          key: vmss
+          name: azure-secret
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
@@ -196,26 +179,10 @@ spec:
         - path: /etc/kubernetes/azure.json
           owner: "root:root"
           permissions: "0644"
-          content: |
-            {
-              "cloud": "AzurePublicCloud",
-              "tenantId": "${AZURE_TENANT_ID}",
-              "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-              "aadClientId": "${AZURE_CLIENT_ID}",
-              "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-              "resourceGroup": "${CLUSTER_NAME}",
-              "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-              "location": "${AZURE_LOCATION}",
-              "vmType": "vmss",
-              "vnetName": "${CLUSTER_NAME}-vnet",
-              "vnetResourceGroup": "${CLUSTER_NAME}",
-              "subnetName": "${CLUSTER_NAME}-node-subnet",
-              "routeTableName": "${CLUSTER_NAME}-node-routetable",
-              "loadBalancerSku": "standard",
-              "maximumLoadBalancerRuleCount": 250,
-              "useManagedIdentityExtension": false,
-              "useInstanceMetadata": true
-            }
+          contentFrom:
+            secret:
+              key: vmss
+              name: azure-secret
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachineTemplate

--- a/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -87,27 +87,10 @@ spec:
     - path: /etc/kubernetes/azure.json
       owner: "root:root"
       permissions: "0644"
-      content: |
-        {
-          "cloud": "AzurePublicCloud",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${AZURE_RESOURCE_GROUP}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${CLUSTER_NAME}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "userAssignedID": "${CLUSTER_NAME}",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+      contentFrom:
+        secret:
+          key: vmss
+          name: azure-secret
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
@@ -194,26 +177,10 @@ spec:
     - path: /etc/kubernetes/azure.json
       owner: "root:root"
       permissions: "0644"
-      content: |
-        {
-          "cloud": "AzurePublicCloud",
-          "tenantId": "${AZURE_TENANT_ID}",
-          "subscriptionId": "${AZURE_SUBSCRIPTION_ID}",
-          "aadClientId": "${AZURE_CLIENT_ID}",
-          "aadClientSecret": "${AZURE_CLIENT_SECRET}",
-          "resourceGroup": "${CLUSTER_NAME}",
-          "securityGroupName": "${CLUSTER_NAME}-node-nsg",
-          "location": "${AZURE_LOCATION}",
-          "vmType": "vmss",
-          "vnetName": "${CLUSTER_NAME}-vnet",
-          "vnetResourceGroup": "${CLUSTER_NAME}",
-          "subnetName": "${CLUSTER_NAME}-node-subnet",
-          "routeTableName": "${CLUSTER_NAME}-node-routetable",
-          "loadBalancerSku": "standard",
-          "maximumLoadBalancerRuleCount": 250,
-          "useManagedIdentityExtension": false,
-          "useInstanceMetadata": true
-        }
+      contentFrom:
+        secret:
+          key: vmss
+          name: azure-secret
 ---
 apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachinePool

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -75,6 +75,8 @@ var _ = Describe("Workoad cluster creation", func() {
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, cluster, e2eConfig.GetIntervals, skipCleanup)
 		Expect(os.Unsetenv(AzureResourceGroup)).NotTo(HaveOccurred())
 		Expect(os.Unsetenv(AzureVNetName)).NotTo(HaveOccurred())
+		Expect(os.Unsetenv(AzureStandardJson)).NotTo(HaveOccurred())
+		Expect(os.Unsetenv(AzureVMSSJson)).NotTo(HaveOccurred())
 	})
 
 	Context("Create single controlplane cluster", func() {

--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -31,11 +31,33 @@ import (
 )
 
 var _ = Describe("Running the Cluster API E2E tests", func() {
+	var (
+		standardCloudConfig string
+		vmssCloudConfig     string
+	)
 
 	BeforeEach(func() {
 		rgName := fmt.Sprintf("capz-e2e-%s", util.RandomString(6))
 		Expect(os.Setenv(AzureResourceGroup, rgName)).NotTo(HaveOccurred())
 		Expect(os.Setenv(AzureVNetName, fmt.Sprintf("%s-vnet", rgName))).NotTo(HaveOccurred())
+
+		var err error
+		standardCloudConfig, err = getCloudProviderConfig(rgName, "standard")
+		Expect(err).NotTo(HaveOccurred())
+
+		vmssCloudConfig, err = getCloudProviderConfig(rgName, "vmss")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.Setenv(AzureStandardJson, standardCloudConfig)).NotTo(HaveOccurred())
+		Expect(os.Setenv(AzureVMSSJson, vmssCloudConfig)).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		redactLogs()
+		Expect(os.Unsetenv(AzureResourceGroup)).NotTo(HaveOccurred())
+		Expect(os.Unsetenv(AzureVNetName)).NotTo(HaveOccurred())
+		Expect(os.Unsetenv(AzureStandardJson)).NotTo(HaveOccurred())
+		Expect(os.Unsetenv(AzureVMSSJson)).NotTo(HaveOccurred())
 	})
 
 	Context("Running the quick-start spec", func() {

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -54,6 +54,7 @@ variables:
   KUBERNETES_VERSION_UPGRADE_TO: "${KUBERNETES_VERSION_UPGRADE_TO:-v1.18.3}"
   KUBERNETES_VERSION_UPGRADE_FROM: "${KUBERNETES_VERSION_UPGRADE_FROM:-v1.17.4}"
   CNI: "${PWD}/templates/addons/calico.yaml"
+  REDACT_LOG_SCRIPT: "${PWD}/hack/log/redact.sh"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

Follow-up PR for https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/653. Also fixed CAPI e2e regression introduced by #653.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```