### PR TITLE
🌱 cloud/publicips: add logger scope in public ip service

### DIFF
--- a/cloud/services/publicips/mock_publicips/publicips_mock.go
+++ b/cloud/services/publicips/mock_publicips/publicips_mock.go
@@ -22,6 +22,7 @@ package mock_publicips
 
 import (
 	autorest "github.com/Azure/go-autorest/autorest"
+	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	v1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
@@ -49,6 +50,100 @@ func NewMockPublicIPScope(ctrl *gomock.Controller) *MockPublicIPScope {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPublicIPScope) EXPECT() *MockPublicIPScopeMockRecorder {
 	return m.recorder
+}
+
+// Info mocks base method.
+func (m *MockPublicIPScope) Info(msg string, keysAndValues ...interface{}) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{msg}
+	for _, a := range keysAndValues {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Info", varargs...)
+}
+
+// Info indicates an expected call of Info.
+func (mr *MockPublicIPScopeMockRecorder) Info(msg interface{}, keysAndValues ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{msg}, keysAndValues...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockPublicIPScope)(nil).Info), varargs...)
+}
+
+// Enabled mocks base method.
+func (m *MockPublicIPScope) Enabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Enabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Enabled indicates an expected call of Enabled.
+func (mr *MockPublicIPScopeMockRecorder) Enabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enabled", reflect.TypeOf((*MockPublicIPScope)(nil).Enabled))
+}
+
+// Error mocks base method.
+func (m *MockPublicIPScope) Error(err error, msg string, keysAndValues ...interface{}) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{err, msg}
+	for _, a := range keysAndValues {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Error", varargs...)
+}
+
+// Error indicates an expected call of Error.
+func (mr *MockPublicIPScopeMockRecorder) Error(err, msg interface{}, keysAndValues ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{err, msg}, keysAndValues...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockPublicIPScope)(nil).Error), varargs...)
+}
+
+// V mocks base method.
+func (m *MockPublicIPScope) V(level int) logr.InfoLogger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "V", level)
+	ret0, _ := ret[0].(logr.InfoLogger)
+	return ret0
+}
+
+// V indicates an expected call of V.
+func (mr *MockPublicIPScopeMockRecorder) V(level interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V", reflect.TypeOf((*MockPublicIPScope)(nil).V), level)
+}
+
+// WithValues mocks base method.
+func (m *MockPublicIPScope) WithValues(keysAndValues ...interface{}) logr.Logger {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range keysAndValues {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WithValues", varargs...)
+	ret0, _ := ret[0].(logr.Logger)
+	return ret0
+}
+
+// WithValues indicates an expected call of WithValues.
+func (mr *MockPublicIPScopeMockRecorder) WithValues(keysAndValues ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithValues", reflect.TypeOf((*MockPublicIPScope)(nil).WithValues), keysAndValues...)
+}
+
+// WithName mocks base method.
+func (m *MockPublicIPScope) WithName(name string) logr.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithName", name)
+	ret0, _ := ret[0].(logr.Logger)
+	return ret0
+}
+
+// WithName indicates an expected call of WithName.
+func (mr *MockPublicIPScopeMockRecorder) WithName(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithName", reflect.TypeOf((*MockPublicIPScope)(nil).WithName), name)
 }
 
 // SubscriptionID mocks base method.

--- a/cloud/services/publicips/publicips.go
+++ b/cloud/services/publicips/publicips.go
@@ -23,15 +23,13 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 )
 
 // Reconcile gets/creates/updates a public ip.
 func (s *Service) Reconcile(ctx context.Context) error {
 	for _, ip := range s.Scope.PublicIPSpecs() {
-		klog.V(2).Infof("creating public IP %s", ip.Name)
-
+		s.Scope.V(2).Info("creating public IP", "public ip", ip.Name)
 		err := s.Client.CreateOrUpdate(
 			ctx,
 			s.Scope.ResourceGroup(),
@@ -54,15 +52,17 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "cannot create public IP")
 		}
-		klog.V(2).Infof("successfully created public IP %s", ip.Name)
+
+		s.Scope.V(2).Info("successfully created public IP", "public ip", ip.Name)
 	}
+
 	return nil
 }
 
 // Delete deletes the public IP with the provided scope.
 func (s *Service) Delete(ctx context.Context) error {
 	for _, ip := range s.Scope.PublicIPSpecs() {
-		klog.V(2).Infof("deleting public IP %s", ip.Name)
+		s.Scope.V(2).Info("deleting public IP", "public ip", ip.Name)
 		err := s.Client.Delete(ctx, s.Scope.ResourceGroup(), ip.Name)
 		if err != nil && azure.ResourceNotFound(err) {
 			// already deleted
@@ -72,7 +72,7 @@ func (s *Service) Delete(ctx context.Context) error {
 			return errors.Wrapf(err, "failed to delete public IP %s in resource group %s", ip.Name, s.Scope.ResourceGroup())
 		}
 
-		klog.V(2).Infof("deleted public IP %s", ip.Name)
+		s.Scope.V(2).Info("deleted public IP", "public ip", ip.Name)
 	}
 	return nil
 }

--- a/cloud/services/publicips/publicips_test.go
+++ b/cloud/services/publicips/publicips_test.go
@@ -31,6 +31,7 @@ import (
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
@@ -48,6 +49,7 @@ func TestReconcilePublicIP(t *testing.T) {
 			name:          "can create public IPs",
 			expectedError: "",
 			expect: func(s *mock_publicips.MockPublicIPScopeMockRecorder, m *mock_publicips.MockClientMockRecorder) {
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.PublicIPSpecs().Return([]azure.PublicIPSpec{
 					{
 						Name:    "my-publicip",
@@ -72,6 +74,7 @@ func TestReconcilePublicIP(t *testing.T) {
 			name:          "fail to create a public IP",
 			expectedError: "cannot create public IP: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_publicips.MockPublicIPScopeMockRecorder, m *mock_publicips.MockClientMockRecorder) {
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.PublicIPSpecs().Return([]azure.PublicIPSpec{
 					{
 						Name:    "my-publicip",
@@ -123,6 +126,7 @@ func TestDeletePublicIP(t *testing.T) {
 			name:          "successfully delete two existing public IP",
 			expectedError: "",
 			expect: func(s *mock_publicips.MockPublicIPScopeMockRecorder, m *mock_publicips.MockClientMockRecorder) {
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.PublicIPSpecs().Return([]azure.PublicIPSpec{
 					{
 						Name: "my-publicip",
@@ -140,6 +144,7 @@ func TestDeletePublicIP(t *testing.T) {
 			name:          "public ip already deleted",
 			expectedError: "",
 			expect: func(s *mock_publicips.MockPublicIPScopeMockRecorder, m *mock_publicips.MockClientMockRecorder) {
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.PublicIPSpecs().Return([]azure.PublicIPSpec{
 					{
 						Name: "my-publicip",
@@ -154,6 +159,7 @@ func TestDeletePublicIP(t *testing.T) {
 			name:          "public ip deletion fails",
 			expectedError: "failed to delete public IP my-publicip in resource group my-rg: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_publicips.MockPublicIPScopeMockRecorder, m *mock_publicips.MockClientMockRecorder) {
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.PublicIPSpecs().Return([]azure.PublicIPSpec{
 					{
 						Name: "my-publicip",

--- a/cloud/services/publicips/service.go
+++ b/cloud/services/publicips/service.go
@@ -18,10 +18,13 @@ package publicips
 
 import (
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
+
+	"github.com/go-logr/logr"
 )
 
 // PublicIPScope defines the scope interface for a public IP service.
 type PublicIPScope interface {
+	logr.Logger
 	azure.ClusterDescriber
 	PublicIPSpecs() []azure.PublicIPSpec
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a scope logger in the public IP services as follow up of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/739#issuecomment-652460892


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```