### PR TITLE
💎  Embed ClusterDescriber in MachineScope to remove the need for duplicate Getters

### DIFF
--- a/cloud/services/disks/disks_test.go
+++ b/cloud/services/disks/disks_test.go
@@ -28,14 +28,8 @@ import (
 
 	"github.com/golang/mock/gomock"
 
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/klogr"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
-
-func init() {
-	_ = clusterv1.AddToScheme(scheme.Scheme)
-}
 
 func TestDeleteDisk(t *testing.T) {
 	testcases := []struct {

--- a/cloud/services/scalesets/vmss_test.go
+++ b/cloud/services/scalesets/vmss_test.go
@@ -75,12 +75,11 @@ func TestNewService(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	mps, err := scope.NewMachinePoolScope(scope.MachinePoolScopeParams{
-		AzureClients:     s.AzureClients,
 		Client:           client,
 		Logger:           s.Logger,
 		MachinePool:      new(clusterv1exp.MachinePool),
 		AzureMachinePool: new(infrav1exp.AzureMachinePool),
-		ClusterScope:     s,
+		ClusterDescriber: s,
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	actual := NewService(mps)
@@ -869,16 +868,15 @@ func getScopes(g *gomega.GomegaWithT) (*scope.ClusterScope, *scope.MachinePoolSc
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	mps, err := scope.NewMachinePoolScope(scope.MachinePoolScopeParams{
-		AzureClients: s.AzureClients,
-		Client:       client,
-		Logger:       s.Logger,
-		MachinePool:  new(clusterv1exp.MachinePool),
+		Client:      client,
+		Logger:      s.Logger,
+		MachinePool: new(clusterv1exp.MachinePool),
 		AzureMachinePool: &infrav1exp.AzureMachinePool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "capz-mp-0",
 			},
 		},
-		ClusterScope: s,
+		ClusterDescriber: s,
 	})
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -654,13 +654,10 @@ func TestReconcileVM(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
-				Client:  client,
-				Machine: &tc.machine,
-				AzureClients: scope.AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
-				AzureMachine: azureMachine,
-				ClusterScope: clusterScope,
+				Client:           client,
+				Machine:          &tc.machine,
+				AzureMachine:     azureMachine,
+				ClusterDescriber: clusterScope,
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -179,11 +179,11 @@ func (r *AzureMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, ret
 
 	// Create the machine scope
 	machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
-		Logger:       logger,
-		Client:       r.Client,
-		Machine:      machine,
-		AzureMachine: azureMachine,
-		ClusterScope: clusterScope,
+		Logger:           logger,
+		Client:           r.Client,
+		Machine:          machine,
+		AzureMachine:     azureMachine,
+		ClusterDescriber: clusterScope,
 	})
 	if err != nil {
 		r.Recorder.Eventf(azureMachine, corev1.EventTypeWarning, "Error creating the machine scope", err.Error())

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -303,13 +303,10 @@ func TestConditions(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
-				AzureClients: scope.AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
-				Client:       client,
-				ClusterScope: clusterScope,
-				Machine:      tc.machine,
-				AzureMachine: tc.azureMachine,
+				Client:           client,
+				ClusterDescriber: clusterScope,
+				Machine:          tc.machine,
+				AzureMachine:     tc.azureMachine,
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/azuremachine_reconciler_test.go
+++ b/controllers/azuremachine_reconciler_test.go
@@ -127,8 +127,8 @@ func TestIsAvailabilityZoneSupported(t *testing.T) {
 
 	s := azureMachineService{
 		machineScope: &scope.MachineScope{
-			Logger:       log.Log.Logger,
-			ClusterScope: clusterScope,
+			Logger:           log.Log.Logger,
+			ClusterDescriber: clusterScope,
 		},
 	}
 

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -202,7 +202,7 @@ func (r *AzureMachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result,
 		Client:           r.Client,
 		MachinePool:      machinePool,
 		AzureMachinePool: azMachinePool,
-		ClusterScope:     clusterScope,
+		ClusterDescriber: clusterScope,
 	})
 	if err != nil {
 		return reconcile.Result{}, errors.Errorf("failed to create scope: %+v", err)

--- a/exp/controllers/azuremachinepool_controller_unit_test.go
+++ b/exp/controllers/azuremachinepool_controller_unit_test.go
@@ -269,7 +269,7 @@ func Test_newAzureMachinePoolService(t *testing.T) {
 	}
 
 	mps := &scope.MachinePoolScope{
-		ClusterScope: cs,
+		ClusterDescriber: cs,
 		AzureMachinePool: &infrav1exp.AzureMachinePool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "poolName",


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: This is an amendment to what was done in #716. What it does:
- embeds ClusterDescriber in MachineScope and MachinePoolScope (instead of having a field `ClusterScope azure.ClusterDescriber`)
- removes pass through functions such as `func (m *MachineScope) Location() string {
	return m.ClusterScope.Location()
}`
- ~changes newClusterScope, newMachineScope and newMachinePoolScope signature to not return a pointer (so that the returned scope can be used as param to build another scope without having to dereference the pointer).~
- Removes AzureClients from MachinePoolScope since it is already part of ClusterScope (already removed from MachineScope).

Now, machine/machinepool scope only need to implement functions that need to override the cluster scope one, eg. PublicIPSpecs(), instead of having to implement all the ClusterDescriber functions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
:gem: Embed ClusterScope in MachineScope to remove the need for duplicate Cluster Getters
```