### PR TITLE
🐛 Add secondary network interface for node public IPs

### DIFF
--- a/cloud/defaults.go
+++ b/cloud/defaults.go
@@ -82,14 +82,19 @@ func GenerateNodeOutboundIPName(clusterName string) string {
 	return fmt.Sprintf("pip-%s-node-outbound", clusterName)
 }
 
-// GenerateNodePublicIPName generates a node public IP name, based on the NIC name.
-func GenerateNodePublicIPName(nicName string) string {
-	return fmt.Sprintf("%s-public-ip", nicName)
+// GenerateNodePublicIPName generates a node public IP name, based on the machine name.
+func GenerateNodePublicIPName(machineName string) string {
+	return fmt.Sprintf("pip-%s", machineName)
 }
 
 // GenerateNICName generates the name of a network interface based on the name of a VM.
 func GenerateNICName(machineName string) string {
 	return fmt.Sprintf("%s-nic", machineName)
+}
+
+// GeneratePublicNICName generates the name of a public network interface based on the name of a VM.
+func GeneratePublicNICName(machineName string) string {
+	return fmt.Sprintf("%s-public-nic", machineName)
 }
 
 // GenerateOSDiskName generates the name of an OS disk based on the name of a VM.

--- a/cloud/services/networkinterfaces/networkinterfaces.go
+++ b/cloud/services/networkinterfaces/networkinterfaces.go
@@ -36,8 +36,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to get subnets")
 		}
-
 		nicConfig.Subnet = &network.Subnet{ID: subnet.ID}
+
 		nicConfig.PrivateIPAllocationMethod = network.Dynamic
 		if nicSpec.StaticIPAddress != "" {
 			nicConfig.PrivateIPAllocationMethod = network.Static
@@ -50,7 +50,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			if lberr != nil {
 				return errors.Wrap(lberr, "failed to get public LB")
 			}
-
 			backendAddressPools = append(backendAddressPools,
 				network.BackendAddressPool{
 					ID: (*lb.BackendAddressPools)[0].ID,

--- a/cloud/services/networkinterfaces/networkinterfaces_test.go
+++ b/cloud/services/networkinterfaces/networkinterfaces_test.go
@@ -448,10 +448,20 @@ func TestReconcileNetworkInterface(t *testing.T) {
 						VNetName:                 "my-vnet",
 						VNetResourceGroup:        "my-rg",
 						PublicLoadBalancerName:   "my-public-lb",
-						PublicIPName:             "my-public-ip",
 						InternalLoadBalancerName: "my-internal-lb",
 						VMSize:                   "Standard_D2v2",
 						AcceleratedNetworking:    nil,
+					},
+					{
+						Name:                  "my-public-net-interface",
+						MachineName:           "azure-test1",
+						MachineRole:           infrav1.Node,
+						SubnetName:            "my-subnet",
+						VNetName:              "my-vnet",
+						VNetResourceGroup:     "my-rg",
+						PublicIPName:          "my-public-ip",
+						VMSize:                "Standard_D2v2",
+						AcceleratedNetworking: nil,
 					},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -461,7 +471,8 @@ func TestReconcileNetworkInterface(t *testing.T) {
 					mLoadBalancer.Get(context.TODO(), "my-rg", "my-public-lb").Return(getFakeNodeOutboundLoadBalancer(), nil),
 					mPublicIP.Get(context.TODO(), "my-rg", "my-public-ip").Return(network.PublicIPAddress{}, nil),
 					mResourceSku.HasAcceleratedNetworking(gomock.Any(), gomock.Any()),
-					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomock.AssignableToTypeOf(network.Interface{})))
+					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomock.AssignableToTypeOf(network.Interface{})),
+					m.CreateOrUpdate(context.TODO(), "my-rg", "my-public-net-interface", gomock.AssignableToTypeOf(network.Interface{})))
 			},
 		},
 		{

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -675,7 +675,7 @@ func TestReconcileVM(t *testing.T) {
 
 			vmSpec := &Spec{
 				Name:          machineScope.Name(),
-				NICName:       "test-nic",
+				NICNames:      []string{"test-nic"},
 				SSHKeyData:    "fake-key",
 				Size:          machineScope.AzureMachine.Spec.VMSize,
 				OSDisk:        machineScope.AzureMachine.Spec.OSDisk,

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -209,6 +209,11 @@ func (s *azureMachineService) reconcileVirtualMachine(ctx context.Context, nicNa
 		}
 	}
 
+	nicNames := []string{nicName}
+	if s.machineScope.AzureMachine.Spec.AllocatePublicIP == true {
+		nicNames = append(nicNames, azure.GeneratePublicNICName(s.machineScope.Name()))
+	}
+
 	image, err := getVMImage(s.machineScope)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get VM image")
@@ -221,7 +226,7 @@ func (s *azureMachineService) reconcileVirtualMachine(ctx context.Context, nicNa
 
 	vmSpec := &virtualmachines.Spec{
 		Name:                   s.machineScope.Name(),
-		NICName:                nicName,
+		NICNames:               nicNames,
 		SSHKeyData:             string(decoded),
 		Size:                   s.machineScope.AzureMachine.Spec.VMSize,
 		OSDisk:                 s.machineScope.AzureMachine.Spec.OSDisk,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: Fix error `NicWithPublicIpCannotReferencePoolWithOutboundRule` when `allocatePublicIP` is true on an AzureMachine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #717 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
:bug: Add secondary network interface for node public IPs
```