### PR TITLE
🐛 Delete OS disk when failed VM gets deleted

### DIFF
--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -252,6 +252,13 @@ func (s *azureMachineService) reconcileVirtualMachine(ctx context.Context, nicNa
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to delete machine")
 			}
+			OSDiskSpec := &disks.Spec{
+				Name: azure.GenerateOSDiskName(s.machineScope.Name()),
+			}
+			err = s.disksSvc.Delete(ctx, OSDiskSpec)
+			if err != nil && !azure.ResourceNotFound(err) {
+				return nil, errors.Wrapf(err, "failed to delete OS disk of machine %s", s.machineScope.Name())
+			}
 			return nil, errors.Errorf("virtual machine %s is deleted, retry creating in next reconcile", s.machineScope.Name())
 		} else if newVM.State != infrav1.VMStateSucceeded {
 			return nil, errors.Errorf("virtual machine %s is still in provisioning state %s, reconcile", s.machineScope.Name(), newVM.State)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: Fixes an error `Only CreateOption.Attach is supported` if an internal (transient) Azure error occurs, when the VM is deleted and we try to create it again with the same existing OS disk.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #755 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Delete OS disk when failed VM gets deleted
```