### PR TITLE
💚 add test to validate accelerated networking for VMs

### DIFF
--- a/cloud/services/agentpools/agentpools_test.go
+++ b/cloud/services/agentpools/agentpools_test.go
@@ -229,7 +229,7 @@ func TestReconcile(t *testing.T) {
 				Name:          "my-agent-pool",
 				ResourceGroup: "my-rg",
 				Cluster:       "my-cluster",
-				SKU:           "Standard_A1",
+				SKU:           "Standard_D2s_v3",
 				Version:       to.StringPtr("9.99.9999"),
 				Replicas:      2,
 				OSDiskSizeGB:  100,
@@ -240,7 +240,7 @@ func TestReconcile(t *testing.T) {
 					ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 						Count:               to.Int32Ptr(2),
 						OsDiskSizeGB:        to.Int32Ptr(100),
-						VMSize:              containerservice.VMSizeTypesStandardA1,
+						VMSize:              containerservice.VMSizeTypesStandardD2sV3,
 						OrchestratorVersion: to.StringPtr("9.99.9999"),
 						ProvisioningState:   to.StringPtr("Succeeded"),
 					},

--- a/test/e2e/azure_accelnet.go
+++ b/test/e2e/azure_accelnet.go
@@ -1,0 +1,96 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// AzureAcceleratedNetworkingSpecInput is the input for AzureAcceleratedNetworkingSpec.
+type AzureAcceleratedNetworkingSpecInput struct {
+	ClusterName string
+}
+
+// AzureAcceleratedNetworkingSpec implements a test that verifies Azure VMs in a workload
+// cluster provisioned by CAPZ have accelerated networking enabled if they're capable of it.
+func AzureAcceleratedNetworkingSpec(ctx context.Context, inputGetter func() AzureAcceleratedNetworkingSpecInput) {
+	var (
+		specName = "azure-accelerated-networking"
+		input    AzureAcceleratedNetworkingSpecInput
+	)
+
+	input = inputGetter()
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+
+	By("creating Azure clients with the workload cluster's subscription")
+	settings, err := auth.GetSettingsFromEnvironment()
+	Expect(err).NotTo(HaveOccurred())
+	subscriptionID := settings.GetSubscriptionID()
+	authorizer, err := settings.GetAuthorizer()
+	Expect(err).NotTo(HaveOccurred())
+	vmsClient := compute.NewVirtualMachinesClient(subscriptionID)
+	vmsClient.Authorizer = authorizer
+	nicsClient := network.NewInterfacesClient(subscriptionID)
+	nicsClient.Authorizer = authorizer
+
+	By("verifying EnableAcceleratedNetworking for the primary NIC of each VM")
+	// NOTE: add SKUs being tested to this lookup table.
+	acceleratedNetworking := map[compute.VirtualMachineSizeTypes]bool{
+		compute.VirtualMachineSizeTypesStandardB2ms:  false,
+		compute.VirtualMachineSizeTypesStandardD2V2:  true,
+		compute.VirtualMachineSizeTypesStandardD2V3:  false,
+		compute.VirtualMachineSizeTypesStandardD2sV3: false,
+		compute.VirtualMachineSizeTypesStandardD4V2:  true,
+		compute.VirtualMachineSizeTypesStandardD4V3:  true,
+		compute.VirtualMachineSizeTypesStandardD8sV3: true,
+	}
+	rgName := input.ClusterName
+	page, err := vmsClient.List(ctx, rgName)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(page.Values())).To(BeNumerically(">", 0))
+	for page.NotDone() {
+		for _, vm := range page.Values() {
+			sku := vm.HardwareProfile.VMSize
+			for _, nic := range *vm.NetworkProfile.NetworkInterfaces {
+				if nic.Primary != nil && *nic.Primary {
+					// verify that accelerated networking is enabled if the SKU is capable
+					nicInfo, err := nicsClient.Get(ctx, rgName, filepath.Base(*nic.ID), "")
+					Expect(err).NotTo(HaveOccurred())
+					capable, found := acceleratedNetworking[sku]
+					if !found {
+						fmt.Fprintf(GinkgoWriter, "SKU %s was not found, please add to the acceleratedNetworking lookup table.\n", sku)
+					} else {
+						Expect(capable).To(Equal(*nicInfo.EnableAcceleratedNetworking))
+					}
+					break
+				}
+			}
+		}
+		err = page.NextWithContext(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Workload cluster creation", func() {
 				})
 			})
 
-			Context("Creating a accessible load balancer", func() {
+			Context("Creating an accessible load balancer", func() {
 				AzureLBSpec(ctx, func() AzureLBSpecInput {
 					return AzureLBSpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
@@ -143,6 +143,14 @@ var _ = Describe("Workload cluster creation", func() {
 						Namespace:             namespace,
 						ClusterName:           clusterName,
 						SkipCleanup:           skipCleanup,
+					}
+				})
+			})
+
+			Context("Validating accelerated networking", func() {
+				AzureAcceleratedNetworkingSpec(ctx, func() AzureAcceleratedNetworkingSpecInput {
+					return AzureAcceleratedNetworkingSpecInput{
+						ClusterName: clusterName,
 					}
 				})
 			})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

Validates that the Azure VMs created have accelerated networking enabled if it's available for that SKU. (This is the default behavior--I didn't add a test for explicitly toggling it on or off.)

**Which issue(s) this PR fixes**:

Fixes #706

**Special notes for your reviewer**:

I didn't add a similar test for VM scalesets because we don't utilize `MachinePool` in e2e tests (yet).

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
💚 add test to validate accelerated networking for VMs
```