### PR TITLE
makefile: Add a make target to generate test coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.*
 
 # Ansible
 *.retry

--- a/Makefile
+++ b/Makefile
@@ -136,14 +136,21 @@ help:  ## Display this help
 .PHONY: test
 test: generate lint go-test ## Run generate lint and tests
 
-go-test: export TEST_ASSET_KUBECTL = $(KUBECTL)
-go-test: export TEST_ASSET_KUBE_APISERVER = $(KUBE_APISERVER)
-go-test: export TEST_ASSET_ETCD = $(ETCD)
+envs-test:
+export TEST_ASSET_KUBECTL = $(KUBECTL)
+export TEST_ASSET_KUBE_APISERVER = $(KUBE_APISERVER)
+export TEST_ASSET_ETCD = $(ETCD)
 
 .PHONY: go-test
-go-test: $(KUBECTL) $(KUBE_APISERVER) $(ETCD) ## Run go tests
+go-test: envs-test $(KUBECTL) $(KUBE_APISERVER) $(ETCD) ## Run go tests
+	echo $(TEST_ASSET_KUBECTL)
 	go test ./...
 
+.PHONY: test-cover
+test-cover: envs-test $(KUBECTL) $(KUBE_APISERVER) $(ETCD) ## Run tests with code coverage and code generate reports
+	go test -v -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out -o coverage.txt
+	go tool cover -html=coverage.out -o coverage.html
 
 .PHONY: test-integration
 test-integration: ## Run integration tests


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a make target to generate test coverage reports in similar way that was added here: https://github.com/kubernetes-sigs/cluster-api/pull/3310

After this, we can create the prow job to generate the reports. i hope :)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes partially https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/692

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
makefile: Add a make target to generate test coverage report
```