### PR TITLE
💎  rename feature_gate_machine_pool to exp_machine_pool to match capi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ SKIP_CREATE_MGMT_CLUSTER ?= false
 LDFLAGS := $(shell hack/version.sh)
 
 # Allow overriding the feature gates
-FEATURE_GATE_MACHINE_POOL ?= false
-FEATURE_GATES_JSON_PATCH := [{"op": "add", "path": "/spec/template/spec/containers/1/args/-", "value": "--feature-gates=MachinePool=$(FEATURE_GATE_MACHINE_POOL)"}]
+EXP_MACHINE_POOL ?= false
+FEATURE_GATES_JSON_PATCH := [{"op": "add", "path": "/spec/template/spec/containers/1/args/-", "value": "--feature-gates=MachinePool=$(EXP_MACHINE_POOL)"}]
 
 CLUSTER_TEMPLATE ?= cluster-template.yaml
 MANAGED_CLUSTER_TEMPLATE ?= cluster-template-aks.yaml

--- a/docs/development.md
+++ b/docs/development.md
@@ -387,7 +387,7 @@ You can optionally set the following variables:
 | `PARALLEL`                     | Skip serial tests and set --ginkgo-parallel.                                                                  |
 | `USE_CI_ARTIFACTS`             | Use a CI version of Kubernetes, ie. not a released version (eg. `v1.19.0-alpha.1.426+0926c9c47677e9`)         |
 | `CI_VERSION`                   | Provide a custom CI version of Kubernetes. By default, the latest master commit will be used.                 |
-| `FEATURE_GATE_MACHINE_POOL`    | Use [Machine Pool](topics/machinepools.md) for worker machines.                                               |
+| `EXP_MACHINE_POOL`             | Use [Machine Pool](topics/machinepools.md) for worker machines.                                               |
 
 You can also customize the configuration of the CAPZ cluster (assuming that `SKIP_CREATE_WORKLOAD_CLUSTER` is not set). See [Customizing the cluster deployment](#customizing-the-cluster-deployment) for more details.
 

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -78,7 +78,7 @@ create_cluster() {
         export CLUSTER_TEMPLATE="test/cluster-template-prow.yaml"
     fi
 
-    if [[ "${FEATURE_GATE_MACHINE_POOL:-}" == "true" ]]; then
+    if [[ "${EXP_MACHINE_POOL:-}" == "true" ]]; then
         export CLUSTER_TEMPLATE="${CLUSTER_TEMPLATE/prow/prow-machine-pool}"
     fi
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:
rename `feature_gate_machine_pool` to `exp_machine_pool` to match cluster-api
 


- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Rename FEATURE_GATE_MACHINE_POOL to EXP_MACHINE_POOL so its matches cluster-api
```