### PR TITLE
🌱 Enable experimental features in e2e testing

### DIFF
--- a/.tiltignore
+++ b/.tiltignore
@@ -1,0 +1,1 @@
+templates

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
         - args:
             - --enable-leader-election
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},AKS=${EXP_AKS:=false}"
           image: controller:latest
           imagePullPolicy: Always
           name: manager

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -23,3 +23,4 @@ spec:
           args:
             - "--metrics-addr=127.0.0.1:8080"
             - "--enable-leader-election"
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},AKS=${EXP_AKS:=false}"

--- a/config/webhook/manager_webhook_patch.yaml
+++ b/config/webhook/manager_webhook_patch.yaml
@@ -11,6 +11,7 @@ spec:
           args:
             - "--metrics-addr=127.0.0.1:8080"
             - "--webhook-port=9443"
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},AKS=${EXP_AKS:=false}"
           ports:
             - containerPort: 9443
               name: webhook-server

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -55,6 +55,9 @@ variables:
   KUBERNETES_VERSION_UPGRADE_FROM: "${KUBERNETES_VERSION_UPGRADE_FROM:-v1.17.4}"
   CNI: "${PWD}/templates/addons/calico.yaml"
   REDACT_LOG_SCRIPT: "${PWD}/hack/log/redact.sh"
+  EXP_CLUSTER_RESOURCE_SET: "true"
+  EXP_AKS: "true"
+  EXP_MACHINE_POOL: "true"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

The current E2E tests do not enable experimental features. This PR enables ENV var substitution for known feature flags and populates env vars for the E2E tests with true, enabling the features.

related: https://github.com/kubernetes-sigs/cluster-api/pull/3325

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable env substitution for experimental features and enable them in the E2E tests
```