### PR TITLE
Exp cluster resourse set

### DIFF
--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -370,3 +372,26 @@ spec:
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
       - bash -c /tmp/kubeadm-bootstrap.sh
+---
+apiVersion: v1
+data:
+  addon.yaml: ${CNI_RESOURCES}
+kind: Secret
+metadata:
+  name: cni-calico
+  namespace: default
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  resources:
+  - kind: Secret
+    name: cni-calico
+  strategy: ApplyOnce

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -366,3 +368,26 @@ spec:
   preKubeadmCommands:
   - bash -c /tmp/kubeadm-bootstrap.sh
   useExperimentalRetryJoin: true
+---
+apiVersion: v1
+data:
+  addon.yaml: ${CNI_RESOURCES}
+kind: Secret
+metadata:
+  name: cni-calico
+  namespace: default
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  resources:
+  - kind: Secret
+    name: cni-calico
+  strategy: ApplyOnce

--- a/templates/test/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/cluster-template-prow-machine-pool.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -200,3 +202,26 @@ spec:
         cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
   useExperimentalRetryJoin: true
+---
+apiVersion: v1
+data:
+  addon.yaml: ${CNI_RESOURCES}
+kind: Secret
+metadata:
+  name: cni-calico
+  namespace: default
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  resources:
+  - kind: Secret
+    name: cni-calico
+  strategy: ApplyOnce

--- a/templates/test/cluster-template-prow.yaml
+++ b/templates/test/cluster-template-prow.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -205,3 +207,26 @@ spec:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
+---
+apiVersion: v1
+data:
+  addon.yaml: ${CNI_RESOURCES}
+kind: Secret
+metadata:
+  name: cni-calico
+  namespace: default
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  resources:
+  - kind: Secret
+    name: cni-calico
+  strategy: ApplyOnce

--- a/templates/test/patches/cluster-resource-set-label.yaml
+++ b/templates/test/patches/cluster-resource-set-label.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+  labels:
+    cni: "calico"

--- a/templates/test/patches/cluster-resource-set.yaml
+++ b/templates/test/patches/cluster-resource-set.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cni-calico
+type: addons.cluster.x-k8s.io/resource-set
+data:
+  addon.yaml: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name:  "${CLUSTER_NAME}-crs-0"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "calico"
+  resources:
+    - name: cni-calico
+      kind: Secret
+---

--- a/templates/test/prow-machine-pool/kustomization.yaml
+++ b/templates/test/prow-machine-pool/kustomization.yaml
@@ -3,5 +3,8 @@ kind: Kustomization
 namespace: default
 resources:
   - ../../flavors/machinepool
+  - ../patches/cluster-resource-set.yaml
+
 patchesStrategicMerge:
   - ../patches/tags.yaml
+  - ../patches/cluster-resource-set-label.yaml

--- a/templates/test/prow/kustomization.yaml
+++ b/templates/test/prow/kustomization.yaml
@@ -3,5 +3,8 @@ kind: Kustomization
 namespace: default
 resources:
   - ../../flavors/default
+  - ../patches/cluster-resource-set.yaml
+
 patchesStrategicMerge:
   - ../patches/tags.yaml
+  - ../patches/cluster-resource-set-label.yaml

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -52,7 +53,10 @@ var _ = Describe("Workload cluster creation", func() {
 		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
 
 		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		// Read CNI file and set CNI_RESOURCES environmental variable
 		Expect(e2eConfig.Variables).To(HaveKey(CNIPath))
+		setCNIResources(e2eConfig.GetVariable(CNIPath))
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
@@ -91,7 +95,6 @@ var _ = Describe("Workload cluster creation", func() {
 					ControlPlaneMachineCount: pointer.Int64Ptr(1),
 					WorkerMachineCount:       pointer.Int64Ptr(0),
 				},
-				CNIManifestPath:              e2eConfig.GetVariable(CNIPath),
 				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
@@ -115,7 +118,6 @@ var _ = Describe("Workload cluster creation", func() {
 					ControlPlaneMachineCount: pointer.Int64Ptr(3),
 					WorkerMachineCount:       pointer.Int64Ptr(1),
 				},
-				CNIManifestPath:              e2eConfig.GetVariable(CNIPath),
 				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
 				WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -23,12 +23,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -39,6 +41,7 @@ import (
 const (
 	KubernetesVersion   = "KUBERNETES_VERSION"
 	CNIPath             = "CNI"
+	CNIResources        = "CNI_RESOURCES"
 	RedactLogScriptPath = "REDACT_LOG_SCRIPT"
 	AzureResourceGroup  = "AZURE_RESOURCE_GROUP"
 	AzureVNetName       = "AZURE_VNET_NAME"
@@ -142,4 +145,11 @@ func redactLogs() {
 	Expect(e2eConfig.Variables).To(HaveKey(RedactLogScriptPath))
 	cmd := exec.Command(e2eConfig.GetVariable(RedactLogScriptPath))
 	cmd.Run()
+}
+
+func setCNIResources(cniManifestPath string) {
+	cniData, err := ioutil.ReadFile(cniManifestPath)
+	Expect(err).ToNot(HaveOccurred(), "Failed to read the e2e test CNI file")
+	Expect(cniData).ToNot(BeEmpty(), "CNI file should not be empty")
+	Expect(os.Setenv(CNIResources, base64.StdEncoding.EncodeToString(cniData)))
 }

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -55,7 +55,7 @@ variables:
   KUBERNETES_VERSION_UPGRADE_FROM: "${KUBERNETES_VERSION_UPGRADE_FROM:-v1.17.4}"
   CNI: "${PWD}/templates/addons/calico.yaml"
   REDACT_LOG_SCRIPT: "${PWD}/hack/log/redact.sh"
-  EXP_CLUSTER_RESOURCE_SET: "true"
+  EXP_CLUSTER_RESOURSE_SET: "true"
   EXP_AKS: "true"
   EXP_MACHINE_POOL: "true"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a typo in ClusterResourceSet flag in v0.3.7 release, fixed recently: https://github.com/kubernetes-sigs/cluster-api/pull/3341

We need to use the flag with typo until next release.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
"NONE"
