### PR TITLE
[e2e] Change ClusterResourceSet flag to match with CAPI flag

### DIFF
--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -55,9 +55,10 @@ variables:
   KUBERNETES_VERSION_UPGRADE_FROM: "${KUBERNETES_VERSION_UPGRADE_FROM:-v1.17.4}"
   CNI: "${PWD}/templates/addons/calico.yaml"
   REDACT_LOG_SCRIPT: "${PWD}/hack/log/redact.sh"
-  EXP_CLUSTER_RESOURCE_SET: "true"
   EXP_AKS: "true"
   EXP_MACHINE_POOL: "true"
+  # TODO: Fix the typo when updating CAPI urls above to a v0.3.8 release.
+  EXP_CLUSTER_RESOURSE_SET: "true"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a typo in ClusterResourceSet flag in CAPI v0.3.7 release, fixed recently: https://github.com/kubernetes-sigs/cluster-api/pull/3341

We need to use the flag with typo until next release.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

```release-note
NONE
```
