### PR TITLE
🐛 fix template default variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,8 @@ CONVERSION_GEN_VER := v0.18.4
 CONVERSION_GEN_BIN := conversion-gen
 CONVERSION_GEN := $(TOOLS_BIN_DIR)/$(CONVERSION_GEN_BIN)-$(CONVERSION_GEN_VER)
 
-ENVSUBST_VER := v1.1.0
 ENVSUBST_BIN := envsubst
-ENVSUBST := $(TOOLS_BIN_DIR)/$(ENVSUBST_BIN)-$(ENVSUBST_VER)
+ENVSUBST := $(TOOLS_BIN_DIR)/$(ENVSUBST_BIN)
 
 GOLANGCI_LINT_VER := v1.27.0
 GOLANGCI_LINT_BIN := golangci-lint
@@ -184,7 +183,7 @@ $(CONVERSION_GEN): ## Build conversion-gen.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) k8s.io/code-generator/cmd/conversion-gen $(CONVERSION_GEN_BIN) $(CONVERSION_GEN_VER)
 
 $(ENVSUBST): ## Build envsubst from tools folder.
-	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/a8m/envsubst/cmd/envsubst $(ENVSUBST_BIN) $(ENVSUBST_VER)
+	mkdir -p $(TOOLS_DIR) && cd $(TOOLS_DIR) && go build -tags=tools -o $(ENVSUBST) github.com/drone/envsubst/cmd/envsubst
 
 .PHONY: $(ENVSUBST_BIN)
 $(ENVSUBST_BIN): $(ENVSUBST) ## Build envsubst from tools folder.

--- a/docs/development.md
+++ b/docs/development.md
@@ -291,7 +291,7 @@ export AZURE_JSON_B64=$(echo '{
     "securityGroupName": "${CLUSTER_NAME}-node-nsg",
     "location": "${AZURE_LOCATION}",
     "vmType": "vmss",
-    "vnetName": "${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}",
+    "vnetName": "${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}",
     "vnetResourceGroup": "${CLUSTER_NAME}",
     "subnetName": "${CLUSTER_NAME}-node-subnet",
     "routeTableName": "${CLUSTER_NAME}-node-routetable",

--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -68,7 +68,7 @@ export AZURE_JSON_B64=$(echo '{
     "securityGroupName": "${CLUSTER_NAME}-node-nsg",
     "location": "${AZURE_LOCATION}",
     "vmType": "vmss",
-    "vnetName": "${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}",
+    "vnetName": "${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}",
     "vnetResourceGroup": "${CLUSTER_NAME}",
     "subnetName": "${CLUSTER_NAME}-node-subnet",
     "routeTableName": "${CLUSTER_NAME}-node-routetable",

--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -26,7 +26,7 @@ spec:
   defaultPoolRef:
     name: agentpool0
   location: ${AZURE_LOCATION}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   sshPublicKey: ${AZURE_SSH_PUBLIC_KEY}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
   version: ${KUBERNETES_VERSION}

--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -26,8 +26,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -26,8 +26,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -26,8 +26,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -26,8 +26,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -26,8 +26,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -26,8 +26,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/flavors/aks/cluster-template.yaml
+++ b/templates/flavors/aks/cluster-template.yaml
@@ -29,7 +29,7 @@ metadata:
   name: ${CLUSTER_NAME}-control-plane
 spec:
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
-  resourceGroup: "${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}"
+  resourceGroup: "${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}"
   location: "${AZURE_LOCATION}"
   defaultPoolRef:
     name: "agentpool0"

--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -21,12 +21,12 @@ kind: AzureCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  resourceGroup: "${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}"
+  resourceGroup: "${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}"
   location: "${AZURE_LOCATION}"
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
   networkSpec:
     vnet:
-      name: "${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}"
+      name: "${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}"
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -29,8 +29,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -29,8 +29,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/test/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/cluster-template-prow-machine-pool.yaml
@@ -29,8 +29,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3

--- a/templates/test/cluster-template-prow.yaml
+++ b/templates/test/cluster-template-prow.yaml
@@ -29,8 +29,8 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
-      name: ${AZURE_VNET_NAME:=$CLUSTER_NAME-vnet}
-  resourceGroup: ${AZURE_RESOURCE_GROUP:=$CLUSTER_NAME}
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: 
follow up from #789 to fix Tilt + defaults in templates
- use drone/envsubst to be consistent with clusterctl 
- use ${VAR:=${FOO}} syntax as envsubst to does not work with ${VAR:=$FOO}
```
export CLUSTER_NAME=cecile
echo 'name: ${AZURE_VNET_NAME=$CLUSTER_NAME-vnet}' | ./hack/tools/bin/envsubst
name: $CLUSTER_NAME-vnet
echo 'name: ${AZURE_VNET_NAME=${CLUSTER_NAME}-vnet}' | ./hack/tools/bin/envsubst
name: cecile-vnet
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```