### PR TITLE
💎 add resource group defaulting

### DIFF
--- a/api/v1alpha3/azurecluster_default.go
+++ b/api/v1alpha3/azurecluster_default.go
@@ -34,8 +34,15 @@ func (c *AzureCluster) setDefaults() {
 }
 
 func (c *AzureCluster) setNetworkSpecDefaults() {
+	c.setResourceGroupDefault()
 	c.setVnetDefaults()
 	c.setSubnetDefaults()
+}
+
+func (c *AzureCluster) setResourceGroupDefault() {
+	if c.Spec.ResourceGroup == "" {
+		c.Spec.ResourceGroup = c.Name
+	}
 }
 
 func (c *AzureCluster) setVnetDefaults() {

--- a/api/v1alpha3/azurecluster_default_test.go
+++ b/api/v1alpha3/azurecluster_default_test.go
@@ -21,8 +21,64 @@ import (
 	"reflect"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestResourceGroupDefault(t *testing.T) {
+	cases := map[string]struct {
+		cluster *AzureCluster
+		output  *AzureCluster
+	}{
+		"default empty rg": {
+			cluster: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: AzureClusterSpec{},
+			},
+			output: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: AzureClusterSpec{
+					ResourceGroup: "foo",
+				},
+			},
+		},
+		"don't change if mismatched": {
+			cluster: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: AzureClusterSpec{
+					ResourceGroup: "bar",
+				},
+			},
+			output: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: AzureClusterSpec{
+					ResourceGroup: "bar",
+				},
+			},
+		},
+	}
+
+	for name := range cases {
+		c := cases[name]
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c.cluster.setResourceGroupDefault()
+			if !reflect.DeepEqual(c.cluster, c.output) {
+				expected, _ := json.MarshalIndent(c.output, "", "\t")
+				actual, _ := json.MarshalIndent(c.cluster, "", "\t")
+				t.Errorf("Expected %s, got %s", string(expected), string(actual))
+			}
+		})
+	}
+}
 
 func TestVnetDefaults(t *testing.T) {
 	cases := []struct {

--- a/api/v1alpha3/azurecluster_types.go
+++ b/api/v1alpha3/azurecluster_types.go
@@ -32,8 +32,10 @@ type AzureClusterSpec struct {
 	// NetworkSpec encapsulates all things related to Azure network.
 	NetworkSpec NetworkSpec `json:"networkSpec,omitempty"`
 
-	ResourceGroup string `json:"resourceGroup"`
+	// +optional
+	ResourceGroup string `json:"resourceGroup,omitempty"`
 
+	// +optional
 	SubscriptionID string `json:"subscriptionID,omitempty"`
 
 	Location string `json:"location"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -606,7 +606,6 @@ spec:
                 type: string
             required:
             - location
-            - resourceGroup
             type: object
           status:
             description: AzureClusterStatus defines the observed state of AzureCluster


### PR DESCRIPTION
Signed-off-by: Alexander Eldeib <alexeldeib@gmail.com>

**What this PR does / why we need it**:

default rg to cluster-name. k8s name validation is already a subset of rg restrictions (I think? happy to be corrected) so this should be safe.

https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftresources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
default resource group name to AzureCluster name if not specified
```