### PR TITLE
Fixes unit tests that didn't have parrallelism set up correctly

### DIFF
--- a/api/v1alpha2/tags_test.go
+++ b/api/v1alpha2/tags_test.go
@@ -75,6 +75,7 @@ func TestTags_Merge(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tags := Tags{

--- a/api/v1alpha3/tags_test.go
+++ b/api/v1alpha3/tags_test.go
@@ -75,6 +75,7 @@ func TestTags_Merge(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tags := Tags{

--- a/cloud/services/disks/disks_test.go
+++ b/cloud/services/disks/disks_test.go
@@ -86,6 +86,7 @@ func TestDeleteDisk(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 

--- a/cloud/services/groups/groups_test.go
+++ b/cloud/services/groups/groups_test.go
@@ -77,6 +77,7 @@ func TestReconcileGroups(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
@@ -189,6 +190,7 @@ func TestDeleteGroups(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 

--- a/cloud/services/loadbalancers/loadbalancers_test.go
+++ b/cloud/services/loadbalancers/loadbalancers_test.go
@@ -18,12 +18,13 @@ package loadbalancers
 
 import (
 	"context"
-	"github.com/Azure/go-autorest/autorest/to"
 	"net/http"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/subnets/mock_subnets"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/virtualnetworks/mock_virtualnetworks"
 	"sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers"
-	"testing"
 
 	"k8s.io/klog/klogr"
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
@@ -521,6 +522,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
@@ -612,6 +614,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()

--- a/cloud/services/networkinterfaces/networkinterfaces.go
+++ b/cloud/services/networkinterfaces/networkinterfaces.go
@@ -19,6 +19,7 @@ package networkinterfaces
 import (
 	"context"
 	"fmt"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"

--- a/cloud/services/publicips/publicips_test.go
+++ b/cloud/services/publicips/publicips_test.go
@@ -89,6 +89,7 @@ func TestReconcilePublicIP(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
@@ -173,6 +174,7 @@ func TestDeletePublicIP(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:
When adding tests for the ipv6 I noticed some strange behavior in the unit tests.  It ends up the parallel tests was missing a capture of the range variable which causes inconsistent behavior in the tests and allowed all of the tests to pass even if mocks were not called properly.

This updates the tests that were missing the capture of the range variable. Only the networking interface tests needed updating due to invalid tests.  I tried to capture the intent of the tests but made a few changes that someone else might have more context for. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
If you run the tests before the range variable was capture the tests will pass. You can try adding invalid values to expectations to see that the tests do pass when not captured. After disabling parallel tests or capture the range the tests with invalid values will fail.

The docs here show an example of the capture:  https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```