### PR TITLE
 🐛 normalize version in managed control plane

### DIFF
--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -107,7 +107,6 @@ spec:
               version:
                 description: Version defines the desired Kubernetes version.
                 minLength: 2
-                pattern: ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$
                 type: string
             required:
             - defaultPoolRef

--- a/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
@@ -26,7 +26,6 @@ import (
 type AzureManagedControlPlaneSpec struct {
 	// Version defines the desired Kubernetes version.
 	// +kubebuilder:validation:MinLength:=2
-	// +kubebuilder:validation:Pattern:=^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$
 	Version string `json:"version"`
 
 	// ResourceGroup is the name of the Azure resource group for this AKS Cluster.

--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/pkg/errors"
@@ -54,13 +55,20 @@ func newAzureManagedMachinePoolReconciler(scope *scope.ManagedControlPlaneScope)
 // Reconcile reconciles all the services in pre determined order
 func (r *azureManagedMachinePoolReconciler) Reconcile(ctx context.Context, scope *scope.ManagedControlPlaneScope) error {
 	scope.Logger.Info("reconciling machine pool")
+
+	var normalizedVersion *string
+	if scope.MachinePool.Spec.Template.Spec.Version != nil {
+		v := strings.TrimPrefix(*scope.MachinePool.Spec.Template.Spec.Version, "v")
+		normalizedVersion = &v
+	}
+
 	agentPoolSpec := &agentpools.Spec{
 		Name:          scope.InfraMachinePool.Name,
 		ResourceGroup: scope.ControlPlane.Spec.ResourceGroup,
 		Cluster:       scope.ControlPlane.Name,
 		SKU:           scope.InfraMachinePool.Spec.SKU,
 		Replicas:      1,
-		Version:       scope.MachinePool.Spec.Template.Spec.Version,
+		Version:       normalizedVersion,
 	}
 
 	if scope.InfraMachinePool.Spec.OSDiskSizeGB != nil {

--- a/exp/controllers/helpers.go
+++ b/exp/controllers/helpers.go
@@ -174,6 +174,11 @@ func AzureManagedClusterToAzureManagedControlPlaneMapper(c client.Client, log lo
 			return nil
 		}
 
+		if cluster == nil {
+			log.Error(err, "cluster has not set owner ref yet")
+			return nil
+		}
+
 		ref := cluster.Spec.ControlPlaneRef
 		if ref == nil || ref.Name == "" {
 			return nil


### PR DESCRIPTION
Signed-off-by: Alexander Eldeib <alexeldeib@gmail.com>

**What this PR does / why we need it**:

remove strict validation and always let prefix normalization occur if necessary on the versions. We added this in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/745 after realizing it mismatched with Machine, but Machine and KCP themselves were mismatched which was fixed in https://github.com/kubernetes-sigs/cluster-api/pull/3147

This PR removes the stricter validation we added, and allows the prefix trimming (inside managed control plane reconciler) to always normalize the version string.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
reduce validation strictness on `v` prefix in Kubernetes versions
```