### PR TITLE
Add validation on CLUSTER_NAME

### DIFF
--- a/api/v1alpha3/azurecluster_default_test.go
+++ b/api/v1alpha3/azurecluster_default_test.go
@@ -90,6 +90,9 @@ func TestVnetDefaults(t *testing.T) {
 			name:    "resource group vnet specified",
 			cluster: createValidCluster(),
 			output: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Vnet: VnetSpec{

--- a/docs/development.md
+++ b/docs/development.md
@@ -219,6 +219,8 @@ The steps below are provided in a convenient script in [hack/create-dev-cluster.
 CLUSTER_NAME=<my-capz-cluster-name> ./hack/create-dev-cluster.sh
 ```
 
+   NOTE: `CLUSTER_NAME` can only include letters, numbers, and hyphens and can't be longer than 44 characters.
+
 ##### Building and pushing dev images
 
 1. To build images with custom tags,


### PR DESCRIPTION


 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:
validations for  cluster name to be used as prefix for naming other azure resources such as VMs, VNET, and so on
- max length of 44 characters
- no special characters allowed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #678 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add validation on Cluster Name to limit length and not accept special characters
```