### PR TITLE
Handle large yaml files on linux in tilt config

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,5 @@
 # -*- mode: Python -*-
 
-kustomize_cmd = "./hack/tools/bin/kustomize"
 envsubst_cmd = "./hack/tools/bin/envsubst"
 
 update_settings(k8s_upsert_timeout_secs=60)  # on first tilt up, often can take longer than 30 seconds
@@ -152,7 +151,7 @@ COPY manager .
 # Build CAPZ and add feature gates
 def capz():
     # Apply the kustomized yaml for this provider
-    yaml = str(kustomize("./config"))
+    yaml = str(kustomizesub("./config"))
     substitutions = settings.get("kustomize_substitutions", {})
     for substitution in substitutions:
         value = substitutions[substitution]
@@ -200,7 +199,6 @@ def capz():
         ignore = ["templates"]
     )
 
-    yaml = envsubst(yaml)
     k8s_yaml(blob(yaml))
 
 
@@ -333,10 +331,13 @@ def base64_decode(to_decode):
     decode_blob = local("echo '{}' | base64 --decode -".format(to_decode), quiet=True)
     return str(decode_blob)
 
-
 def envsubst(yaml):
     yaml = yaml.replace('"', '\\"')
     return str(local("echo \"{}\" | {}".format(yaml, envsubst_cmd), quiet=True))
+
+def kustomizesub(folder):
+    yaml = local('hack/kustomize-sub.sh {}'.format(folder), quiet=True)
+    return yaml
 
 ##############################
 # Actual work happens here

--- a/hack/kustomize-sub.sh
+++ b/hack/kustomize-sub.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+root=$(dirname "${BASH_SOURCE[0]}")
+$root/tools/bin/kustomize build $1 | $root/tools/bin/envsubst


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:
`make tilt-up` breaks on linux with message:

```
error: fork/exec /usr/bin/sh: argument list too long"
```

This is because the file is echoed onto the command line 

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/bceee96d979fd164662ff6a4dcf10676271555da/Tiltfile#L339

The amount of data in the `yaml` string is to much on linux (I am guessing this works on mac) but eventually someone on a mac might have run into this as the yaml grows with more features.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The env sub command for the flavors works because the amount for a yaml is small.  

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix tilt-up argument list too long error on linux
```