### PR TITLE
fix: add useExperimentalRetryJoin: true to worker node spec

### DIFF
--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -206,3 +206,4 @@ spec:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
+      useExperimentalRetryJoin: true

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -202,3 +202,4 @@ spec:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
+      useExperimentalRetryJoin: true

--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -218,3 +218,4 @@ spec:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
+      useExperimentalRetryJoin: true

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -223,3 +223,4 @@ spec:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
+      useExperimentalRetryJoin: true

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -202,3 +202,4 @@ spec:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
+      useExperimentalRetryJoin: true

--- a/templates/flavors/default/machine-deployment.yaml
+++ b/templates/flavors/default/machine-deployment.yaml
@@ -45,6 +45,7 @@ metadata:
 spec:
   template:
     spec:
+      useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/external-cloud-provider/patches/external-cloud-provider.yaml
+++ b/templates/flavors/external-cloud-provider/patches/external-cloud-provider.yaml
@@ -42,6 +42,7 @@ metadata:
 spec:
   template:
     spec:
+      useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:

--- a/templates/flavors/system-assigned-identity/patches/system-assigned-identity.yaml
+++ b/templates/flavors/system-assigned-identity/patches/system-assigned-identity.yaml
@@ -27,6 +27,7 @@ spec:
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"
+      useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:

--- a/templates/flavors/system-assigned-identity/system-assigned-identity-md.yaml
+++ b/templates/flavors/system-assigned-identity/system-assigned-identity-md.yaml
@@ -46,6 +46,7 @@ metadata:
 spec:
   template:
     spec:
+      useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/user-assigned-identity/user-assigned-identity-md.yaml
+++ b/templates/flavors/user-assigned-identity/user-assigned-identity-md.yaml
@@ -48,6 +48,7 @@ metadata:
 spec:
   template:
     spec:
+      useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -370,3 +370,4 @@ spec:
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
       - bash -c /tmp/kubeadm-bootstrap.sh
+      useExperimentalRetryJoin: true

--- a/templates/test/cluster-template-prow.yaml
+++ b/templates/test/cluster-template-prow.yaml
@@ -205,3 +205,4 @@ spec:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
+      useExperimentalRetryJoin: true


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

This PR adds the `useExperimentalRetryJoin: true` kubeadm configuration to the worker node spec to prevent scenarios described in issue #832 from prevening nodes joining a cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #832

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add useExperimentalRetryJoin: true to all KubeadmConfigTemplate resource specs
```