### PR TITLE
🐛 sku api should use resourceType, not kind

### DIFF
--- a/cloud/services/resourceskus/cache.go
+++ b/cloud/services/resourceskus/cache.go
@@ -84,7 +84,7 @@ func (c *Cache) refresh(ctx context.Context, location string) error {
 // enhancing this function to handle restrictions (e.g. SKU not
 // supported in region), which is why it returns an error and not a
 // boolean.
-func (c *Cache) Get(ctx context.Context, name string, kind Kind) (SKU, error) {
+func (c *Cache) Get(ctx context.Context, name string, kind ResourceType) (SKU, error) {
 	if c.data == nil {
 		if err := c.refresh(ctx, c.location); err != nil {
 			return SKU{}, err
@@ -97,22 +97,6 @@ func (c *Cache) Get(ctx context.Context, name string, kind Kind) (SKU, error) {
 		}
 	}
 	return SKU{}, fmt.Errorf("resource sku with name '%s' and category '%s' not found", name, string(kind))
-}
-
-// List returns a list of all known SKUs, useful for further filtering.
-func (c *Cache) List(ctx context.Context, name string, kind Kind) ([]SKU, error) {
-	if c.data == nil {
-		if err := c.refresh(ctx, c.location); err != nil {
-			return nil, err
-		}
-	}
-
-	// return a converted copy so clients do not mutate underlying data.
-	var skus = make([]SKU, len(c.data))
-	for i := range c.data {
-		skus[i] = SKU(c.data[i])
-	}
-	return skus, nil
 }
 
 // Map invokes a function over all cached values.
@@ -138,7 +122,7 @@ func (c *Cache) GetZones(ctx context.Context, location string) ([]string, error)
 	var allZones = make(map[string]bool)
 	mapFn := func(sku SKU) {
 		// Look for VMs only
-		if sku.Kind != nil && strings.EqualFold(*sku.Kind, string(VirtualMachines)) {
+		if sku.ResourceType != nil && strings.EqualFold(*sku.ResourceType, string(VirtualMachines)) {
 			// find matching location
 			for _, locationInfo := range *sku.LocationInfo {
 				if strings.EqualFold(*locationInfo.Location, location) {
@@ -196,7 +180,7 @@ func (c *Cache) GetZones(ctx context.Context, location string) ([]string, error)
 func (c *Cache) GetZonesWithVMSize(ctx context.Context, size, location string) ([]string, error) {
 	var allZones = make(map[string]bool)
 	mapFn := func(sku SKU) {
-		if sku.Name != nil && strings.EqualFold(*sku.Name, size) && sku.Kind != nil && strings.EqualFold(*sku.Kind, string(VirtualMachines)) {
+		if sku.Name != nil && strings.EqualFold(*sku.Name, size) && sku.ResourceType != nil && strings.EqualFold(*sku.ResourceType, string(VirtualMachines)) {
 			// find matching location
 			for _, locationInfo := range *sku.LocationInfo {
 				if strings.EqualFold(*locationInfo.Location, location) {

--- a/cloud/services/resourceskus/cache_test.go
+++ b/cloud/services/resourceskus/cache_test.go
@@ -28,28 +28,28 @@ import (
 
 func TestCacheGet(t *testing.T) {
 	cases := map[string]struct {
-		sku  string
-		kind Kind
-		have []compute.ResourceSku
-		err  string
+		sku          string
+		resourceType ResourceType
+		have         []compute.ResourceSku
+		err          string
 	}{
 		"should find": {
-			sku:  "foo",
-			kind: "bar",
+			sku:          "foo",
+			resourceType: "bar",
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("other"),
-					Kind: to.StringPtr("baz"),
+					Name:         to.StringPtr("other"),
+					ResourceType: to.StringPtr("baz"),
 				},
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr("bar"),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr("bar"),
 				},
 			},
 		},
 		"should not find": {
-			sku:  "foo",
-			kind: "bar",
+			sku:          "foo",
+			resourceType: "bar",
 			have: []compute.ResourceSku{
 				{
 					Name: to.StringPtr("other"),
@@ -68,7 +68,7 @@ func TestCacheGet(t *testing.T) {
 				data: tc.have,
 			}
 
-			val, err := cache.Get(context.Background(), tc.sku, tc.kind)
+			val, err := cache.Get(context.Background(), tc.sku, tc.resourceType)
 			if tc.err != "" {
 				if err == nil {
 					t.Fatalf("expected cache.get to fail with error %s, but actual error was nil", tc.err)
@@ -86,12 +86,12 @@ func TestCacheGet(t *testing.T) {
 				if *val.Name != tc.sku {
 					t.Fatalf("expected name to be %s, but was %s", tc.sku, *val.Name)
 				}
-				if val.Kind == nil {
+				if val.ResourceType == nil {
 					t.Fatalf("expected name to be %s, but was nil", tc.sku)
 					return
 				}
-				if *val.Kind != string(tc.kind) {
-					t.Fatalf("expected kind to be %s, but was %s", tc.kind, *val.Kind)
+				if *val.ResourceType != string(tc.resourceType) {
+					t.Fatalf("expected kind to be %s, but was %s", tc.resourceType, *val.ResourceType)
 				}
 			}
 
@@ -107,8 +107,8 @@ func TestCacheGetZones(t *testing.T) {
 		"should find 1 result": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
@@ -125,8 +125,8 @@ func TestCacheGetZones(t *testing.T) {
 		"should find 2 results": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
@@ -138,8 +138,8 @@ func TestCacheGetZones(t *testing.T) {
 					},
 				},
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
@@ -156,8 +156,8 @@ func TestCacheGetZones(t *testing.T) {
 		"should not find due to location mismatch": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"foobar",
 					},
@@ -174,8 +174,8 @@ func TestCacheGetZones(t *testing.T) {
 		"should not find due to location restriction": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
@@ -198,8 +198,8 @@ func TestCacheGetZones(t *testing.T) {
 		"should not find due to zone restriction": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
@@ -251,8 +251,8 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should find 1 result": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
@@ -269,8 +269,8 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should find 2 results": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
@@ -287,8 +287,8 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should not find due to size mismatch": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foobar"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foobar"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
@@ -305,8 +305,8 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should not find due to location mismatch": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"foobar",
 					},
@@ -323,8 +323,8 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should not find due to location restriction": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},
@@ -347,8 +347,8 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 		"should not find due to zone restriction": {
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("foo"),
-					Kind: to.StringPtr(string(VirtualMachines)),
+					Name:         to.StringPtr("foo"),
+					ResourceType: to.StringPtr(string(VirtualMachines)),
 					Locations: &[]string{
 						"baz",
 					},

--- a/cloud/services/resourceskus/sku.go
+++ b/cloud/services/resourceskus/sku.go
@@ -27,14 +27,14 @@ import (
 // SKU is a thin layer over the Azure resource SKU API to better introspect capabilities
 type SKU compute.ResourceSku
 
-// Kind models available resource types as a set of known string constants.
-type Kind string
+// ResourceType models available resource types as a set of known string constants.
+type ResourceType string
 
 const (
 	// VirtualMachines is a convenience constant to filter resource SKUs to only include VMs.
-	VirtualMachines Kind = "virtualMachines"
+	VirtualMachines ResourceType = "virtualMachines"
 	// Disks is a convenience constant to filter resource SKUs to only include disks.
-	Disks Kind = "disks"
+	Disks ResourceType = "disks"
 )
 
 // Supported models an enum of possible boolean values for resource support in the Azure API.


### PR DESCRIPTION
Signed-off-by: Alexander Eldeib <alexeldeib@gmail.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

Not sure how I goofed on this, the sku API pivots on resourceType, not kind. This always was filtering out all resources. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```