### PR TITLE
🐛  use versioned image for log-dump-daemonset.yaml

### DIFF
--- a/hack/log/log-dump-daemonset.yaml
+++ b/hack/log/log-dump-daemonset.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: log-dump-node
-        image: fedora # A base image that has 'journalctl' binary
+        image: fedora:30 # A base image that has 'journalctl' binary
         args:
         - sleep
         - "3600"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

Fixes the following error when dumping logs:
```
error: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "93fe28b192159e1ca333b6153f5c8ee4f81733806193c26645d2a37376688223": OCI runtime exec failed: exec failed: container_linux.go:349: starting container process caused "exec: \"journalctl\": executable file not found in $PATH": unknown
```

Related PR: https://github.com/kubernetes-sigs/cloud-provider-azure/pull/347

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```