### PR TITLE
fix: load kustomize_substitutions before envsubst

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -151,11 +151,11 @@ COPY manager .
 # Build CAPZ and add feature gates
 def capz():
     # Apply the kustomized yaml for this provider
-    yaml = str(kustomizesub("./config"))
     substitutions = settings.get("kustomize_substitutions", {})
     for substitution in substitutions:
-        value = substitutions[substitution]
-        yaml = yaml.replace("${" + substitution + "}", value)
+        os.putenv(substitution, substitutions[substitution])
+    yaml = str(kustomizesub("./config"))
+
 
     # add extra_args if they are defined
     if settings.get("extra_args"):


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

With #829 the kustomize_substitutions in the tilt settings file were not being loaded into the env or replaced in the yaml before running `envsubst`. This PR fixes this problem by loading them into the env prior to executing `envsubst` via `kustomizesub`.

/cc @CecileRobertMichon and @jsturtevant  

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```