### PR TITLE
Fix issue with cluster paused map function

### DIFF
--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -51,10 +51,9 @@ type AzureClusterReconciler struct {
 }
 
 func (r *AzureClusterReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
-	azCluster := &infrav1.AzureCluster{}
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
-		For(azCluster).
+		For(&infrav1.AzureCluster{}).
 		WithEventFilter(predicates.ResourceNotPaused(r.Log)). // don't queue reconcile if resource is paused
 		Build(r)
 	if err != nil {
@@ -65,7 +64,7 @@ func (r *AzureClusterReconciler) SetupWithManager(mgr ctrl.Manager, options cont
 	if err = c.Watch(
 		&source.Kind{Type: &clusterv1.Cluster{}},
 		&handler.EnqueueRequestsFromMapFunc{
-			ToRequests: util.ClusterToInfrastructureMapFunc(azCluster.GroupVersionKind()),
+			ToRequests: util.ClusterToInfrastructureMapFunc(infrav1.GroupVersion.WithKind("AzureCluster")),
 		},
 		predicates.ClusterUnpaused(r.Log),
 	); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Switch to using the API package's GroupVersion to supply the
GroupVersionKind for the map function, as azCluster's APIVersion and
Kind fields were empty, resulting in the map function never matching on
AzureCluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #840

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed an issue where AzureClusters were not being reprocessed when a Cluster is unpaused.
```