### PR TITLE
scripts: Use ci/latest version marker for retrieving cross builds

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -69,7 +69,7 @@ create_cluster() {
         if [[ "${KUBERNETES_BRANCH:-}" =~ "release-" ]]; then
             CI_VERSION_URL="https://dl.k8s.io/ci/latest-${KUBERNETES_BRANCH/release-}.txt"
         else
-            CI_VERSION_URL="https://dl.k8s.io/ci/k8s-master.txt"
+            CI_VERSION_URL="https://dl.k8s.io/ci/latest.txt"
         fi
         export CLUSTER_TEMPLATE="test/cluster-template-prow-ci-version.yaml"
         export CI_VERSION="${CI_VERSION:-$(curl -sSL ${CI_VERSION_URL})}"


### PR DESCRIPTION
**What this PR does / why we need it**:

(Follow-up to https://github.com/kubernetes/test-infra/pull/18290.)

[Now](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-build/1288265272272097280) that the `ci/latest` version marker again represents a cross build of `kubernetes/kubernetes@master`, we should stop using the `ci/k8s-master` generic version marker.

ref: https://github.com/kubernetes/test-infra/blob/master/docs/kubernetes-versions.md, https://github.com/kubernetes/sig-release/issues/850

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @CecileRobertMichon @nader-ziada @cpanato 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```