### PR TITLE
🌱  Remove extra GET API calls for resource IDs

### DIFF
--- a/cloud/defaults.go
+++ b/cloud/defaults.go
@@ -50,6 +50,21 @@ func GeneratePublicLBName(clusterName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, "public-lb")
 }
 
+// GenerateBackendAddressPoolName generates a load balancer backend address pool name.
+func GenerateBackendAddressPoolName(lbName string) string {
+	return fmt.Sprintf("%s-%s", lbName, "backendPool")
+}
+
+// GenerateOutboundBackendddressPoolName generates a load balancer outbound backend address pool name.
+func GenerateOutboundBackendddressPoolName(lbName string) string {
+	return fmt.Sprintf("%s-%s", lbName, "outboundBackendPool")
+}
+
+// GenerateFrontendIPConfigName generates a load balancer frontend IP config name.
+func GenerateFrontendIPConfigName(lbName string) string {
+	return fmt.Sprintf("%s-%s", lbName, "frontEnd")
+}
+
 // GeneratePublicIPName generates a public IP name, based on the cluster name and a hash.
 func GeneratePublicIPName(clusterName, hash string) string {
 	return fmt.Sprintf("%s-%s", clusterName, hash)
@@ -83,6 +98,51 @@ func GenerateOSDiskName(machineName string) string {
 // GenerateDataDiskName generates the name of a data disk based on the name of a VM.
 func GenerateDataDiskName(machineName, nameSuffix string) string {
 	return fmt.Sprintf("%s_%s", machineName, nameSuffix)
+}
+
+// SubnetID returns the azure resource ID for a given subnet.
+func SubnetID(subscriptionID, resoourceGroup, vnetName, subnetName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s", subscriptionID, resoourceGroup, vnetName, subnetName)
+}
+
+// PublicIPID returns the azure resource ID for a given public IP.
+func PublicIPID(subscriptionID, resoourceGroup, ipName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/publicIPAddresses/%s", subscriptionID, resoourceGroup, ipName)
+}
+
+// RouteTableID returns the azure resource ID for a given route table.
+func RouteTableID(subscriptionID, resoourceGroup, routeTableName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/routeTables/%s", subscriptionID, resoourceGroup, routeTableName)
+}
+
+// SecurityGroupID returns the azure resource ID for a given security group.
+func SecurityGroupID(subscriptionID, resoourceGroup, routeTableName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/%s", subscriptionID, resoourceGroup, routeTableName)
+}
+
+// NetworkInterfaceID returns the azure resource ID for a given network interface.
+func NetworkInterfaceID(subscriptionID, resoourceGroup, nicName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s", subscriptionID, resoourceGroup, nicName)
+}
+
+// FrontendIPConfigID returns the azure resource ID for a given frontend IP config.
+func FrontendIPConfigID(subscriptionID, resoourceGroup, loadBalancerName, configName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s", subscriptionID, resoourceGroup, loadBalancerName, configName)
+}
+
+// AddressPoolID returns the azure resource ID for a given backend address pool.
+func AddressPoolID(subscriptionID, resoourceGroup, loadBalancerName, backendPoolName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/backendAddressPools/%s", subscriptionID, resoourceGroup, loadBalancerName, backendPoolName)
+}
+
+// ProbeID returns the azure resource ID for a given probe.
+func ProbeID(subscriptionID, resoourceGroup, loadBalancerName, probeName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/probes/%s", subscriptionID, resoourceGroup, loadBalancerName, probeName)
+}
+
+// NATRuleID returns the azure resource ID for a inbound NAT rule.
+func NATRuleID(subscriptionID, resoourceGroup, loadBalancerName, natRuleName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/inboundNatRules/%s", subscriptionID, resoourceGroup, loadBalancerName, natRuleName)
 }
 
 // GetDefaultImageSKUID gets the SKU ID of the image to use for the provided version of Kubernetes.

--- a/cloud/services/loadbalancers/service.go
+++ b/cloud/services/loadbalancers/service.go
@@ -19,8 +19,6 @@ package loadbalancers
 import (
 	"github.com/go-logr/logr"
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/publicips"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/subnets"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/virtualnetworks"
 )
 
@@ -35,8 +33,6 @@ type LBScope interface {
 type Service struct {
 	Scope LBScope
 	Client
-	PublicIPsClient       publicips.Client
-	SubnetsClient         subnets.Client
 	VirtualNetworksClient virtualnetworks.Client
 }
 
@@ -45,8 +41,6 @@ func NewService(scope LBScope) *Service {
 	return &Service{
 		Scope:                 scope,
 		Client:                NewClient(scope),
-		PublicIPsClient:       publicips.NewClient(scope),
-		SubnetsClient:         subnets.NewClient(scope),
 		VirtualNetworksClient: virtualnetworks.NewClient(scope),
 	}
 }

--- a/cloud/services/networkinterfaces/networkinterfaces_test.go
+++ b/cloud/services/networkinterfaces/networkinterfaces_test.go
@@ -22,91 +22,47 @@ import (
 	"net/http"
 	"testing"
 
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
-
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/loadbalancers/mock_loadbalancers"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/networkinterfaces/mock_networkinterfaces"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/publicips/mock_publicips"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/resourceskus"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/subnets/mock_subnets"
-
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"k8s.io/klog/klogr"
-	"k8s.io/utils/pointer"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/networkinterfaces/mock_networkinterfaces"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/resourceskus"
 )
 
 func TestReconcileNetworkInterface(t *testing.T) {
 	testcases := []struct {
 		name          string
 		expectedError string
-		expect        func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-			m *mock_networkinterfaces.MockClientMockRecorder,
-			mSubnet *mock_subnets.MockClientMockRecorder,
-			mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-			mPublicIP *mock_publicips.MockClientMockRecorder,
-		)
+		expect        func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder)
 	}{
-		{
-			name:          "get subnets fails",
-			expectedError: "failed to get subnets: #: Internal Server Error: StatusCode=500",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
-				s.NICSpecs().Return([]azure.NICSpec{
-					{
-						Name:              "my-net-interface",
-						MachineName:       "azure-test1",
-						SubnetName:        "my-subnet",
-						VNetName:          "my-vnet",
-						VNetResourceGroup: "vnet-rg",
-					},
-				})
-				s.ResourceGroup().AnyTimes().Return("my-rg")
-				s.Location().AnyTimes().Return("fake-location")
-				mSubnet.Get(context.TODO(), "vnet-rg", "my-vnet", "my-subnet").
-					Return(network.Subnet{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
-			},
-		},
 		{
 			name:          "node network interface create fails",
 			expectedError: "failed to create network interface my-net-interface in resource group my-rg: #: Internal Server Error: StatusCode=500",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
-						Name:                   "my-net-interface",
-						MachineName:            "azure-test1",
-						MachineRole:            infrav1.Node,
-						SubnetName:             "my-subnet",
-						VNetName:               "my-vnet",
-						VNetResourceGroup:      "my-rg",
-						PublicLoadBalancerName: "my-public-lb",
-						VMSize:                 "Standard_D2v2",
-						AcceleratedNetworking:  nil,
+						Name:                  "my-net-interface",
+						MachineName:           "azure-test1",
+						SubnetName:            "my-subnet",
+						VNetName:              "my-vnet",
+						VNetResourceGroup:     "my-rg",
+						PublicLBName:          "my-public-lb",
+						VMSize:                "Standard_D2v2",
+						AcceleratedNetworking: nil,
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").
-						Return(network.Subnet{}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-public-lb").Return(getFakeNodeOutboundLoadBalancer(), nil),
 					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomock.AssignableToTypeOf(network.Interface{})).
 						Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error")))
 			},
@@ -114,80 +70,67 @@ func TestReconcileNetworkInterface(t *testing.T) {
 		{
 			name:          "node network interface with Static private IP successfully created",
 			expectedError: "",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
-						Name:                   "my-net-interface",
-						MachineName:            "azure-test1",
-						MachineRole:            infrav1.Node,
-						SubnetName:             "my-subnet",
-						VNetName:               "my-vnet",
-						VNetResourceGroup:      "my-rg",
-						PublicLoadBalancerName: "my-public-lb",
-						StaticIPAddress:        "fake.static.ip",
-						VMSize:                 "Standard_D2v2",
-						AcceleratedNetworking:  nil,
+						Name:                    "my-net-interface",
+						MachineName:             "azure-test1",
+						SubnetName:              "my-subnet",
+						VNetName:                "my-vnet",
+						VNetResourceGroup:       "my-rg",
+						PublicLBName:            "my-public-lb",
+						PublicLBAddressPoolName: "cluster-name-outboundBackendPool",
+						StaticIPAddress:         "fake.static.ip",
+						VMSize:                  "Standard_D2v2",
+						AcceleratedNetworking:   nil,
 					},
 				})
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-public-lb").Return(getFakeNodeOutboundLoadBalancer(), nil),
-					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
-						Location: to.StringPtr("fake-location"),
-						InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-							EnableAcceleratedNetworking: to.BoolPtr(true),
-							IPConfigurations: &[]network.InterfaceIPConfiguration{
-								{
-									Name: to.StringPtr("pipConfig"),
-									InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-										LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: to.StringPtr("cluster-name-outboundBackendPool")}},
-										PrivateIPAllocationMethod:       network.Static,
-										PrivateIPAddress:                to.StringPtr("fake.static.ip"),
-										Subnet:                          &network.Subnet{},
-									},
+				m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(true),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
+									PrivateIPAllocationMethod:       network.Static,
+									PrivateIPAddress:                to.StringPtr("fake.static.ip"),
+									Subnet:                          &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 								},
 							},
 						},
-					})))
+					},
+				}))
 			},
 		},
 		{
 			name:          "node network interface with Dynamic private IP successfully created",
 			expectedError: "",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
-						Name:                   "my-net-interface",
-						MachineName:            "azure-test1",
-						MachineRole:            infrav1.Node,
-						SubnetName:             "my-subnet",
-						VNetName:               "my-vnet",
-						VNetResourceGroup:      "my-rg",
-						PublicLoadBalancerName: "my-public-lb",
-						VMSize:                 "Standard_D2v2",
-						AcceleratedNetworking:  nil,
+						Name:                    "my-net-interface",
+						MachineName:             "azure-test1",
+						SubnetName:              "my-subnet",
+						VNetName:                "my-vnet",
+						VNetResourceGroup:       "my-rg",
+						PublicLBName:            "my-public-lb",
+						PublicLBAddressPoolName: "cluster-name-outboundBackendPool",
+						VMSize:                  "Standard_D2v2",
+						AcceleratedNetworking:   nil,
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(3)).AnyTimes().Return(klogr.New())
 				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-public-lb").Return(getFakeNodeOutboundLoadBalancer(), nil),
 					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
 						Location: to.StringPtr("fake-location"),
 						InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
@@ -196,9 +139,9 @@ func TestReconcileNetworkInterface(t *testing.T) {
 								{
 									Name: to.StringPtr("pipConfig"),
 									InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-										LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: to.StringPtr("cluster-name-outboundBackendPool")}},
+										LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
 										PrivateIPAllocationMethod:       network.Dynamic,
-										Subnet:                          &network.Subnet{},
+										Subnet:                          &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
 									},
 								},
 							},
@@ -209,155 +152,56 @@ func TestReconcileNetworkInterface(t *testing.T) {
 		{
 			name:          "control plane network interface successfully created",
 			expectedError: "",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
-						Name:                     "my-net-interface",
-						MachineName:              "azure-test1",
-						MachineRole:              infrav1.ControlPlane,
-						SubnetName:               "my-subnet",
-						VNetName:                 "my-vnet",
-						VNetResourceGroup:        "my-rg",
-						PublicLoadBalancerName:   "my-public-lb",
-						InternalLoadBalancerName: "my-internal-lb",
-						VMSize:                   "Standard_D2v2",
-						AcceleratedNetworking:    nil,
+						Name:                      "my-net-interface",
+						MachineName:               "azure-test1",
+						SubnetName:                "my-subnet",
+						VNetName:                  "my-vnet",
+						VNetResourceGroup:         "my-rg",
+						PublicLBName:              "my-public-lb",
+						PublicLBAddressPoolName:   "my-public-lb-backendPool",
+						PublicLBNATRuleName:       "azure-test1",
+						InternalLBName:            "my-internal-lb",
+						InternalLBAddressPoolName: "my-internal-lb-backendPool",
+						VMSize:                    "Standard_D2v2",
+						AcceleratedNetworking:     nil,
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(3)).AnyTimes().Return(klogr.New())
-
-				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").
-						Return(network.Subnet{ID: to.StringPtr("my-subnet-id")}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-public-lb").Return(network.LoadBalancer{
-						Name: to.StringPtr("my-public-lb"),
-						ID:   pointer.StringPtr("my-public-lb-id"),
-						LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
-							FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
-								{
-									ID: to.StringPtr("frontend-ip-config-id"),
-								},
-							},
-							BackendAddressPools: &[]network.BackendAddressPool{
-								{
-									ID: pointer.StringPtr("my-backend-pool-id"),
-								},
-							},
-							InboundNatRules: &[]network.InboundNatRule{},
-						}}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-internal-lb").
-						Return(network.LoadBalancer{
-							ID: pointer.StringPtr("my-internal-lb-id"),
-							LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
-								BackendAddressPools: &[]network.BackendAddressPool{
-									{
-										ID: pointer.StringPtr("my-internal-backend-pool-id"),
-									},
-								},
-							}}, nil),
-					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
-						Location: to.StringPtr("fake-location"),
-						InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-							EnableAcceleratedNetworking: to.BoolPtr(true),
-							IPConfigurations: &[]network.InterfaceIPConfiguration{
-								{
-									Name: to.StringPtr("pipConfig"),
-									InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-										Subnet:                          &network.Subnet{ID: to.StringPtr("my-subnet-id")},
-										PrivateIPAllocationMethod:       network.Dynamic,
-										LoadBalancerInboundNatRules:     &[]network.InboundNatRule{{ID: to.StringPtr("my-public-lb-id/inboundNatRules/azure-test1")}},
-										LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: to.StringPtr("my-backend-pool-id")}, {ID: to.StringPtr("my-internal-backend-pool-id")}},
-									},
+				m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(true),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                      &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:   network.Dynamic,
+									LoadBalancerInboundNatRules: &[]network.InboundNatRule{{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{
+										{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/my-public-lb-backendPool")},
+										{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-internal-lb/backendAddressPools/my-internal-lb-backendPool")}},
 								},
 							},
 						},
-					})))
-			},
-		},
-		{
-			name:          "control plane network interface fail to get public LB",
-			expectedError: "failed to get public LB: #: Internal Server Error: StatusCode=500",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
-				s.NICSpecs().Return([]azure.NICSpec{
-					{
-						Name:                     "my-net-interface",
-						MachineName:              "azure-test1",
-						MachineRole:              infrav1.ControlPlane,
-						SubnetName:               "my-subnet",
-						VNetName:                 "my-vnet",
-						VNetResourceGroup:        "my-rg",
-						PublicLoadBalancerName:   "my-public-lb",
-						InternalLoadBalancerName: "my-internal-lb",
-						VMSize:                   "Standard_D2v2",
-						AcceleratedNetworking:    nil,
 					},
-				})
-				s.ResourceGroup().AnyTimes().Return("my-rg")
-				s.Location().AnyTimes().Return("fake-location")
-				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-public-lb").
-						Return(network.LoadBalancer{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error")))
-			},
-		},
-		{
-			name:          "control plane network interface fail to get internal LB",
-			expectedError: "failed to get internalLB: #: Internal Server Error: StatusCode=500",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
-				s.NICSpecs().Return([]azure.NICSpec{
-					{
-						Name:                     "my-net-interface",
-						MachineName:              "azure-test1",
-						MachineRole:              infrav1.ControlPlane,
-						SubnetName:               "my-subnet",
-						VNetName:                 "my-vnet",
-						VNetResourceGroup:        "my-rg",
-						InternalLoadBalancerName: "my-internal-lb",
-						VMSize:                   "Standard_D2v2",
-						AcceleratedNetworking:    nil,
-					},
-				})
-				s.ResourceGroup().AnyTimes().Return("my-rg")
-				s.Location().AnyTimes().Return("fake-location")
-				s.V(gomock.AssignableToTypeOf(3)).AnyTimes().Return(klogr.New())
-
-				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-internal-lb").
-						Return(network.LoadBalancer{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error")))
+				}))
 			},
 		},
 		{
 			name:          "network interface with Public IP successfully created",
 			expectedError: "",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
 						Name:                  "my-public-net-interface",
 						MachineName:           "azure-test1",
-						MachineRole:           infrav1.Node,
 						SubnetName:            "my-subnet",
 						VNetName:              "my-vnet",
 						VNetResourceGroup:     "my-rg",
@@ -366,159 +210,89 @@ func TestReconcileNetworkInterface(t *testing.T) {
 						AcceleratedNetworking: nil,
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(3)).AnyTimes().Return(klogr.New())
-
-				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil),
-					mPublicIP.Get(context.TODO(), "my-rg", "my-public-ip").Return(network.PublicIPAddress{}, nil),
-					m.CreateOrUpdate(context.TODO(), "my-rg", "my-public-net-interface", gomock.AssignableToTypeOf(network.Interface{})),
-				)
-			},
-		},
-		{
-			name:          "network interface with Public IP fail to get Public IP",
-			expectedError: "failed to get publicIP: #: Internal Server Error: StatusCode=500",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
-				s.NICSpecs().Return([]azure.NICSpec{
-					{
-						Name:                   "my-net-interface",
-						MachineName:            "azure-test1",
-						MachineRole:            infrav1.ControlPlane,
-						SubnetName:             "my-subnet",
-						VNetName:               "my-vnet",
-						VNetResourceGroup:      "my-rg",
-						PublicLoadBalancerName: "my-public-lb",
-						PublicIPName:           "my-public-ip",
-						VMSize:                 "Standard_D2v2",
-						AcceleratedNetworking:  nil,
-					},
-				})
-				s.ResourceGroup().AnyTimes().Return("my-rg")
-				s.Location().AnyTimes().Return("fake-location")
-				s.V(gomock.Any()).AnyTimes().Return(klogr.New())
-				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-public-lb").Return(network.LoadBalancer{
-						Name: to.StringPtr("my-public-lb"),
-						ID:   pointer.StringPtr("my-public-lb-id"),
-						LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
-							FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
-								{
-									ID: to.StringPtr("frontend-ip-config-id"),
-								},
-							},
-							BackendAddressPools: &[]network.BackendAddressPool{
-								{
-									ID: pointer.StringPtr("my-backend-pool-id"),
-								},
-							},
-							InboundNatRules: &[]network.InboundNatRule{},
-						},
-					}, nil),
-					mPublicIP.Get(context.TODO(), "my-rg", "my-public-ip").Return(network.PublicIPAddress{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error")))
+				m.CreateOrUpdate(context.TODO(), "my-rg", "my-public-net-interface", gomock.AssignableToTypeOf(network.Interface{}))
 			},
 		},
 		{
 			name:          "network interface with accelerated networking successfully created",
 			expectedError: "",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
-						Name:                   "my-net-interface",
-						MachineName:            "azure-test1",
-						MachineRole:            infrav1.Node,
-						SubnetName:             "my-subnet",
-						VNetName:               "my-vnet",
-						VNetResourceGroup:      "my-rg",
-						PublicLoadBalancerName: "my-public-lb",
-						VMSize:                 "Standard_D2v2",
-						AcceleratedNetworking:  nil,
+						Name:                  "my-net-interface",
+						MachineName:           "azure-test1",
+						SubnetName:            "my-subnet",
+						VNetName:              "my-vnet",
+						VNetResourceGroup:     "my-rg",
+						PublicLBName:          "my-public-lb",
+						VMSize:                "Standard_D2v2",
+						AcceleratedNetworking: nil,
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-public-lb").Return(getFakeNodeOutboundLoadBalancer(), nil),
-					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
-						Location: to.StringPtr("fake-location"),
-						InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-							EnableAcceleratedNetworking: to.BoolPtr(true),
-							IPConfigurations: &[]network.InterfaceIPConfiguration{
-								{
-									Name: to.StringPtr("pipConfig"),
-									InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-										Subnet:                          &network.Subnet{},
-										PrivateIPAllocationMethod:       network.Dynamic,
-										LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: to.StringPtr("cluster-name-outboundBackendPool")}},
-									},
+				m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(true),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                          &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       network.Dynamic,
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
 								},
 							},
 						},
-					})),
+					},
+				}),
 				)
 			},
 		},
 		{
 			name:          "network interface without accelerated networking successfully created",
 			expectedError: "",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder,
-				mSubnet *mock_subnets.MockClientMockRecorder,
-				mLoadBalancer *mock_loadbalancers.MockClientMockRecorder,
-				mPublicIP *mock_publicips.MockClientMockRecorder,
-			) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
-						Name:                   "my-net-interface",
-						MachineName:            "azure-test1",
-						MachineRole:            infrav1.Node,
-						SubnetName:             "my-subnet",
-						VNetName:               "my-vnet",
-						VNetResourceGroup:      "my-rg",
-						PublicLoadBalancerName: "my-public-lb",
-						VMSize:                 "Standard_D2v2",
-						AcceleratedNetworking:  to.BoolPtr(false),
+						Name:                  "my-net-interface",
+						MachineName:           "azure-test1",
+						SubnetName:            "my-subnet",
+						VNetName:              "my-vnet",
+						VNetResourceGroup:     "my-rg",
+						PublicLBName:          "my-public-lb",
+						VMSize:                "Standard_D2v2",
+						AcceleratedNetworking: to.BoolPtr(false),
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-
-				gomock.InOrder(
-					mSubnet.Get(context.TODO(), "my-rg", "my-vnet", "my-subnet").Return(network.Subnet{}, nil),
-					mLoadBalancer.Get(context.TODO(), "my-rg", "my-public-lb").Return(getFakeNodeOutboundLoadBalancer(), nil),
-					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
-						Location: to.StringPtr("fake-location"),
-						InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
-							EnableAcceleratedNetworking: to.BoolPtr(false),
-							IPConfigurations: &[]network.InterfaceIPConfiguration{
-								{
-									Name: to.StringPtr("pipConfig"),
-									InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
-										Subnet:                          &network.Subnet{},
-										PrivateIPAllocationMethod:       network.Dynamic,
-										LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: to.StringPtr("cluster-name-outboundBackendPool")}},
-									},
+				m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(false),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                          &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       network.Dynamic,
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
 								},
 							},
 						},
-					})),
-				)
+					},
+				}))
 			},
 		},
 	}
@@ -527,25 +301,17 @@ func TestReconcileNetworkInterface(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			// t.Parallel()
+			//t.Parallel()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 			scopeMock := mock_networkinterfaces.NewMockNICScope(mockCtrl)
 			clientMock := mock_networkinterfaces.NewMockClient(mockCtrl)
-			subnetMock := mock_subnets.NewMockClient(mockCtrl)
-			loadBalancerMock := mock_loadbalancers.NewMockClient(mockCtrl)
-			publicIPsMock := mock_publicips.NewMockClient(mockCtrl)
 
-			tc.expect(scopeMock.EXPECT(), clientMock.EXPECT(), subnetMock.EXPECT(),
-				loadBalancerMock.EXPECT(), publicIPsMock.EXPECT(),
-			)
+			tc.expect(scopeMock.EXPECT(), clientMock.EXPECT())
 
 			s := &Service{
-				Scope:               scopeMock,
-				Client:              clientMock,
-				SubnetsClient:       subnetMock,
-				LoadBalancersClient: loadBalancerMock,
-				PublicIPsClient:     publicIPsMock,
+				Scope:  scopeMock,
+				Client: clientMock,
 				ResourceSKUCache: resourceskus.NewStaticCache([]compute.ResourceSku{
 					{
 						Name: to.StringPtr("Standard_D2v2"),
@@ -586,19 +352,17 @@ func TestDeleteNetworkInterface(t *testing.T) {
 	testcases := []struct {
 		name          string
 		expectedError string
-		expect        func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-			m *mock_networkinterfaces.MockClientMockRecorder, mPublicIP *mock_publicips.MockClientMockRecorder)
+		expect        func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder)
 	}{
 		{
 			name:          "successfully delete an existing network interface",
 			expectedError: "",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder, mPublicIP *mock_publicips.MockClientMockRecorder) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
-						Name:                   "my-net-interface",
-						PublicLoadBalancerName: "my-public-lb",
-						MachineName:            "azure-test1",
+						Name:         "my-net-interface",
+						PublicLBName: "my-public-lb",
+						MachineName:  "azure-test1",
 					},
 				})
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
@@ -609,13 +373,12 @@ func TestDeleteNetworkInterface(t *testing.T) {
 		{
 			name:          "network interface already deleted",
 			expectedError: "",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder, mPublicIP *mock_publicips.MockClientMockRecorder) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
-						Name:                   "my-net-interface",
-						PublicLoadBalancerName: "my-public-lb",
-						MachineName:            "azure-test1",
+						Name:         "my-net-interface",
+						PublicLBName: "my-public-lb",
+						MachineName:  "azure-test1",
 					},
 				})
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
@@ -627,13 +390,12 @@ func TestDeleteNetworkInterface(t *testing.T) {
 		{
 			name:          "network interface deletion fails",
 			expectedError: "failed to delete network interface my-net-interface in resource group my-rg: #: Internal Server Error: StatusCode=500",
-			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder,
-				m *mock_networkinterfaces.MockClientMockRecorder, mPublicIP *mock_publicips.MockClientMockRecorder) {
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
 				s.NICSpecs().Return([]azure.NICSpec{
 					{
-						Name:                   "my-net-interface",
-						PublicLoadBalancerName: "my-public-lb",
-						MachineName:            "azure-test1",
+						Name:         "my-net-interface",
+						PublicLBName: "my-public-lb",
+						MachineName:  "azure-test1",
 					},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -648,19 +410,17 @@ func TestDeleteNetworkInterface(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			// t.Parallel()
+			t.Parallel()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 			scopeMock := mock_networkinterfaces.NewMockNICScope(mockCtrl)
 			clientMock := mock_networkinterfaces.NewMockClient(mockCtrl)
-			publicIPMock := mock_publicips.NewMockClient(mockCtrl)
 
-			tc.expect(scopeMock.EXPECT(), clientMock.EXPECT(), publicIPMock.EXPECT())
+			tc.expect(scopeMock.EXPECT(), clientMock.EXPECT())
 
 			s := &Service{
-				Scope:           scopeMock,
-				Client:          clientMock,
-				PublicIPsClient: publicIPMock,
+				Scope:  scopeMock,
+				Client: clientMock,
 			}
 
 			err := s.Delete(context.TODO())
@@ -672,33 +432,4 @@ func TestDeleteNetworkInterface(t *testing.T) {
 			}
 		})
 	}
-}
-
-func getFakeNodeOutboundLoadBalancer() network.LoadBalancer {
-	return network.LoadBalancer{
-		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
-			InboundNatRules: &[]network.InboundNatRule{{
-				Name: pointer.StringPtr("azure-test1"),
-				InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
-					FrontendPort:         to.Int32Ptr(22),
-					BackendPort:          to.Int32Ptr(22),
-					EnableFloatingIP:     to.BoolPtr(false),
-					IdleTimeoutInMinutes: to.Int32Ptr(4),
-					FrontendIPConfiguration: &network.SubResource{
-						ID: to.StringPtr("frontend-ip-config-id"),
-					},
-					Protocol: network.TransportProtocolTCP,
-				},
-			}},
-			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
-				{
-					ID: to.StringPtr("frontend-ip-config-id"),
-				},
-			},
-			BackendAddressPools: &[]network.BackendAddressPool{
-				{
-					ID: pointer.StringPtr("cluster-name-outboundBackendPool"),
-				},
-			},
-		}}
 }

--- a/cloud/services/networkinterfaces/service.go
+++ b/cloud/services/networkinterfaces/service.go
@@ -19,11 +19,7 @@ package networkinterfaces
 import (
 	"github.com/go-logr/logr"
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/inboundnatrules"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/loadbalancers"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/publicips"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/resourceskus"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/subnets"
 )
 
 // NICScope defines the scope interface for a network interfaces service.
@@ -37,22 +33,14 @@ type NICScope interface {
 type Service struct {
 	Scope NICScope
 	Client
-	SubnetsClient         subnets.Client
-	LoadBalancersClient   loadbalancers.Client
-	PublicIPsClient       publicips.Client
-	InboundNATRulesClient inboundnatrules.Client
-	ResourceSKUCache      *resourceskus.Cache
+	ResourceSKUCache *resourceskus.Cache
 }
 
 // NewService creates a new service.
 func NewService(scope NICScope, skuCache *resourceskus.Cache) *Service {
 	return &Service{
-		Scope:                 scope,
-		Client:                NewClient(scope),
-		SubnetsClient:         subnets.NewClient(scope),
-		LoadBalancersClient:   loadbalancers.NewClient(scope),
-		PublicIPsClient:       publicips.NewClient(scope),
-		InboundNATRulesClient: inboundnatrules.NewClient(scope),
-		ResourceSKUCache:      skuCache,
+		Scope:            scope,
+		Client:           NewClient(scope),
+		ResourceSKUCache: skuCache,
 	}
 }

--- a/cloud/services/subnets/service.go
+++ b/cloud/services/subnets/service.go
@@ -19,8 +19,6 @@ package subnets
 import (
 	"github.com/go-logr/logr"
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/routetables"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/securitygroups"
 )
 
 // SubnetScope defines the scope interface for a network interfaces service.
@@ -34,16 +32,12 @@ type SubnetScope interface {
 type Service struct {
 	Scope SubnetScope
 	Client
-	SecurityGroupsClient securitygroups.Client
-	RouteTablesClient    routetables.Client
 }
 
 // NewService creates a new service.
 func NewService(scope SubnetScope) *Service {
 	return &Service{
-		Scope:                scope,
-		Client:               NewClient(scope),
-		SecurityGroupsClient: securitygroups.NewClient(scope),
-		RouteTablesClient:    routetables.NewClient(scope),
+		Scope:  scope,
+		Client: NewClient(scope),
 	}
 }

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -125,7 +125,7 @@ func TestGetExistingVM(t *testing.T) {
 			name:          "vm not found",
 			vmName:        "my-vm",
 			result:        &infrav1.VM{},
-			expectedError: "VM my-vm not found: #: Not found: StatusCode=404",
+			expectedError: "#: Not found: StatusCode=404",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
@@ -313,6 +313,7 @@ func TestReconcileVM(t *testing.T) {
 						SpotVMOptions:          nil,
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.AdditionalTags()
@@ -320,14 +321,6 @@ func TestReconcileVM(t *testing.T) {
 				s.ClusterName().Return("my-cluster")
 				m.Get(context.TODO(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
-				mnic.Get(context.TODO(), "my-rg", "my-nic").Return(network.Interface{
-					ID:   to.StringPtr("fake/nic/id"),
-					Name: to.StringPtr("my-nic"),
-				}, nil)
-				mnic.Get(context.TODO(), "my-rg", "second-nic").Return(network.Interface{
-					ID:   to.StringPtr("second/fake/nic/id"),
-					Name: to.StringPtr("second-nic"),
-				}, nil)
 				s.GetVMImage().Return(&infrav1.Image{
 					Marketplace: &infrav1.AzureMarketplaceImage{
 						Publisher: "fake-publisher",
@@ -385,11 +378,11 @@ func TestReconcileVM(t *testing.T) {
 							NetworkInterfaces: &[]compute.NetworkInterfaceReference{
 								{
 									NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{Primary: to.BoolPtr(true)},
-									ID:                                  to.StringPtr("fake/nic/id"),
+									ID:                                  to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/my-nic"),
 								},
 								{
 									NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{Primary: to.BoolPtr(false)},
-									ID:                                  to.StringPtr("second/fake/nic/id"),
+									ID:                                  to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/second-nic"),
 								},
 							},
 						},
@@ -428,6 +421,7 @@ func TestReconcileVM(t *testing.T) {
 						SpotVMOptions:          nil,
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.AdditionalTags()
@@ -435,10 +429,6 @@ func TestReconcileVM(t *testing.T) {
 				s.ClusterName().Return("my-cluster")
 				m.Get(context.TODO(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
-				mnic.Get(context.TODO(), "my-rg", "my-nic").Return(network.Interface{
-					ID:   to.StringPtr("fake/nic/id"),
-					Name: to.StringPtr("my-nic"),
-				}, nil)
 				s.GetVMImage().Return(&infrav1.Image{
 					Marketplace: &infrav1.AzureMarketplaceImage{
 						Publisher: "fake-publisher",
@@ -473,6 +463,7 @@ func TestReconcileVM(t *testing.T) {
 						SpotVMOptions:          nil,
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.AdditionalTags()
@@ -480,10 +471,6 @@ func TestReconcileVM(t *testing.T) {
 				s.ClusterName().Return("my-cluster")
 				m.Get(context.TODO(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
-				mnic.Get(context.TODO(), "my-rg", "my-nic").Return(network.Interface{
-					ID:   to.StringPtr("fake/nic/id"),
-					Name: to.StringPtr("my-nic"),
-				}, nil)
 				s.GetVMImage().Return(&infrav1.Image{
 					Marketplace: &infrav1.AzureMarketplaceImage{
 						Publisher: "fake-publisher",
@@ -518,6 +505,7 @@ func TestReconcileVM(t *testing.T) {
 						SpotVMOptions:          &infrav1.SpotVMOptions{},
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.AdditionalTags()
@@ -525,10 +513,6 @@ func TestReconcileVM(t *testing.T) {
 				s.ClusterName().Return("my-cluster")
 				m.Get(context.TODO(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
-				mnic.Get(context.TODO(), "my-rg", "my-nic").Return(network.Interface{
-					ID:   to.StringPtr("fake/nic/id"),
-					Name: to.StringPtr("my-nic"),
-				}, nil)
 				s.GetVMImage().Return(&infrav1.Image{
 					Marketplace: &infrav1.AzureMarketplaceImage{
 						Publisher: "fake-publisher",
@@ -564,6 +548,7 @@ func TestReconcileVM(t *testing.T) {
 						SpotVMOptions:          nil,
 					},
 				})
+				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.AdditionalTags()
@@ -571,10 +556,6 @@ func TestReconcileVM(t *testing.T) {
 				s.ClusterName().Return("my-cluster")
 				m.Get(context.TODO(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
-				mnic.Get(context.TODO(), "my-rg", "my-nic").Return(network.Interface{
-					ID:   to.StringPtr("fake/nic/id"),
-					Name: to.StringPtr("my-nic"),
-				}, nil)
 				s.GetVMImage().Return(&infrav1.Image{
 					Marketplace: &infrav1.AzureMarketplaceImage{
 						Publisher: "fake-publisher",

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -28,18 +28,20 @@ type PublicIPSpec struct {
 
 // NICSpec defines the specification for a Network Interface.
 type NICSpec struct {
-	Name                     string
-	MachineName              string
-	MachineRole              string
-	SubnetName               string
-	VNetName                 string
-	VNetResourceGroup        string
-	StaticIPAddress          string
-	PublicLoadBalancerName   string
-	InternalLoadBalancerName string
-	PublicIPName             string
-	VMSize                   string
-	AcceleratedNetworking    *bool
+	Name                      string
+	MachineName               string
+	SubnetName                string
+	VNetName                  string
+	VNetResourceGroup         string
+	StaticIPAddress           string
+	PublicLBName              string
+	PublicLBAddressPoolName   string
+	PublicLBNATRuleName       string
+	InternalLBName            string
+	InternalLBAddressPoolName string
+	PublicIPName              string
+	VMSize                    string
+	AcceleratedNetworking     *bool
 }
 
 // DiskSpec defines the specification for a Disk.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: This removes Azure API calls to get the resource ID for sub resources since we already have all the information required to construct that string ID. Adds new helper functions do build resource IDs in the `azure` package. The benefits are 1) less API calls per reconcile loop, reduced risk of API throttling 2) no need to wait for Azure to send a response so speeds up cluster reconcile duration

~TODO: tests~

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove extra GET API calls for resource IDs
```