### PR TITLE
[WIP] 🌱 add more capi e2e specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ test-integration: ## Run integration tests
 .PHONY: test-e2e
 test-e2e: $(ENVSUBST) $(GINKGO) ## Run e2e tests
 	PULL_POLICY=IfNotPresent $(MAKE) docker-build
+	$(MAKE) docker-push
 	MANAGER_IMAGE=$(CONTROLLER_IMG)-$(ARCH):$(TAG) \
 	$(ENVSUBST) < $(E2E_CONF_FILE) > $(E2E_CONF_FILE_ENVSUBST) && \
 	$(GINKGO) -v -trace -tags=e2e -focus=$(GINKGO_FOCUS) -nodes=$(GINKGO_NODES) --noColor=$(GINKGO_NOCOLOR) ./test/e2e -- \

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -48,7 +48,11 @@ get_random_region() {
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
 
-export REGISTRY="e2e"
+export REGISTRY=gcr.io/k8s-staging-cluster-api-azure
+export TAG=e2e
+export ARCH=amd64
+export PULL_POLICY=IfNotPresent
+
 export AZURE_ENVIRONMENT="AzurePublicCloud"
 export GINKGO_NODES=3
 export AZURE_SUBSCRIPTION_ID_B64="$(echo -n "$AZURE_SUBSCRIPTION_ID" | base64 | tr -d '\n')"

--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -55,18 +55,17 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 		})
 	})
 
-	// TODO: fix and enable
-	//Context("Running the KCP upgrade spec", func() {
-	//	capi_e2e.KCPUpgradeSpec(context.TODO(), func() capi_e2e.KCPUpgradeSpecInput {
-	//		return capi_e2e.KCPUpgradeSpecInput{
-	//			E2EConfig:             e2eConfig,
-	//			ClusterctlConfigPath:  clusterctlConfigPath,
-	//			BootstrapClusterProxy: bootstrapClusterProxy,
-	//			ArtifactFolder:        artifactFolder,
-	//			SkipCleanup:           skipCleanup,
-	//		}
-	//	})
-	//})
+	Context("Running the KCP upgrade spec", func() {
+		capi_e2e.KCPUpgradeSpec(context.TODO(), func() capi_e2e.KCPUpgradeSpecInput {
+			return capi_e2e.KCPUpgradeSpecInput{
+				E2EConfig:             e2eConfig,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				ArtifactFolder:        artifactFolder,
+				SkipCleanup:           skipCleanup,
+			}
+		})
+	})
 
 	Context("Running the MachineDeployment upgrade spec", func() {
 		capi_e2e.MachineDeploymentUpgradesSpec(context.TODO(), func() capi_e2e.MachineDeploymentUpgradesSpecInput {
@@ -80,16 +79,15 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 		})
 	})
 
-	// TODO: fix and enable
-	// Context("Running the self-hosted spec", func() {
-	// 	capi_e2e.SelfHostedSpec(context.TODO(), func() capi_e2e.SelfHostedSpecInput {
-	// 		return capi_e2e.SelfHostedSpecInput{
-	// 			E2EConfig:             e2eConfig,
-	// 			ClusterctlConfigPath:  clusterctlConfigPath,
-	// 			BootstrapClusterProxy: bootstrapClusterProxy,
-	// 			ArtifactFolder:        artifactFolder,
-	// 			SkipCleanup:           skipCleanup,
-	// 		}
-	// 	})
-	// })
+	Context("Running the self-hosted spec", func() {
+		capi_e2e.SelfHostedSpec(context.TODO(), func() capi_e2e.SelfHostedSpecInput {
+			return capi_e2e.SelfHostedSpecInput{
+				E2EConfig:             e2eConfig,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				ArtifactFolder:        artifactFolder,
+				SkipCleanup:           skipCleanup,
+			}
+		})
+	})
 })

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -63,10 +63,10 @@ variables:
 intervals:
   default/wait-controllers: ["3m", "10s"]
   default/wait-cluster: ["20m", "10s"]
-  default/wait-control-plane: ["10m", "10s"]
-  default/wait-worker-nodes: ["10m", "10s"]
+  default/wait-control-plane: ["20m", "10s"]
+  default/wait-worker-nodes: ["20m", "10s"]
   default/wait-delete-cluster: ["30m", "10s"]
-  default/wait-machine-upgrade: ["20m", "10s"]
+  default/wait-machine-upgrade: ["30m", "10s"]
   default/wait-machine-remediation: ["20m", "10s"]
   default/wait-deployment: ["5m", "10s"]
   default/wait-job: ["5m", "10s"]


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:
- enable more capi specs in the e2e package
- push the e2e image so nodes on azure can get it
- increase timeouts in config

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #780 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add more cluster-api e2e specs 
```