### PR TITLE
🐛 fix requeue, labels in azure json reconciler

### DIFF
--- a/controllers/azurejson_machine_controller.go
+++ b/controllers/azurejson_machine_controller.go
@@ -104,7 +104,7 @@ func (f filterUnclonedMachinesPredicate) Generic(e event.GenericEvent) bool {
 func (r *AzureJSONMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx, cancel := context.WithTimeout(context.Background(), reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()
-	log := r.Log.WithValues("namespace", req.Namespace, "AzureJSONMachine", req.Name)
+	log := r.Log.WithValues("namespace", req.Namespace, "AzureMachine", req.Name)
 
 	// Fetch the AzureMachine instance
 	azureMachine := &infrav1.AzureMachine{}
@@ -150,12 +150,8 @@ func (r *AzureJSONMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result,
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
 
-	err = r.Get(ctx, azureClusterName, azureCluster)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("object was not found")
-			return reconcile.Result{}, nil
-		}
+	if err := r.Get(ctx, azureClusterName, azureCluster); err != nil {
+		log.Error(err, "failed to fetch AzureCluster")
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -59,7 +59,7 @@ func (r *AzureJSONMachinePoolReconciler) SetupWithManager(mgr ctrl.Manager, opti
 func (r *AzureJSONMachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx, cancel := context.WithTimeout(context.Background(), reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()
-	log := r.Log.WithValues("namespace", req.Namespace, "AzureJSONMachinePool", req.Name)
+	log := r.Log.WithValues("namespace", req.Namespace, "AzureMachinePool", req.Name)
 
 	// Fetch the AzureMachine instance
 	azureMachinePool := &expv1.AzureMachinePool{}
@@ -108,12 +108,8 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.Res
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
 
-	err = r.Get(ctx, azureClusterName, azureCluster)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("object was not found")
-			return reconcile.Result{}, nil
-		}
+	if err := r.Get(ctx, azureClusterName, azureCluster); err != nil {
+		log.Error(err, "failed to fetch AzureCluster")
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/azurejson_machinetemplate_controller.go
+++ b/controllers/azurejson_machinetemplate_controller.go
@@ -91,10 +91,8 @@ func (r *AzureJSONTemplateReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 		return ctrl.Result{}, nil
 	}
 
-	_, kind := infrav1.GroupVersion.WithKind("AzureCluster").ToAPIVersionAndKind()
-
 	// only look at azure clusters
-	if cluster.Spec.InfrastructureRef.Kind != kind {
+	if cluster.Spec.InfrastructureRef.Kind != "AzureCluster" {
 		log.WithValues("kind", cluster.Spec.InfrastructureRef.Kind).Info("infra ref was not an AzureCluster")
 		return ctrl.Result{}, nil
 	}
@@ -106,12 +104,8 @@ func (r *AzureJSONTemplateReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
 
-	err = r.Get(ctx, azureClusterName, azureCluster)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("object was not found")
-			return reconcile.Result{}, nil
-		}
+	if err := r.Get(ctx, azureClusterName, azureCluster); err != nil {
+		log.Error(err, "failed to fetch AzureCluster")
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -277,7 +277,7 @@ func reconcileAzureSecret(ctx context.Context, log logr.Logger, kubeclient clien
 
 	tag, exists := old.Labels[clusterName]
 
-	if exists && tag == string(infrav1.ResourceLifecycleOwned) {
+	if exists && tag != string(infrav1.ResourceLifecycleOwned) {
 		log.Info("returning early from json reconcile, user provided secret already exists")
 		return nil
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
while investigating bootstrap failures, I can see this line get hit, and then the cloud provider secret doesn't get created until 15 min later. I'm a bit surprised the cluster can't be found: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/8b2866123ccce2d63c0df52c8507d0e2996857e9/controllers/azurejson_machinetemplate_controller.go#L109-L116

because the secret doesn't exist, capbk can't successfully get to this part of the reconcile loop, where it sets config.Status.Ready = true: https://github.com/kubernetes-sigs/cluster-api/blob/f8dd8a3bdba86bae3e72abdf2c8d7cbac9573cf7/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go#L798-L834

so we don't hit this switch case: https://github.com/kubernetes-sigs/cluster-api/blob/f8dd8a3bdba86bae3e72abdf2c8d7cbac9573cf7/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go#L241-L264

so the token doesn't get refreshed, but the bootstrap secret still gets stored with the original token as soon as we can find the secrets to generate the data. i'm not totally sure why the jsontemplate can't find AzureCluster and how that ends up with a 15min requeue, and it's not clear to me what happens to the originally generated capbk token. I would assume ttlcleaner kills it after 15minutes, but then idk where the other token comes from that does exist in the cluster (haven't followed the logic to see how that would get created).

regardless of the final answers, this is a bug that should be fixed. we should requeue on not finding the AzureCluster

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```