### PR TITLE
 🐛 generate json for individual cp machine, add tests

### DIFF
--- a/controllers/azurejson_machine_controller.go
+++ b/controllers/azurejson_machine_controller.go
@@ -90,15 +90,19 @@ func (f filterUnclonedMachinesPredicate) Generic(e event.GenericEvent) bool {
 		return false
 	}
 
-	// when watching machines, we only care about machines users created one-off
-	// outside of machinedeployments/machinesets. if a machine is part of a machineset
-	// or machinedeployment, we already created a secret for the template. All machines
-	// in the machinedeployment will share that one secret.
-	_, isControlPlaneNode := e.Meta.GetLabels()[clusterv1.MachineControlPlaneLabelName]
+	// when watching machines, we only care about machines users created
+	// one-off outside of machinedeployments/machinesets. if a machine
+	// is part of a machineset or machinedeployment, we already created
+	// a secret for the template. All machines in the machinedeployment
+	// will share that one secret.
+	//
+	// We create individual secrets for control plane machines even if
+	// they were created from a template, to allow for one-off control
+	// plane machines and control plane adoption.
 	_, isMachineSetNode := e.Meta.GetLabels()[clusterv1.MachineSetLabelName]
 	_, isMachineDeploymentNode := e.Meta.GetLabels()[clusterv1.MachineDeploymentLabelName]
 
-	return !isControlPlaneNode && !isMachineSetNode && !isMachineDeploymentNode
+	return !isMachineSetNode && !isMachineDeploymentNode
 }
 
 // Reconcile reconciles the azure json for a specific machine not in a machine deployment

--- a/controllers/azurejson_machine_controller_test.go
+++ b/controllers/azurejson_machine_controller_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestUnclonedMachinesPredicate(t *testing.T) {
+	cases := map[string]struct {
+		expected bool
+		labels   map[string]string
+	}{
+		"uncloned worker node should return true": {
+			expected: true,
+			labels:   nil,
+		},
+		"control plane node should return true": {
+			expected: true,
+			labels: map[string]string{
+				clusterv1.MachineControlPlaneLabelName: "",
+			},
+		},
+		"machineset node should return false": {
+			expected: false,
+			labels: map[string]string{
+				clusterv1.MachineSetLabelName: "",
+			},
+		},
+		"machinedeployment node should return false": {
+			expected: false,
+			labels: map[string]string{
+				clusterv1.MachineDeploymentLabelName: "",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			machine := &infrav1.AzureMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: tc.labels,
+				},
+			}
+			e := event.GenericEvent{
+				Meta:   machine,
+				Object: machine,
+			}
+			filter := filterUnclonedMachinesPredicate{}
+			if filter.Generic(e) != tc.expected {
+				t.Errorf("expected: %t, got %t", tc.expected, filter.Generic(e))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #874 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
CAPZ will now generate the cloud provider secret for machines not created by a control plane CRD. This enables KCP to adopt pre-existing machines.
```