### PR TITLE
💎 add coverage reports

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - run: "make test-cover"
+    - uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.out
+        fail_ci_if_error: true


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

add public code coverage reports. several of our recent bugs were in areas which were poorly tested, and which added unit tests would have prevented.

e.g.
- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/870
- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/876
- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/843 (testing against multiple versions)
- https://github.com/kubernetes-sigs/cluster-api/pull/3472

I'd personally like to use this to find areas of weak coverage which present high probability areas for bugs, add tests, and refactor them as necessary to simplify testing as we go.

Our current coverage on controllers is 22.28%. Our overall coverage is 33.76%. We have the best overall coverall coverage on the cloud service code at 44.38%, excluding utility files. This strikes me as very poor.

reference: https://codecov.io/gh/alexeldeib/cluster-api-provider-azure/tree/791f8eec2a1642427be7a1e4e1815279cb62db04

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```