### PR TITLE
🐛 fix incorrect owner references on azure json

### DIFF
--- a/controllers/azurejson_machine_controller.go
+++ b/controllers/azurejson_machine_controller.go
@@ -188,6 +188,7 @@ func (r *AzureJSONMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result,
 		clusterScope,
 		azureMachine.Namespace,
 		azureMachine.Name,
+		owner,
 		azureMachine.Spec.Identity,
 		userAssignedIdentityIfExists,
 	)

--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -140,6 +140,7 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.Res
 		clusterScope,
 		azureMachinePool.Namespace,
 		azureMachinePool.Name,
+		owner,
 		infrav1.VMIdentityNone,
 		"",
 	)

--- a/controllers/azurejson_machinetemplate_controller.go
+++ b/controllers/azurejson_machinetemplate_controller.go
@@ -144,6 +144,7 @@ func (r *AzureJSONTemplateReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 		clusterScope,
 		azureMachineTemplate.Namespace,
 		azureMachineTemplate.Name,
+		owner,
 		azureMachineTemplate.Spec.Template.Spec.Identity,
 		userAssignedIdentityIfExists,
 	)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:

we're not setting the owner references on the azure json properly. do so and add unit tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prior to this release, cloud provider secrets created for azuremachines, azuremachinepools, and azuremachinetemplates were not correctly cleaned up. Users may wish to manually delete these secrets if the associated machines no longer exist.
```