### PR TITLE
cloud/vm/vmss: validate if vCPUs and Memory matched the minimum required

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -337,7 +337,7 @@ type ManagedDisk struct {
 // DiffDiskSettings describe ephemeral disk settings for the os disk.
 type DiffDiskSettings struct {
 	// Option enables ephemeral OS when set to "Local"
-	// See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks for full details
+	// See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details
 	// +kubebuilder:validation:Enum=Local
 	Option string `json:"option"`
 }

--- a/cloud/services/resourceskus/sku.go
+++ b/cloud/services/resourceskus/sku.go
@@ -52,6 +52,14 @@ const (
 	EphemeralOSDisk = "EphemeralOSDiskSupported"
 	// AcceleratedNetworking identifies the capability for accelerated networking support.
 	AcceleratedNetworking = "AcceleratedNetworkingEnabled"
+	//VCPUs identifies the capability for the number of vCPUS.
+	VCPUs = "vCPUs"
+	// MemoryGB identifies the capability for memory Size.
+	MemoryGB = "MemoryGB"
+	// MinimumVCPUS is the minimum vCPUS allowed.
+	MinimumVCPUS = 2
+	// MinimumMemory is the minimum memory allowed.
+	MinimumMemory = 2
 )
 
 // HasCapability return true for a capability which can be either

--- a/cloud/services/scalesets/vmss.go
+++ b/cloud/services/scalesets/vmss.go
@@ -89,6 +89,24 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 		return errors.Wrapf(err, "failed to get find vm sku %s in compute api", vmssSpec.Sku)
 	}
 
+	// Checking if the requested VM size has at least 2 vCPUS
+	vCPUCapability, err := sku.HasCapabilityWithCapacity(resourceskus.VCPUs, resourceskus.MinimumVCPUS)
+	if err != nil {
+		return errors.Wrap(err, "failed to validate the vCPU cabability")
+	}
+	if !vCPUCapability {
+		return errors.New("vm size should be bigger or equal to at least 2 vCPUs")
+	}
+
+	// Checking if the requested VM size has at least 2 Gi of memory
+	MemoryCapability, err := sku.HasCapabilityWithCapacity(resourceskus.MemoryGB, resourceskus.MinimumMemory)
+	if err != nil {
+		return errors.Wrap(err, "failed to validate the memory cabability")
+	}
+	if !MemoryCapability {
+		return errors.New("vm memory should be bigger or equal to at least 2Gi")
+	}
+
 	if vmssSpec.AcceleratedNetworking == nil {
 		// set accelerated networking to the capability of the VMSize
 		accelNet := sku.HasCapability(resourceskus.AcceleratedNetworking)

--- a/cloud/services/virtualmachines/virtualmachines.go
+++ b/cloud/services/virtualmachines/virtualmachines.go
@@ -291,13 +291,31 @@ func (s *Service) generateStorageProfile(ctx context.Context, vmSpec azure.VMSpe
 		},
 	}
 
+	sku, err := s.ResourceSKUCache.Get(ctx, vmSpec.Size, resourceskus.VirtualMachines)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get find vm sku %s in compute api", vmSpec.Size)
+	}
+
+	// Checking if the requested VM size has at least 2 vCPUS
+	vCPUCapability, err := sku.HasCapabilityWithCapacity(resourceskus.VCPUs, resourceskus.MinimumVCPUS)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to validate the vCPU cabability")
+	}
+	if !vCPUCapability {
+		return nil, errors.New("vm size should be bigger or equal to at least 2 vCPUs")
+	}
+
+	// Checking if the requested VM size has at least 2 Gi of memory
+	MemoryCapability, err := sku.HasCapabilityWithCapacity(resourceskus.MemoryGB, resourceskus.MinimumMemory)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to validate the memory cabability")
+	}
+	if !MemoryCapability {
+		return nil, errors.New("vm memory should be bigger or equal to at least 2Gi")
+	}
+
 	// enable ephemeral OS
 	if vmSpec.OSDisk.DiffDiskSettings != nil {
-		sku, err := s.ResourceSKUCache.Get(ctx, vmSpec.Size, resourceskus.VirtualMachines)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get find vm sku %s in compute api", vmSpec.Size)
-		}
-
 		if !sku.HasCapability(resourceskus.EphemeralOSDisk) {
 			return nil, fmt.Errorf("vm size %s does not support ephemeral os. select a different vm size or disable ephemeral os", vmSpec.Size)
 		}

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -32,6 +32,7 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/networkinterfaces/mock_networkinterfaces"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/publicips/mock_publicips"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/resourceskus"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/virtualmachines/mock_virtualmachines"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -279,13 +280,14 @@ func TestGetExistingVM(t *testing.T) {
 
 func TestReconcileVM(t *testing.T) {
 	testcases := []struct {
-		name          string
-		expect        func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder)
-		expectedError string
+		Name          string
+		Expect        func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder)
+		ExpectedError string
+		SetupSKUs     func(svc *Service)
 	}{
 		{
-			name: "can create a vm",
-			expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+			Name: "can create a vm",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
 				s.VMSpecs().Return([]azure.VMSpec{
 					{
 						Name:       "my-vm",
@@ -401,11 +403,41 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}))
 			},
-			expectedError: "",
+			ExpectedError: "",
+			SetupSKUs: func(svc *Service) {
+				skus := []compute.ResourceSku{
+					{
+						Name: to.StringPtr("Standard_D2v3"),
+						Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+						Locations: &[]string{
+							"test-location",
+						},
+						LocationInfo: &[]compute.ResourceSkuLocationInfo{
+							{
+								Location: to.StringPtr("test-location"),
+								Zones:    &[]string{"1"},
+							},
+						},
+						Capabilities: &[]compute.ResourceSkuCapabilities{
+							{
+								Name:  to.StringPtr(resourceskus.VCPUs),
+								Value: to.StringPtr("2"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.MemoryGB),
+								Value: to.StringPtr("4"),
+							},
+						},
+					},
+				}
+				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				svc.ResourceSKUCache = resourceSkusCache
+
+			},
 		},
 		{
-			name: "can create a vm with system assigned identity",
-			expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+			Name: "can create a vm with system assigned identity",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
 				s.VMSpecs().Return([]azure.VMSpec{
 					{
 						Name:                   "my-vm",
@@ -443,11 +475,41 @@ func TestReconcileVM(t *testing.T) {
 					g.Expect(vm.Identity.UserAssignedIdentities).To(HaveLen(0))
 				})
 			},
-			expectedError: "",
+			ExpectedError: "",
+			SetupSKUs: func(svc *Service) {
+				skus := []compute.ResourceSku{
+					{
+						Name: to.StringPtr("Standard_D2v3"),
+						Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+						Locations: &[]string{
+							"test-location",
+						},
+						LocationInfo: &[]compute.ResourceSkuLocationInfo{
+							{
+								Location: to.StringPtr("test-location"),
+								Zones:    &[]string{"1"},
+							},
+						},
+						Capabilities: &[]compute.ResourceSkuCapabilities{
+							{
+								Name:  to.StringPtr(resourceskus.VCPUs),
+								Value: to.StringPtr("2"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.MemoryGB),
+								Value: to.StringPtr("4"),
+							},
+						},
+					},
+				}
+				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				svc.ResourceSKUCache = resourceSkusCache
+
+			},
 		},
 		{
-			name: "can create a vm with user assigned identity",
-			expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+			Name: "can create a vm with user assigned identity",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
 				s.VMSpecs().Return([]azure.VMSpec{
 					{
 						Name:                   "my-vm",
@@ -485,11 +547,41 @@ func TestReconcileVM(t *testing.T) {
 					g.Expect(vm.Identity.UserAssignedIdentities).To(Equal(map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{"my-user-id": {}}))
 				})
 			},
-			expectedError: "",
+			ExpectedError: "",
+			SetupSKUs: func(svc *Service) {
+				skus := []compute.ResourceSku{
+					{
+						Name: to.StringPtr("Standard_D2v3"),
+						Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+						Locations: &[]string{
+							"test-location",
+						},
+						LocationInfo: &[]compute.ResourceSkuLocationInfo{
+							{
+								Location: to.StringPtr("test-location"),
+								Zones:    &[]string{"1"},
+							},
+						},
+						Capabilities: &[]compute.ResourceSkuCapabilities{
+							{
+								Name:  to.StringPtr(resourceskus.VCPUs),
+								Value: to.StringPtr("2"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.MemoryGB),
+								Value: to.StringPtr("4"),
+							},
+						},
+					},
+				}
+				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				svc.ResourceSKUCache = resourceSkusCache
+
+			},
 		},
 		{
-			name: "can create a spot vm",
-			expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+			Name: "can create a spot vm",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
 				s.VMSpecs().Return([]azure.VMSpec{
 					{
 						Name:                   "my-vm",
@@ -528,11 +620,41 @@ func TestReconcileVM(t *testing.T) {
 					g.Expect(vm.BillingProfile).To(BeNil())
 				})
 			},
-			expectedError: "",
+			ExpectedError: "",
+			SetupSKUs: func(svc *Service) {
+				skus := []compute.ResourceSku{
+					{
+						Name: to.StringPtr("Standard_D2v3"),
+						Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+						Locations: &[]string{
+							"test-location",
+						},
+						LocationInfo: &[]compute.ResourceSkuLocationInfo{
+							{
+								Location: to.StringPtr("test-location"),
+								Zones:    &[]string{"1"},
+							},
+						},
+						Capabilities: &[]compute.ResourceSkuCapabilities{
+							{
+								Name:  to.StringPtr(resourceskus.VCPUs),
+								Value: to.StringPtr("2"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.MemoryGB),
+								Value: to.StringPtr("4"),
+							},
+						},
+					},
+				}
+				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				svc.ResourceSKUCache = resourceSkusCache
+
+			},
 		},
 		{
-			name: "vm creation fails",
-			expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+			Name: "vm creation fails",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
 				s.VMSpecs().Return([]azure.VMSpec{
 					{
 						Name:                   "my-vm",
@@ -567,13 +689,414 @@ func TestReconcileVM(t *testing.T) {
 				s.GetBootstrapData(context.TODO()).Return("fake-bootstrap-data", nil)
 				m.CreateOrUpdate(context.TODO(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 			},
-			expectedError: "failed to create VM my-vm in resource group my-rg: #: Internal Server Error: StatusCode=500",
+			ExpectedError: "failed to create VM my-vm in resource group my-rg: #: Internal Server Error: StatusCode=500",
+			SetupSKUs: func(svc *Service) {
+				skus := []compute.ResourceSku{
+					{
+						Name: to.StringPtr("Standard_D2v3"),
+						Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+						Locations: &[]string{
+							"test-location",
+						},
+						LocationInfo: &[]compute.ResourceSkuLocationInfo{
+							{
+								Location: to.StringPtr("test-location"),
+								Zones:    &[]string{"1"},
+							},
+						},
+						Capabilities: &[]compute.ResourceSkuCapabilities{
+							{
+								Name:  to.StringPtr(resourceskus.VCPUs),
+								Value: to.StringPtr("2"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.MemoryGB),
+								Value: to.StringPtr("4"),
+							},
+						},
+					},
+				}
+				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				svc.ResourceSKUCache = resourceSkusCache
+
+			},
+		},
+		{
+			Name: "cannot create vm if vCPU is less than 2",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+				s.VMSpecs().Return([]azure.VMSpec{
+					{
+						Name:       "my-vm",
+						Role:       infrav1.ControlPlane,
+						NICNames:   []string{"my-nic", "second-nic"},
+						SSHKeyData: "ZmFrZXNzaGtleQo=",
+						Size:       "Standard_D1v3",
+						Zone:       "1",
+						Identity:   infrav1.VMIdentityNone,
+						OSDisk: infrav1.OSDisk{
+							OSType:     "Linux",
+							DiskSizeGB: 128,
+							ManagedDisk: infrav1.ManagedDisk{
+								StorageAccountType: "Premium_LRS",
+							},
+						},
+						DataDisks: []infrav1.DataDisk{
+							{
+								NameSuffix: "mydisk",
+								DiskSizeGB: 64,
+								Lun:        to.Int32Ptr(0),
+							},
+						},
+						UserAssignedIdentities: nil,
+						SpotVMOptions:          nil,
+					},
+				})
+				s.SubscriptionID().AnyTimes().Return("123")
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				m.Get(context.TODO(), "my-rg", "my-vm").
+					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+			},
+			ExpectedError: "vm size should be bigger or equal to at least 2 vCPUs",
+			SetupSKUs: func(svc *Service) {
+				skus := []compute.ResourceSku{
+					{
+						Name: to.StringPtr("Standard_D1v3"),
+						Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+						Locations: &[]string{
+							"test-location",
+						},
+						LocationInfo: &[]compute.ResourceSkuLocationInfo{
+							{
+								Location: to.StringPtr("test-location"),
+								Zones:    &[]string{"1"},
+							},
+						},
+						Capabilities: &[]compute.ResourceSkuCapabilities{
+							{
+								Name:  to.StringPtr(resourceskus.VCPUs),
+								Value: to.StringPtr("1"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.MemoryGB),
+								Value: to.StringPtr("4"),
+							},
+						},
+					},
+				}
+				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				svc.ResourceSKUCache = resourceSkusCache
+
+			},
+		},
+		{
+			Name: "cannot create vm if memory is less than 2Gi",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+				s.VMSpecs().Return([]azure.VMSpec{
+					{
+						Name:       "my-vm",
+						Role:       infrav1.ControlPlane,
+						NICNames:   []string{"my-nic", "second-nic"},
+						SSHKeyData: "ZmFrZXNzaGtleQo=",
+						Size:       "Standard_D2v3",
+						Zone:       "1",
+						Identity:   infrav1.VMIdentityNone,
+						OSDisk: infrav1.OSDisk{
+							OSType:     "Linux",
+							DiskSizeGB: 128,
+							ManagedDisk: infrav1.ManagedDisk{
+								StorageAccountType: "Premium_LRS",
+							},
+						},
+						DataDisks: []infrav1.DataDisk{
+							{
+								NameSuffix: "mydisk",
+								DiskSizeGB: 64,
+								Lun:        to.Int32Ptr(0),
+							},
+						},
+						UserAssignedIdentities: nil,
+						SpotVMOptions:          nil,
+					},
+				})
+				s.SubscriptionID().AnyTimes().Return("123")
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				m.Get(context.TODO(), "my-rg", "my-vm").
+					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+			},
+			ExpectedError: "vm memory should be bigger or equal to at least 2Gi",
+			SetupSKUs: func(svc *Service) {
+				skus := []compute.ResourceSku{
+					{
+						Name: to.StringPtr("Standard_D2v3"),
+						Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+						Locations: &[]string{
+							"test-location",
+						},
+						LocationInfo: &[]compute.ResourceSkuLocationInfo{
+							{
+								Location: to.StringPtr("test-location"),
+								Zones:    &[]string{"1"},
+							},
+						},
+						Capabilities: &[]compute.ResourceSkuCapabilities{
+							{
+								Name:  to.StringPtr(resourceskus.VCPUs),
+								Value: to.StringPtr("2"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.MemoryGB),
+								Value: to.StringPtr("1"),
+							},
+						},
+					},
+				}
+				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				svc.ResourceSKUCache = resourceSkusCache
+
+			},
+		},
+		{
+			Name: "cannot create vm if does not support ephemeral os",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+				s.VMSpecs().Return([]azure.VMSpec{
+					{
+						Name:       "my-vm",
+						Role:       infrav1.ControlPlane,
+						NICNames:   []string{"my-nic", "second-nic"},
+						SSHKeyData: "ZmFrZXNzaGtleQo=",
+						Size:       "Standard_D2v3",
+						Zone:       "1",
+						Identity:   infrav1.VMIdentityNone,
+						OSDisk: infrav1.OSDisk{
+							OSType:     "Linux",
+							DiskSizeGB: 128,
+							ManagedDisk: infrav1.ManagedDisk{
+								StorageAccountType: "Premium_LRS",
+							},
+							DiffDiskSettings: &infrav1.DiffDiskSettings{
+								Option: string(compute.Local),
+							},
+						},
+						DataDisks: []infrav1.DataDisk{
+							{
+								NameSuffix: "mydisk",
+								DiskSizeGB: 64,
+								Lun:        to.Int32Ptr(0),
+							},
+						},
+						UserAssignedIdentities: nil,
+						SpotVMOptions:          nil,
+					},
+				})
+				s.SubscriptionID().AnyTimes().Return("123")
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				m.Get(context.TODO(), "my-rg", "my-vm").
+					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+			},
+			ExpectedError: "vm size Standard_D2v3 does not support ephemeral os. select a different vm size or disable ephemeral os",
+			SetupSKUs: func(svc *Service) {
+				skus := []compute.ResourceSku{
+					{
+						Name: to.StringPtr("Standard_D2v3"),
+						Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+						Locations: &[]string{
+							"test-location",
+						},
+						LocationInfo: &[]compute.ResourceSkuLocationInfo{
+							{
+								Location: to.StringPtr("test-location"),
+								Zones:    &[]string{"1"},
+							},
+						},
+						Capabilities: &[]compute.ResourceSkuCapabilities{
+							{
+								Name:  to.StringPtr(resourceskus.EphemeralOSDisk),
+								Value: to.StringPtr("False"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.VCPUs),
+								Value: to.StringPtr("2"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.MemoryGB),
+								Value: to.StringPtr("4"),
+							},
+						},
+					},
+				}
+				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				svc.ResourceSKUCache = resourceSkusCache
+
+			},
+		},
+		{
+			Name: "can create a vm with EphemeralOSDisk",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+				s.VMSpecs().Return([]azure.VMSpec{
+					{
+						Name:       "my-vm",
+						Role:       infrav1.ControlPlane,
+						NICNames:   []string{"my-nic", "second-nic"},
+						SSHKeyData: "ZmFrZXNzaGtleQo=",
+						Size:       "Standard_D2v3",
+						Zone:       "1",
+						Identity:   infrav1.VMIdentityNone,
+						OSDisk: infrav1.OSDisk{
+							OSType:     "Linux",
+							DiskSizeGB: 128,
+							ManagedDisk: infrav1.ManagedDisk{
+								StorageAccountType: "Premium_LRS",
+							},
+							DiffDiskSettings: &infrav1.DiffDiskSettings{
+								Option: string(compute.Local),
+							},
+						},
+						DataDisks: []infrav1.DataDisk{
+							{
+								NameSuffix: "mydisk",
+								DiskSizeGB: 64,
+								Lun:        to.Int32Ptr(0),
+							},
+						},
+						UserAssignedIdentities: nil,
+						SpotVMOptions:          nil,
+					},
+				})
+				s.SubscriptionID().AnyTimes().Return("123")
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.AdditionalTags()
+				s.Location().Return("test-location")
+				s.ClusterName().Return("my-cluster")
+				m.Get(context.TODO(), "my-rg", "my-vm").
+					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+				s.GetVMImage().Return(&infrav1.Image{
+					Marketplace: &infrav1.AzureMarketplaceImage{
+						Publisher: "fake-publisher",
+						Offer:     "my-offer",
+						SKU:       "sku-id",
+						Version:   "1.0",
+					},
+				}, nil)
+				s.GetBootstrapData(context.TODO()).Return("fake-bootstrap-data", nil)
+				m.CreateOrUpdate(context.TODO(), "my-rg", "my-vm", gomockinternal.DiffEq(compute.VirtualMachine{
+					VirtualMachineProperties: &compute.VirtualMachineProperties{
+						HardwareProfile: &compute.HardwareProfile{VMSize: "Standard_D2v3"},
+						StorageProfile: &compute.StorageProfile{
+							ImageReference: &compute.ImageReference{
+								Publisher: to.StringPtr("fake-publisher"),
+								Offer:     to.StringPtr("my-offer"),
+								Sku:       to.StringPtr("sku-id"),
+								Version:   to.StringPtr("1.0"),
+							},
+							OsDisk: &compute.OSDisk{
+								OsType:       "Linux",
+								Name:         to.StringPtr("my-vm_OSDisk"),
+								CreateOption: "FromImage",
+								DiskSizeGB:   to.Int32Ptr(128),
+								ManagedDisk: &compute.ManagedDiskParameters{
+									StorageAccountType: "Premium_LRS",
+								},
+								DiffDiskSettings: &compute.DiffDiskSettings{
+									Option: compute.Local,
+								},
+							},
+							DataDisks: &[]compute.DataDisk{
+								{
+									Lun:          to.Int32Ptr(0),
+									Name:         to.StringPtr("my-vm_mydisk"),
+									CreateOption: "Empty",
+									DiskSizeGB:   to.Int32Ptr(64),
+								},
+							},
+						},
+						OsProfile: &compute.OSProfile{
+							ComputerName:  to.StringPtr("my-vm"),
+							AdminUsername: to.StringPtr("capi"),
+							CustomData:    to.StringPtr("fake-bootstrap-data"),
+							LinuxConfiguration: &compute.LinuxConfiguration{
+								DisablePasswordAuthentication: to.BoolPtr(true),
+								SSH: &compute.SSHConfiguration{
+									PublicKeys: &[]compute.SSHPublicKey{
+										{
+											Path:    to.StringPtr("/home/capi/.ssh/authorized_keys"),
+											KeyData: to.StringPtr("fakesshkey\n"),
+										},
+									},
+								},
+							},
+						},
+						NetworkProfile: &compute.NetworkProfile{
+							NetworkInterfaces: &[]compute.NetworkInterfaceReference{
+								{
+									NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{Primary: to.BoolPtr(true)},
+									ID:                                  to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/my-nic"),
+								},
+								{
+									NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{Primary: to.BoolPtr(false)},
+									ID:                                  to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/second-nic"),
+								},
+							},
+						},
+					},
+					Resources: nil,
+					Identity:  nil,
+					Zones:     &[]string{"1"},
+					ID:        nil,
+					Name:      nil,
+					Type:      nil,
+					Location:  to.StringPtr("test-location"),
+					Tags: map[string]*string{
+						"Name": to.StringPtr("my-vm"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": to.StringPtr("owned"),
+						"sigs.k8s.io_cluster-api-provider-azure_role":               to.StringPtr("control-plane"),
+					},
+				}))
+			},
+			ExpectedError: "",
+			SetupSKUs: func(svc *Service) {
+				skus := []compute.ResourceSku{
+					{
+						Name: to.StringPtr("Standard_D2v3"),
+						Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+						Locations: &[]string{
+							"test-location",
+						},
+						LocationInfo: &[]compute.ResourceSkuLocationInfo{
+							{
+								Location: to.StringPtr("test-location"),
+								Zones:    &[]string{"1"},
+							},
+						},
+						Capabilities: &[]compute.ResourceSkuCapabilities{
+							{
+								Name:  to.StringPtr(resourceskus.EphemeralOSDisk),
+								Value: to.StringPtr("True"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.VCPUs),
+								Value: to.StringPtr("2"),
+							},
+							{
+								Name:  to.StringPtr(resourceskus.MemoryGB),
+								Value: to.StringPtr("4"),
+							},
+						},
+					},
+				}
+				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				svc.ResourceSKUCache = resourceSkusCache
+
+			},
 		},
 	}
 
 	for _, tc := range testcases {
 		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.Name, func(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 			mockCtrl := gomock.NewController(t)
@@ -584,19 +1107,22 @@ func TestReconcileVM(t *testing.T) {
 			interfaceMock := mock_networkinterfaces.NewMockClient(mockCtrl)
 			publicIPMock := mock_publicips.NewMockClient(mockCtrl)
 
-			tc.expect(g, scopeMock.EXPECT(), clientMock.EXPECT(), interfaceMock.EXPECT(), publicIPMock.EXPECT())
+			tc.Expect(g, scopeMock.EXPECT(), clientMock.EXPECT(), interfaceMock.EXPECT(), publicIPMock.EXPECT())
 
 			s := &Service{
 				Scope:            scopeMock,
 				Client:           clientMock,
 				InterfacesClient: interfaceMock,
 				PublicIPsClient:  publicIPMock,
+				ResourceSKUCache: resourceskus.NewStaticCache(nil),
 			}
 
+			tc.SetupSKUs(s)
+
 			err := s.Reconcile(context.TODO())
-			if tc.expectedError != "" {
+			if tc.ExpectedError != "" {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err).To(MatchError(tc.expectedError))
+				g.Expect(err).To(MatchError(tc.ExpectedError))
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 			}

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -238,7 +238,7 @@ spec:
                         properties:
                           option:
                             description: Option enables ephemeral OS when set to "Local"
-                              See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks
+                              See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks
                               for full details
                             enum:
                             - Local

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -741,7 +741,7 @@ spec:
                         properties:
                           option:
                             description: Option enables ephemeral OS when set to "Local"
-                              See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks
+                              See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks
                               for full details
                             enum:
                             - Local

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -407,7 +407,7 @@ spec:
                     properties:
                       option:
                         description: Option enables ephemeral OS when set to "Local"
-                          See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks
+                          See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks
                           for full details
                         enum:
                         - Local

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -351,7 +351,7 @@ spec:
                             properties:
                               option:
                                 description: Option enables ephemeral OS when set
-                                  to "Local" See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks
+                                  to "Local" See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks
                                   for full details
                                 enum:
                                 - Local


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:
- updated reference to point to a valid doc in Azure for `api/v1alpha3/types.go - DiffDiskSettings `
- Added validation to check if both vCPUs and Memory are in the minimum required to create new VMs.
- Added more test to cover the `EphemeralOSDisk` not in the scope here but nice to have

_note_: I added the memory validation as well, but if you don't want let me know then I will remove. I think makes sense because, like CPU, we need some minimum memory as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/765

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cloud/vm/vmss: validate if vCPUs and Memory matched the minimum required
```