### PR TITLE
skip LB direct connect test temporarily

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/google/go-cmp v0.5.1
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
-	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -289,12 +289,6 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
-github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
-github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
-github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
-github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/test/e2e/azure_lb.go
+++ b/test/e2e/azure_lb.go
@@ -20,15 +20,11 @@ package e2e
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
 	"net"
-	"regexp"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -264,18 +260,19 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 	}
 	WaitForJobComplete(context.TODO(), elbJobInput, e2eConfig.GetIntervals(specName, "wait-job")...)
 
-	By("connecting directly to the external LB service")
-	url := fmt.Sprintf("http://%s", elbIP)
-	resp, err := retryablehttp.Get(url)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
-	Expect(err).NotTo(HaveOccurred())
-	body, err := ioutil.ReadAll(resp.Body)
-	Expect(err).NotTo(HaveOccurred())
-	matched, err := regexp.MatchString("(Welcome to nginx)", string(body))
-	Expect(err).NotTo(HaveOccurred())
-	Expect(matched).To(BeTrue())
+	By("SKIPPED: connecting directly to the external LB service")
+	// Temporarily disabled while we investigate some frequent failures.
+	// url := fmt.Sprintf("http://%s", elbIP)
+	// resp, err := retryablehttp.Get(url)
+	// if resp != nil {
+	// 	defer resp.Body.Close()
+	// }
+	// Expect(err).NotTo(HaveOccurred())
+	// body, err := ioutil.ReadAll(resp.Body)
+	// Expect(err).NotTo(HaveOccurred())
+	// matched, err := regexp.MatchString("(Welcome to nginx)", string(body))
+	// Expect(err).NotTo(HaveOccurred())
+	// Expect(matched).To(BeTrue())
 
 	if input.SkipCleanup {
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:

The `connecting directly to the external LB service` test has begun failing too often and needs to be remedied. It's holding up a large queue of PRs, so we propose **temporarily** disabling this so it can be fixed offline without blocking CAPZ progress any longer.

**Which issue(s) this PR fixes**:

See #814

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
skip LB direct connect test temporarily
```