### PR TITLE
Remove AZURE_ENVIRONMENT from required tilt vars

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -18,7 +18,7 @@ settings = {
     "aks_kubernetes_version": "v1.17.7"
 }
 
-keys = ["AZURE_SUBSCRIPTION_ID_B64", "AZURE_TENANT_ID_B64", "AZURE_CLIENT_SECRET_B64", "AZURE_CLIENT_ID_B64", "AZURE_ENVIRONMENT"]
+keys = ["AZURE_SUBSCRIPTION_ID_B64", "AZURE_TENANT_ID_B64", "AZURE_CLIENT_SECRET_B64", "AZURE_CLIENT_ID_B64"]
 
 # global settings
 settings.update(read_json(

--- a/templates/flavors/README.md
+++ b/templates/flavors/README.md
@@ -25,7 +25,7 @@ run ```tilt up ${flavors}``` to spin up worker clusters in Azure represented by 
 Add your desired flavors to tilt_config.json:
 ```json
 {
-    "worker-flavors": ["default", "aks", "external-cloud-provider", "machinepool", "system-assigned-identity", "user-assigned-identity"]
+    "worker-flavors": ["default", "aks", "ephemeral", "external-cloud-provider", "machinepool", "system-assigned-identity", "user-assigned-identity"]
 }
 ```
 
@@ -38,7 +38,6 @@ Please note your tilt-settings.json must contain at minimum the following fields
         "AZURE_TENANT_ID_B64": "******",
         "AZURE_CLIENT_SECRET_B64": "******",
         "AZURE_CLIENT_ID_B64": "******",
-        "AZURE_ENVIRONMENT": "AzurePublicCloud"
     }
 }
 ```
@@ -58,7 +57,7 @@ If you wish to override the default variables for flavor workers, you can specif
         "AZURE_TENANT_ID_B64": "****",
         "AZURE_CLIENT_SECRET_B64": "****",
         "AZURE_CLIENT_ID_B64": "****",
-        "AZURE_ENVIRONMENT": "AzurePublicCloud"
+        "AZURE_ENVIRONMENT": "AzureChinaCloud"
     },
     "worker-templates": {
         "flavors": {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: `AZURE_ENVIRONMENT` is no longer required from tilt vars as it is no longer part of templates since azure.json is generated and it is defaulted in infrastructure components.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove AZURE_ENVIRONMENT from required tilt vars
```