### PR TITLE
🐛  don't update network interface if it already exists

### DIFF
--- a/cloud/services/bastionhosts/bastionhosts.go
+++ b/cloud/services/bastionhosts/bastionhosts.go
@@ -110,7 +110,7 @@ func (s *Service) Delete(ctx context.Context) error {
 		err := s.Client.Delete(ctx, s.Scope.ResourceGroup(), bastionSpec.Name)
 		if err != nil && azure.ResourceNotFound(err) {
 			// already deleted
-			return nil
+			continue
 		}
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete Bastion Host %s in resource group %s", bastionSpec.Name, s.Scope.ResourceGroup())

--- a/cloud/services/bastionhosts/bastionhosts_test.go
+++ b/cloud/services/bastionhosts/bastionhosts_test.go
@@ -309,10 +309,17 @@ func TestDeleteBastionHost(t *testing.T) {
 						SubnetName:   "my-subnet",
 						PublicIPName: "my-publicip",
 					},
+					{
+						Name:         "my-bastionhost1",
+						VNetName:     "my-vnet",
+						SubnetName:   "my-subnet",
+						PublicIPName: "my-publicip",
+					},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				m.Delete(context.TODO(), "my-rg", "my-bastionhost").
 					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+				m.Delete(context.TODO(), "my-rg", "my-bastionhost1")
 			},
 		},
 		{

--- a/cloud/services/disks/disks.go
+++ b/cloud/services/disks/disks.go
@@ -36,7 +36,7 @@ func (s *Service) Delete(ctx context.Context) error {
 		err := s.Client.Delete(ctx, s.Scope.ResourceGroup(), diskSpec.Name)
 		if err != nil && azure.ResourceNotFound(err) {
 			// already deleted
-			return nil
+			continue
 		}
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete disk %s in resource group %s", diskSpec.Name, s.Scope.ResourceGroup())

--- a/cloud/services/disks/disks_test.go
+++ b/cloud/services/disks/disks_test.go
@@ -64,9 +64,13 @@ func TestDeleteDisk(t *testing.T) {
 					{
 						Name: "my-disk-1",
 					},
+					{
+						Name: "my-disk-2",
+					},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				m.Delete(context.TODO(), "my-rg", "my-disk-1").Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not Found"))
+				m.Delete(context.TODO(), "my-rg", "my-disk-2").Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not Found"))
 			},
 		},
 		{
@@ -77,6 +81,9 @@ func TestDeleteDisk(t *testing.T) {
 				s.DiskSpecs().Return([]azure.DiskSpec{
 					{
 						Name: "my-disk-1",
+					},
+					{
+						Name: "my-disk-2",
 					},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")

--- a/cloud/services/networkinterfaces/networkinterfaces.go
+++ b/cloud/services/networkinterfaces/networkinterfaces.go
@@ -18,6 +18,7 @@ package networkinterfaces
 
 import (
 	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"

--- a/cloud/services/networkinterfaces/networkinterfaces_test.go
+++ b/cloud/services/networkinterfaces/networkinterfaces_test.go
@@ -44,6 +44,36 @@ func TestReconcileNetworkInterface(t *testing.T) {
 		expect        func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder)
 	}{
 		{
+			name:          "network interface already exists",
+			expectedError: "",
+			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
+				s.NICSpecs().Return([]azure.NICSpec{
+					{
+						Name:              "nic-1",
+						MachineName:       "azure-test1",
+						SubnetName:        "my-subnet",
+						VNetName:          "my-vnet",
+						VNetResourceGroup: "my-rg",
+						VMSize:            "Standard_D2v2",
+					},
+					{
+						Name:              "nic-2",
+						MachineName:       "azure-test1",
+						SubnetName:        "my-subnet",
+						VNetName:          "my-vnet",
+						VNetResourceGroup: "my-rg",
+						VMSize:            "Standard_D2v2",
+					},
+				})
+				s.SubscriptionID().AnyTimes().Return("123")
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				s.Location().AnyTimes().Return("fake-location")
+				gomock.InOrder(
+					m.Get(context.TODO(), "my-rg", "nic-1"),
+					m.Get(context.TODO(), "my-rg", "nic-2"))
+			},
+		},
+		{
 			name:          "node network interface create fails",
 			expectedError: "failed to create network interface my-net-interface in resource group my-rg: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_networkinterfaces.MockNICScopeMockRecorder, m *mock_networkinterfaces.MockClientMockRecorder) {
@@ -63,6 +93,8 @@ func TestReconcileNetworkInterface(t *testing.T) {
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				gomock.InOrder(
+					m.Get(context.TODO(), "my-rg", "my-net-interface").
+						Return(network.Interface{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found")),
 					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomock.AssignableToTypeOf(network.Interface{})).
 						Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error")))
 			},
@@ -90,6 +122,8 @@ func TestReconcileNetworkInterface(t *testing.T) {
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				m.Get(context.TODO(), "my-rg", "my-net-interface").
+					Return(network.Interface{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
@@ -131,6 +165,8 @@ func TestReconcileNetworkInterface(t *testing.T) {
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(3)).AnyTimes().Return(klogr.New())
 				gomock.InOrder(
+					m.Get(context.TODO(), "my-rg", "my-net-interface").
+						Return(network.Interface{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found")),
 					m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
 						Location: to.StringPtr("fake-location"),
 						InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
@@ -173,6 +209,8 @@ func TestReconcileNetworkInterface(t *testing.T) {
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(3)).AnyTimes().Return(klogr.New())
+				m.Get(context.TODO(), "my-rg", "my-net-interface").
+					Return(network.Interface{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
@@ -214,6 +252,8 @@ func TestReconcileNetworkInterface(t *testing.T) {
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(3)).AnyTimes().Return(klogr.New())
+				m.Get(context.TODO(), "my-rg", "my-public-net-interface").
+					Return(network.Interface{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.CreateOrUpdate(context.TODO(), "my-rg", "my-public-net-interface", gomock.AssignableToTypeOf(network.Interface{}))
 			},
 		},
@@ -237,6 +277,8 @@ func TestReconcileNetworkInterface(t *testing.T) {
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				m.Get(context.TODO(), "my-rg", "my-net-interface").
+					Return(network.Interface{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
@@ -277,6 +319,8 @@ func TestReconcileNetworkInterface(t *testing.T) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.Location().AnyTimes().Return("fake-location")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				m.Get(context.TODO(), "my-rg", "my-net-interface").
+					Return(network.Interface{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.CreateOrUpdate(context.TODO(), "my-rg", "my-net-interface", gomockinternal.DiffEq(network.Interface{
 					Location: to.StringPtr("fake-location"),
 					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
@@ -301,7 +345,7 @@ func TestReconcileNetworkInterface(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			//t.Parallel()
+			t.Parallel()
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 			scopeMock := mock_networkinterfaces.NewMockNICScope(mockCtrl)

--- a/cloud/services/publicips/publicips.go
+++ b/cloud/services/publicips/publicips.go
@@ -66,7 +66,7 @@ func (s *Service) Delete(ctx context.Context) error {
 		err := s.Client.Delete(ctx, s.Scope.ResourceGroup(), ip.Name)
 		if err != nil && azure.ResourceNotFound(err) {
 			// already deleted
-			return nil
+			continue
 		}
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete public IP %s in resource group %s", ip.Name, s.Scope.ResourceGroup())

--- a/cloud/services/publicips/publicips_test.go
+++ b/cloud/services/publicips/publicips_test.go
@@ -150,10 +150,14 @@ func TestDeletePublicIP(t *testing.T) {
 					{
 						Name: "my-publicip",
 					},
+					{
+						Name: "my-publicip-2",
+					},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				m.Delete(context.TODO(), "my-rg", "my-publicip").
 					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+				m.Delete(context.TODO(), "my-rg", "my-publicip-2")
 			},
 		},
 		{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: This fixes a regression introduced in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/827. We should not reconcile network interfaces that already exist as we risk overwriting changes made by Cloud Provider to update the backend pools.

NOTE: an alternative would be to first get the existing backend pools, append the missing ones, and update but we then risk entering a race with cloud provider if it is updating the pools at the same time (and unfortunately the [update](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/vendor/k8s.io/legacy-cloud-providers/azure/azure_backoff.go#L258) doesn't have an etag).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't update network interface if it already exists
```