### PR TITLE
🌱 [e2e] silence output from curl commands

### DIFF
--- a/test/e2e/kubernetes/networkpolicy/networkpolicy.go
+++ b/test/e2e/kubernetes/networkpolicy/networkpolicy.go
@@ -81,7 +81,7 @@ func EnsureOutboundInternetAccess(clientset *kubernetes.Clientset, config *restc
 func EnsureConnectivityResultBetweenPods(clientset *kubernetes.Clientset, config *restclient.Config, fromPods []v1.Pod, toPods []v1.Pod, shouldHaveConnection bool) {
 	for _, fromPod := range fromPods {
 		for _, toPod := range toPods {
-			command := []string{"curl", toPod.Status.PodIP}
+			command := []string{"curl", "-S", "-s", "-o", "/dev/null", toPod.Status.PodIP}
 			err := e2e_pod.Exec(clientset, config, fromPod, command)
 			if shouldHaveConnection {
 				Expect(err).NotTo(HaveOccurred())
@@ -93,7 +93,7 @@ func EnsureConnectivityResultBetweenPods(clientset *kubernetes.Clientset, config
 }
 
 func CheckOutboundConnection(clientset *kubernetes.Clientset, config *restclient.Config, pod v1.Pod) error {
-	command := []string{"curl", "www.bing.com"}
+	command := []string{"curl", "-S", "-s", "-o", "/dev/null", "www.bing.com"}
 	return e2e_pod.Exec(clientset, config, pod, command)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the flags `-S -s -o /dev/null` to `curl` to [silence output](https://catonmat.net/cookbooks/curl/make-curl-silent) unless there is an error. 

The output of the network policy e2e test spec includes several dumps of the raw HTTP response body from bing.com and several default nginx web pages. This makes it hard to find a failure or other useful output in the e2e logs.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Before:

```
[1mSTEP[0m: Creating frontendProd, backend and network-policy pod deployments
[1mSTEP[0m: Ensure there is a running frontend-prod pod
[1mSTEP[0m: waiting for deployment production/frontend-prod-97553 to be available
[1mSTEP[0m: Ensure there is a running frontend-dev pod
[1mSTEP[0m: waiting for deployment development/frontend-dev-197553 to be available
[1mSTEP[0m: Ensure there is a running backend pod
[1mSTEP[0m: waiting for deployment development/backend-297553 to be available
[1mSTEP[0m: Ensure there is a running network-policy pod
[1mSTEP[0m: waiting for deployment development/network-policy-397553 to be available
[1mSTEP[0m: Ensuring we have outbound internet access from the frontend-prod pods
<!doctype html><html lang="en" dir="ltr"><head><meta name="theme-color" content="#4F4F4F" /><meta name="description" content="Bing helps you turn information into action, making it faster and easier to go from searching to doing." /><meta http-equiv="X-UA-Compatible" content="IE=edge" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta property="fb:app_id" content="570810223073062" /><meta property="og:type" content="website" /><meta property="og:title" content="Pancake Rocks" /><meta property="og:image" content="https://www.bing.com/th?id=OHR.PancakeRocks_EN-US1220361824_tmb.jpg&amp;rf=" /><meta property="og:image:width" content="1366" /><meta property="og:image:height" content="768" /><meta property="og:url" content="https://www.bing.com/?form=HPFBBK&amp;ssd=20200825_0700&amp;mkt=en-US" /><meta property="og:site_name" content="Bing" /><meta property="og:description" content="This portion of New Zealand's South Island coast f" /><title>Bing</title><link rel="shortcut icon" href="/sa/simg/bing_p_rr_teal_min.ico" /><link rel="preload" href="/th?id=OHR.PancakeRocks_EN-US1220361824_1920x1080.jpg&amp;rf=LaDigue_1920x1080.jpg" as="image" id="preloadBg" /><link rel="preload" href="/rp/tlifxqsNyCzxIJnRwtQKuZToQQw.js" as="script" /><style type="text/css">@media(max-width:1177px){#id_n{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100px;display:inline-block}}.rwds_svg{vertical-align:top;display:inline-block}.rwds_svg.mobile{float:left}.rwds_svg.serp{margin:8px 0 0 8px}.rwds_svg.serp.mobile{margin:8px 4px 0 8px}.rwds_svg.hp{margin:5px 4px 0 8px}.rwds_svg.hp.mobile{margin:5px 4px 0 10px}.rhlined,.rhfill{vertical-align:top;width:32px;height:32px}#rh_meter{vertical-align:top;width:40px;height:40px;margin-left:-36px;margin-top:-4px}.rh_reedm .rhlined,.rhfill,.rh_reedm .meter{display:none}.rhlined,.rh_reedm .rhfill,#rh_meter{display:inline-block}.rhlined.hp .meter,.rhfill.hp .meter{stroke:rgba(255,255,255,.4)}.noBg .rhlined.hp .meter,.noBg .rhfill.hp .meter,.rhlined.serp .meter,.rhfill.serp .meter{stroke:rgba(177,177,177,.4)}.rhlined.hp .medal,.rhfill.hp .medal{fill:white}.noBg .rhlined.hp .medal,.rhlined.serp .medal{fill:#919191}.noBg .rh_reedm .rhfill.hp .medal,.rh_reedm .rhfill.serp .medal{fill:#00809d}#rh_animcrcl{fill:none;stroke:tran
... you get the idea
```

After:

```
 [1mSTEP[0m: Creating frontendProd, backend and network-policy pod deployments
[1mSTEP[0m: Ensure there is a running frontend-prod pod
[1mSTEP[0m: waiting for deployment production/frontend-prod-56518 to be available
[1mSTEP[0m: Ensure there is a running frontend-dev pod
[1mSTEP[0m: waiting for deployment development/frontend-dev-156518 to be available
[1mSTEP[0m: Ensure there is a running backend pod
[1mSTEP[0m: waiting for deployment development/backend-256518 to be available
[1mSTEP[0m: Ensure there is a running network-policy pod
[1mSTEP[0m: waiting for deployment development/network-policy-356518 to be available
[1mSTEP[0m: Ensuring we have outbound internet access from the frontend-prod pods
[1mSTEP[0m: Ensuring we have outbound internet access from the frontend-dev pods
[1mSTEP[0m: Ensuring we have outbound internet access from the backend pods
[1mSTEP[0m: Ensuring we have outbound internet access from the network-policy pods
[1mSTEP[0m: Ensuring we have connectivity from network-policy pods to frontend-prod pods
[1mSTEP[0m: Ensuring we have connectivity from network-policy pods to backend pods
[1mSTEP[0m: Applying a network policy to deny ingress access to app: webapp, role: backend pods in development namespace
[1mSTEP[0m: Ensuring we no longer have ingress access from the network-policy pods to backend pods
curl: (7) Failed to connect to 192.168.250.5 port 80: Connection timed out
[1mSTEP[0m: Cleaning up after ourselves
[1mSTEP[0m: Applying a network policy to deny egress access in development namespace
[1mSTEP[0m: Ensuring we no longer have egress access from the network-policy pods to backend pods
curl: (7) Failed to connect to 192.168.250.5 port 80: Connection timed out
curl: (7) Failed to connect to 192.168.250.5 port 80: Connection timed out
[1mSTEP[0m: Cleaning up after ourselves
[1mSTEP[0m: Applying a network policy to allow egress access to app: webapp, role: frontend pods in any namespace from pods with app: webapp, role: backend labels in development namespace
[1mSTEP[0m: Ensuring we have egress access from pods with matching labels
[1mSTEP[0m: Ensuring we don't have ingress access from pods without matching labels
curl: (7) Failed to connect to 192.168.250.6 port 80: Connection timed out
[1mSTEP[0m: Cleaning up after ourselves
[1mSTEP[0m: Applying a network policy to allow egress access to app: webapp, role: frontend pods from pods with app: webapp, role: backend labels in same development namespace
[1mSTEP[0m: Ensuring we have egress access from pods with matching labels
[1mSTEP[0m: Ensuring we don't have ingress access from pods without matching labels
curl: (7) Failed to connect to 192.168.250.3 port 80: Connection timed out
curl: (7) Failed to connect to 192.168.250.6 port 80: Connection timed out
[1mSTEP[0m: Cleaning up after ourselves
[1mSTEP[0m: Applying a network policy to only allow ingress access to app: webapp, role: backend pods in development namespace from pods in any namespace with the same labels
[1mSTEP[0m: Ensuring we have ingress access from pods with matching labels
[1mSTEP[0m: Ensuring we don't have ingress access from pods without matching labels
curl: (7) Failed to connect to 192.168.250.5 port 80: Connection timed out
[1mSTEP[0m: Cleaning up after ourselves
[1mSTEP[0m: Applying a network policy to only allow ingress access to app: webapp role:backends in development namespace from pods with label app:webapp, role: frontendProd within namespace with label purpose: development
[1mSTEP[0m: Ensuring we don't have ingress access from role:frontend pods in production namespace
curl: (7) Failed to connect to 192.168.250.5 port 80: Connection timed out
[1mSTEP[0m: Ensuring we have ingress access from role:frontend pods in development namespace
[1mSTEP[0m: Dumping all the Cluster API resources in the "create-workload-cluster-weedos" namespace
[1mSTEP[0m: Deleting cluster create-workload-cluster-weedos/capz-e2e-grt78a
[1mSTEP[0m: deleting cluster capz-e2e-grt78a
INFO: Waiting for the Cluster create-workload-cluster-weedos/capz-e2e-grt78a to be deleted
[1mSTEP[0m: waiting for cluster capz-e2e-grt78a to be deleted
[1mSTEP[0m: Deleting namespace used for hosting the "create-workload-cluster" test spec
INFO: Deleting namespace create-workload-cluster-weedos
[1mSTEP[0m: Redacting sensitive information from logs
```

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
🌱 [e2e] silence output from curl commands
```