### PR TITLE
🌱  remove extra spaces in MHC prow cluster template

### DIFF
--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -373,7 +373,7 @@ metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
-  clusterName: ${ CLUSTER_NAME }
+  clusterName: ${CLUSTER_NAME}
   maxUnhealthy: 100%
   selector:
     matchLabels:

--- a/templates/test/cluster-template-prow.yaml
+++ b/templates/test/cluster-template-prow.yaml
@@ -208,7 +208,7 @@ metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
-  clusterName: ${ CLUSTER_NAME }
+  clusterName: ${CLUSTER_NAME}
   maxUnhealthy: 100%
   selector:
     matchLabels:

--- a/templates/test/prow/mhc.yaml
+++ b/templates/test/prow/mhc.yaml
@@ -4,7 +4,7 @@ kind: MachineHealthCheck
 metadata:
   name: "${CLUSTER_NAME}-mhc-0"
 spec:
-  clusterName: "${ CLUSTER_NAME }"
+  clusterName: "${CLUSTER_NAME}"
   maxUnhealthy: 100%
   selector:
     matchLabels:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: Fixes conformance tests https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#periodic-conformance-v1alpha3

```
/home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/hack/tools/bin/envsubst-drone < /home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure/templates/test/cluster-template-prow.yaml | kubectl apply -f -
2020/09/01 11:11:57 Error while envsubst: bad substitution
cluster.cluster.x-k8s.io/capz-8mrp9o created
azurecluster.infrastructure.cluster.x-k8s.io/capz-8mrp9o created
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/capz-8mrp9o-control-plane created
azuremachinetemplate.infrastructure.cluster.x-k8s.io/capz-8mrp9o-control-plane created
machinedeployment.cluster.x-k8s.io/capz-8mrp9o-md-0 created
azuremachinetemplate.infrastructure.cluster.x-k8s.io/capz-8mrp9o-md-0 created
kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/capz-8mrp9o-md-0 created
The MachineHealthCheck "capz-8mrp9o-mhc-0" is invalid: 
* spec.clusterName: Invalid value: "": spec.clusterName in body should be at least 1 chars long
* spec.unhealthyConditions: Invalid value: "null": spec.unhealthyConditions in body must be of type array: "null"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```