### PR TITLE
🔧   Use k8s_resource to move CRDs out of uncategorized in Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -174,6 +174,21 @@ def capz():
         deps = ["api", "cloud", "config", "controllers", "exp", "feature", "pkg", "go.mod", "go.sum", "main.go"]
     )
 
+    k8s_resource('capz-controller-manager:deployment:capz-system', objects=[
+        'azureclusters.infrastructure.cluster.x-k8s.io:customresourcedefinition',
+        'azuremachinepools.exp.infrastructure.cluster.x-k8s.io:customresourcedefinition',
+        'azuremachines.infrastructure.cluster.x-k8s.io:customresourcedefinition',
+        'azuremachinetemplates.infrastructure.cluster.x-k8s.io:customresourcedefinition',
+        'azuremanagedclusters.exp.infrastructure.cluster.x-k8s.io:customresourcedefinition',
+        'azuremanagedcontrolplanes.exp.infrastructure.cluster.x-k8s.io:customresourcedefinition',
+        'azuremanagedmachinepools.exp.infrastructure.cluster.x-k8s.io:customresourcedefinition',
+    ])
+
+    k8s_resource('capz-controller-manager:deployment:capi-webhook-system', objects=[
+        'capz-validating-webhook-configuration:validatingwebhookconfiguration',
+        'capz-mutating-webhook-configuration:mutatingwebhookconfiguration',
+    ])
+
     dockerfile_contents = "\n".join([
         tilt_helper_dockerfile_header,
         tilt_dockerfile_header,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**: Based on the discussion in https://github.com/tilt-dev/tilt/issues/2989 and https://github.com/tilt-dev/tilt/issues/3096, looks like this is what we want to make sure that the CAPZ CRDs are part of the capz-controller resources and not in "uncategorized".

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use k8s_resource to move CRDs out of uncategorized in Tilt
```