### PR TITLE
🌱 AzureMachinePool/AzureManagedControlPlane: generate ssh key when is not set

### DIFF
--- a/api/v1alpha3/azuremachine_default.go
+++ b/api/v1alpha3/azuremachine_default.go
@@ -17,27 +17,22 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"encoding/base64"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
+
+	utilSSH "sigs.k8s.io/cluster-api-provider-azure/util/ssh"
 )
 
 // SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureMachine
 func (m *AzureMachine) SetDefaultSSHPublicKey() error {
 	sshKeyData := m.Spec.SSHPublicKey
 	if sshKeyData == "" {
-		privateKey, perr := rsa.GenerateKey(rand.Reader, 2048)
-		if perr != nil {
-			return errors.Wrap(perr, "Failed to generate private key")
+		_, publicRsaKey, err := utilSSH.GenerateSSHKey()
+		if err != nil {
+			return err
 		}
 
-		publicRsaKey, perr := ssh.NewPublicKey(&privateKey.PublicKey)
-		if perr != nil {
-			return errors.Wrap(perr, "Failed to generate public key")
-		}
 		m.Spec.SSHPublicKey = base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey))
 	}
 

--- a/docs/book/src/topics/ephemeral-os.md
+++ b/docs/book/src/topics/ephemeral-os.md
@@ -7,7 +7,7 @@ disk SKU limits. Instead they will always be capable of saturating the
 VM level limits. This can significantly improve performance on the OS
 disk. Ephemeral storage used for the OS will not persist between
 maintenance events and VM redeployments. This is ideal for stateless
-base OS disks, where any stateful data is kept elsewhere. 
+base OS disks, where any stateful data is kept elsewhere.
 
 There are a few kinds of local storage devices available on Azure VMs.
 Each VM size will have a different combination. For example, some sizes
@@ -56,6 +56,6 @@ spec:
         managedDisk:
           storageAccountType: Standard_LRS
         osType: Linux
-      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64}
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       vmSize: ${AZURE_NODE_MACHINE_TYPE}
 ````

--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -33,7 +33,7 @@ export AZURE_LOCATION="southcentralus"
 export AZURE_RESOURCE_GROUP="${CLUSTER_NAME}"
 # set AZURE_SUBSCRIPTION_ID to the GUID of your subscription
 # this example uses an sdk authentication file and parses the subscriptionId with jq
-# this file may be created using 
+# this file may be created using
 #
 # `az ad sp create-for-rbac --sdk-auth [roles] > sp.json`
 #
@@ -92,7 +92,7 @@ spec:
     name: agentpool0
   location: southcentralus
   resourceGroup: foo-bar
-  sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64}
+  sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   subscriptionID: fae7cc14-bfba-4471-9435-f945b42a16dd # fake uuid
   version: v1.17.4
   networkPolicy: azure # or calico

--- a/exp/api/v1alpha3/azuremachinepool_default.go
+++ b/exp/api/v1alpha3/azuremachinepool_default.go
@@ -17,27 +17,22 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"encoding/base64"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
+
+	utilSSH "sigs.k8s.io/cluster-api-provider-azure/util/ssh"
 )
 
 // SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureMachinePool
 func (amp *AzureMachinePool) SetDefaultSSHPublicKey() error {
 	sshKeyData := amp.Spec.Template.SSHPublicKey
 	if sshKeyData == "" {
-		privateKey, perr := rsa.GenerateKey(rand.Reader, 2048)
-		if perr != nil {
-			return errors.Wrap(perr, "Failed to generate private key")
+		_, publicRsaKey, err := utilSSH.GenerateSSHKey()
+		if err != nil {
+			return err
 		}
 
-		publicRsaKey, perr := ssh.NewPublicKey(&privateKey.PublicKey)
-		if perr != nil {
-			return errors.Wrap(perr, "Failed to generate public key")
-		}
 		amp.Spec.Template.SSHPublicKey = base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey))
 	}
 

--- a/exp/api/v1alpha3/azuremachinepool_default.go
+++ b/exp/api/v1alpha3/azuremachinepool_default.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
+)
+
+// SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureMachinePool
+func (amp *AzureMachinePool) SetDefaultSSHPublicKey() error {
+	sshKeyData := amp.Spec.Template.SSHPublicKey
+	if sshKeyData == "" {
+		privateKey, perr := rsa.GenerateKey(rand.Reader, 2048)
+		if perr != nil {
+			return errors.Wrap(perr, "Failed to generate private key")
+		}
+
+		publicRsaKey, perr := ssh.NewPublicKey(&privateKey.PublicKey)
+		if perr != nil {
+			return errors.Wrap(perr, "Failed to generate public key")
+		}
+		amp.Spec.Template.SSHPublicKey = base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey))
+	}
+
+	return nil
+}

--- a/exp/api/v1alpha3/azuremachinepool_default_test.go
+++ b/exp/api/v1alpha3/azuremachinepool_default_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAzureMachinePool_SetDefaultSSHPublicKey(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		amp *AzureMachinePool
+	}
+
+	existingPublicKey := "testpublickey"
+	publicKeyExistTest := test{amp: createMachinePoolWithSSHPublicKey(t, existingPublicKey)}
+	publicKeyNotExistTest := test{amp: createMachinePoolWithSSHPublicKey(t, "")}
+
+	err := publicKeyExistTest.amp.SetDefaultSSHPublicKey()
+	g.Expect(err).To(BeNil())
+	g.Expect(publicKeyExistTest.amp.Spec.Template.SSHPublicKey).To(Equal(existingPublicKey))
+
+	err = publicKeyNotExistTest.amp.SetDefaultSSHPublicKey()
+	g.Expect(err).To(BeNil())
+	g.Expect(publicKeyNotExistTest.amp.Spec.Template.SSHPublicKey).NotTo(BeEmpty())
+}
+
+func createMachinePoolWithSSHPublicKey(t *testing.T, sshPublicKey string) *AzureMachinePool {
+	return hardcodedAzureMachinePoolWithSSHKey(sshPublicKey)
+}
+
+func hardcodedAzureMachinePoolWithSSHKey(sshPublicKey string) *AzureMachinePool {
+	return &AzureMachinePool{
+		Spec: AzureMachinePoolSpec{
+			Template: AzureMachineTemplate{
+				SSHPublicKey: sshPublicKey,
+			},
+		},
+	}
+}

--- a/exp/api/v1alpha3/azuremachinepool_webhook.go
+++ b/exp/api/v1alpha3/azuremachinepool_webhook.go
@@ -45,6 +45,11 @@ var _ webhook.Defaulter = &AzureMachinePool{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (amp *AzureMachinePool) Default() {
 	azuremachinepoollog.Info("default", "name", amp.Name)
+
+	err := amp.SetDefaultSSHPublicKey()
+	if err != nil {
+		azuremachinepoollog.Error(err, "SetDefaultSshPublicKey failed")
+	}
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-exp-cluster-x-k8s-io-x-k8s-io-v1alpha3-azuremachinepool,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=exp.cluster.x-k8s.io.x-k8s.io,resources=azuremachinepools,versions=v1alpha3,name=vazuremachinepool.kb.io,sideEffects=None
@@ -74,6 +79,7 @@ func (amp *AzureMachinePool) Validate() error {
 	validators := []func() error{
 		amp.ValidateImage,
 		amp.ValidateTerminateNotificationTimeout,
+		amp.ValidateSSHKey,
 	}
 
 	var errs []error
@@ -100,6 +106,7 @@ func (amp *AzureMachinePool) ValidateImage() error {
 			return agg
 		}
 	}
+
 	return nil
 }
 
@@ -114,6 +121,20 @@ func (amp *AzureMachinePool) ValidateTerminateNotificationTimeout() error {
 
 	if *amp.Spec.Template.TerminateNotificationTimeout > 15 {
 		return errors.New("Maximum timeout 15 is allowed for TerminateNotificationTimeout")
+	}
+
+	return nil
+}
+
+// ValidateSSHKey validates an SSHKey
+func (amp *AzureMachinePool) ValidateSSHKey() error {
+	if amp.Spec.Template.SSHPublicKey != "" {
+		sshKey := amp.Spec.Template.SSHPublicKey
+		if errs := infrav1.ValidateSSHKey(sshKey, field.NewPath("sshKey")); len(errs) > 0 {
+			agg := kerrors.NewAggregate(errs.ToAggregate().Errors())
+			azuremachinepoollog.Info("Invalid sshKey: %s", agg.Error())
+			return agg
+		}
 	}
 
 	return nil

--- a/exp/api/v1alpha3/azuremachinepool_webhook_test.go
+++ b/exp/api/v1alpha3/azuremachinepool_webhook_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+)
+
+var (
+	validSSHPublicKey = generateSSHPublicKey(true)
+)
+
+func TestAzureMachinePool_ValidateCreate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name    string
+		amp     *AzureMachinePool
+		wantErr bool
+	}{
+		{
+			name:    "azuremachinepool with marketplace image - full",
+			amp:     createMachinePoolWithtMarketPlaceImage(t, "PUB1234", "OFFER1234", "SKU1234", "1.0.0", to.IntPtr(10)),
+			wantErr: false,
+		},
+		{
+			name:    "azuremachinepool with marketplace image - missing publisher",
+			amp:     createMachinePoolWithtMarketPlaceImage(t, "", "OFFER1234", "SKU1234", "1.0.0", to.IntPtr(10)),
+			wantErr: true,
+		},
+		{
+			name:    "azuremachinepool with shared gallery image - full",
+			amp:     createMachinePoolWithSharedImage(t, "SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0", to.IntPtr(10)),
+			wantErr: false,
+		},
+		{
+			name:    "azuremachinepool with marketplace image - missing subscription",
+			amp:     createMachinePoolWithSharedImage(t, "", "RG123", "NAME123", "GALLERY1", "1.0.0", to.IntPtr(10)),
+			wantErr: true,
+		},
+		{
+			name:    "azuremachinepool with image by - with id",
+			amp:     createMachinePoolWithImageByID(t, "ID123", to.IntPtr(10)),
+			wantErr: false,
+		},
+		{
+			name:    "azuremachinepool with image by - without id",
+			amp:     createMachinePoolWithImageByID(t, "", to.IntPtr(10)),
+			wantErr: true,
+		},
+		{
+			name:    "azuremachinepool with valid SSHPublicKey",
+			amp:     createMachinePoolWithSSHPublicKey(t, validSSHPublicKey),
+			wantErr: false,
+		},
+		{
+			name:    "azuremachinepool with invalid SSHPublicKey",
+			amp:     createMachinePoolWithSSHPublicKey(t, "invalid ssh key"),
+			wantErr: true,
+		},
+		{
+			name:    "azuremachinepool with wrong terminate notification",
+			amp:     createMachinePoolWithSharedImage(t, "SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0", to.IntPtr(35)),
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.amp.ValidateCreate()
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestAzureMachinePool_ValidateUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name    string
+		oldAMP  *AzureMachinePool
+		amp     *AzureMachinePool
+		wantErr bool
+	}{
+		{
+			name:    "azuremachine with valid SSHPublicKey",
+			oldAMP:  createMachinePoolWithSSHPublicKey(t, ""),
+			amp:     createMachinePoolWithSSHPublicKey(t, validSSHPublicKey),
+			wantErr: false,
+		},
+		{
+			name:    "azuremachine with invalid SSHPublicKey",
+			oldAMP:  createMachinePoolWithSSHPublicKey(t, ""),
+			amp:     createMachinePoolWithSSHPublicKey(t, "invalid ssh key"),
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.amp.ValidateUpdate(tc.oldAMP)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestAzureMachine_Default(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		amp *AzureMachinePool
+	}
+
+	existingPublicKey := validSSHPublicKey
+	publicKeyExistTest := test{amp: createMachinePoolWithSSHPublicKey(t, existingPublicKey)}
+	publicKeyNotExistTest := test{amp: createMachinePoolWithSSHPublicKey(t, "")}
+
+	publicKeyExistTest.amp.Default()
+	g.Expect(publicKeyExistTest.amp.Spec.Template.SSHPublicKey).To(Equal(existingPublicKey))
+
+	publicKeyNotExistTest.amp.Default()
+	g.Expect(publicKeyNotExistTest.amp.Spec.Template.SSHPublicKey).NotTo((BeEmpty()))
+}
+
+func createMachinePoolWithtMarketPlaceImage(t *testing.T, publisher, offer, sku, version string, terminateNotificationTimeout *int) *AzureMachinePool {
+	image := &infrav1.Image{
+		Marketplace: &infrav1.AzureMarketplaceImage{
+			Publisher: publisher,
+			Offer:     offer,
+			SKU:       sku,
+			Version:   version,
+		},
+	}
+
+	return &AzureMachinePool{
+		Spec: AzureMachinePoolSpec{
+			Template: AzureMachineTemplate{
+				Image:                        image,
+				SSHPublicKey:                 validSSHPublicKey,
+				TerminateNotificationTimeout: terminateNotificationTimeout,
+			},
+		},
+	}
+}
+
+func createMachinePoolWithSharedImage(t *testing.T, subscriptionID, resourceGroup, name, gallery, version string, terminateNotificationTimeout *int) *AzureMachinePool {
+	image := &infrav1.Image{
+		SharedGallery: &infrav1.AzureSharedGalleryImage{
+			SubscriptionID: subscriptionID,
+			ResourceGroup:  resourceGroup,
+			Name:           name,
+			Gallery:        gallery,
+			Version:        version,
+		},
+	}
+
+	return &AzureMachinePool{
+		Spec: AzureMachinePoolSpec{
+			Template: AzureMachineTemplate{
+				Image:                        image,
+				SSHPublicKey:                 validSSHPublicKey,
+				TerminateNotificationTimeout: terminateNotificationTimeout,
+			},
+		},
+	}
+}
+
+func createMachinePoolWithImageByID(t *testing.T, imageID string, terminateNotificationTimeout *int) *AzureMachinePool {
+	image := &infrav1.Image{
+		ID: &imageID,
+	}
+
+	return &AzureMachinePool{
+		Spec: AzureMachinePoolSpec{
+			Template: AzureMachineTemplate{
+				Image:                        image,
+				SSHPublicKey:                 validSSHPublicKey,
+				TerminateNotificationTimeout: terminateNotificationTimeout,
+			},
+		},
+	}
+}
+
+func generateSSHPublicKey(b64Enconded bool) string {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	publicRsaKey, _ := ssh.NewPublicKey(&privateKey.PublicKey)
+	if b64Enconded {
+		return base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey))
+	}
+	return string(ssh.MarshalAuthorizedKey(publicRsaKey))
+}

--- a/exp/api/v1alpha3/azuremanagedcontrolplane_default.go
+++ b/exp/api/v1alpha3/azuremanagedcontrolplane_default.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
+)
+
+// SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureManagedControlPlane
+func (r *AzureManagedControlPlane) SetDefaultSSHPublicKey() error {
+	sshKeyData := r.Spec.SSHPublicKey
+	if sshKeyData == "" {
+		privateKey, perr := rsa.GenerateKey(rand.Reader, 2048)
+		if perr != nil {
+			return errors.Wrap(perr, "Failed to generate private key")
+		}
+
+		publicRsaKey, perr := ssh.NewPublicKey(&privateKey.PublicKey)
+		if perr != nil {
+			return errors.Wrap(perr, "Failed to generate public key")
+		}
+		r.Spec.SSHPublicKey = base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey))
+	}
+
+	return nil
+}

--- a/exp/api/v1alpha3/azuremanagedcontrolplane_default_test.go
+++ b/exp/api/v1alpha3/azuremanagedcontrolplane_default_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
+	g := NewWithT(t)
+
+	type test struct {
+		r *AzureManagedControlPlane
+	}
+
+	existingPublicKey := "testpublickey"
+	publicKeyExistTest := test{r: createAzureManagedControlPlaneWithSSHPublicKey(t, existingPublicKey)}
+	publicKeyNotExistTest := test{r: createAzureManagedControlPlaneWithSSHPublicKey(t, "")}
+
+	err := publicKeyExistTest.r.SetDefaultSSHPublicKey()
+	g.Expect(err).To(BeNil())
+	g.Expect(publicKeyExistTest.r.Spec.SSHPublicKey).To(Equal(existingPublicKey))
+
+	err = publicKeyNotExistTest.r.SetDefaultSSHPublicKey()
+	g.Expect(err).To(BeNil())
+	g.Expect(publicKeyNotExistTest.r.Spec.SSHPublicKey).NotTo(BeEmpty())
+}
+
+func createAzureManagedControlPlaneWithSSHPublicKey(t *testing.T, sshPublicKey string) *AzureManagedControlPlane {
+	return hardcodedAzureManagedControlPlaneWithSSHKey(sshPublicKey)
+}
+
+func hardcodedAzureManagedControlPlaneWithSSHKey(sshPublicKey string) *AzureManagedControlPlane {
+	return &AzureManagedControlPlane{
+		Spec: AzureManagedControlPlaneSpec{
+			SSHPublicKey: sshPublicKey,
+		},
+	}
+}

--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -27,7 +27,7 @@ spec:
     name: agentpool0
   location: ${AZURE_LOCATION}
   resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
-  sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64}
+  sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
   version: ${KUBERNETES_VERSION}
 ---

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -166,7 +166,7 @@ spec:
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Linux
-    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64}
+    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
     vmSize: ${AZURE_NODE_MACHINE_TYPE}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3

--- a/templates/flavors/aks/cluster-template.yaml
+++ b/templates/flavors/aks/cluster-template.yaml
@@ -33,7 +33,7 @@ spec:
   location: "${AZURE_LOCATION}"
   defaultPoolRef:
     name: "agentpool0"
-  sshPublicKey: "${AZURE_SSH_PUBLIC_KEY_B64}"
+  sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   version: "${KUBERNETES_VERSION}"
 ---
 # Due to the nature of managed Kubernetes and the control plane implementation,

--- a/templates/flavors/machinepool/machine-pool-deployment.yaml
+++ b/templates/flavors/machinepool/machine-pool-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       diskSizeGB: 30
       managedDisk:
         storageAccountType: "Premium_LRS"
-    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64}
+    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -258,7 +258,7 @@ spec:
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Linux
-    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64}
+    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
     vmSize: ${AZURE_NODE_MACHINE_TYPE}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3

--- a/templates/test/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/cluster-template-prow-machine-pool.yaml
@@ -169,7 +169,7 @@ spec:
       managedDisk:
         storageAccountType: Premium_LRS
       osType: Linux
-    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64}
+    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
     vmSize: ${AZURE_NODE_MACHINE_TYPE}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3

--- a/test/e2e/data/infrastructure-azure/cluster-template-kcp-adoption.yaml
+++ b/test/e2e/data/infrastructure-azure/cluster-template-kcp-adoption.yaml
@@ -29,7 +29,7 @@ kind: AzureCluster
 metadata:
   name: ${CLUSTER_NAME}
   labels:
-    initial: ''  
+    initial: ''
 spec:
   additionalTags:
     creationTimestamp: ${TIMESTAMP}
@@ -46,7 +46,7 @@ kind: AzureMachine
 metadata:
   name: ${CLUSTER_NAME}-control-plane-0
   labels:
-    initial: ''  
+    initial: ''
 spec:
   dataDisks:
   - diskSizeGB: 256
@@ -58,15 +58,15 @@ spec:
     managedDisk:
       storageAccountType: Premium_LRS
     osType: Linux
-  sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64}
+  sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   vmSize: Standard_D2s_v3
----      
+---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Machine
 metadata:
   name: ${CLUSTER_NAME}-control-plane-0
   labels:
-    initial: ''      
+    initial: ''
     cluster.x-k8s.io/control-plane: "true"
 spec:
   version: ${KUBERNETES_VERSION}
@@ -79,14 +79,14 @@ spec:
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: AzureMachine
-    name: ${CLUSTER_NAME}-control-plane-0  
+    name: ${CLUSTER_NAME}-control-plane-0
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: ${CLUSTER_NAME}-control-plane-0
   labels:
-    initial: ''    
+    initial: ''
 spec:
   useExperimentalRetryJoin: true
   initConfiguration:
@@ -144,7 +144,7 @@ spec:
       tableType: gpt
   mounts:
   - - LABEL=etcd_disk
-    - /var/lib/etcddisk    
+    - /var/lib/etcddisk
   files:
     - contentFrom:
         secret:
@@ -177,14 +177,14 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: AzureCluster
     name: ${CLUSTER_NAME}
----    
+---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: ${CLUSTER_NAME}-control-plane
   labels:
     cluster.x-k8s.io/cluster-name: "${ CLUSTER_NAME }"
-    kcp: ''  
+    kcp: ''
 spec:
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -279,7 +279,7 @@ spec:
         managedDisk:
           storageAccountType: Premium_LRS
         osType: Linux
-      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64}
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       vmSize: Standard_D2s_v3
 ---
 apiVersion: v1

--- a/util/ssh/ssh_test.go
+++ b/util/ssh/ssh_test.go
@@ -14,27 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha3
+package ssh
 
 import (
-	"encoding/base64"
+	"testing"
 
-	"golang.org/x/crypto/ssh"
-
-	utilSSH "sigs.k8s.io/cluster-api-provider-azure/util/ssh"
+	. "github.com/onsi/gomega"
 )
 
-// SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureManagedControlPlane
-func (r *AzureManagedControlPlane) SetDefaultSSHPublicKey() error {
-	sshKeyData := r.Spec.SSHPublicKey
-	if sshKeyData == "" {
-		_, publicRsaKey, err := utilSSH.GenerateSSHKey()
-		if err != nil {
-			return err
-		}
+func TestGenerateSSHKey(t *testing.T) {
+	g := NewWithT(t)
 
-		r.Spec.SSHPublicKey = base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey))
-	}
-
-	return nil
+	privateKey, publicKey, err := GenerateSSHKey()
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(privateKey).NotTo(BeNil())
+	g.Expect(publicKey).NotTo(BeNil())
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:
Generating ssh key for Azure Machine Pool and Azure Managed ControlPlane when is not defined

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/909

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AzureMachinePool/AzureManagedControlPlane: generate ssh key when is not set
```