### PR TITLE
💚 log elapsed e2e spec time and Ginkgo node number

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -42,9 +43,12 @@ var _ = Describe("Workload cluster creation", func() {
 		cancelWatches context.CancelFunc
 		cluster       *clusterv1.Cluster
 		clusterName   string
+		specTimes     = map[string]time.Time{}
 	)
 
 	BeforeEach(func() {
+		logCheckpoint(specTimes)
+
 		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
 		Expect(e2eConfig).ToNot(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
 		Expect(clusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. clusterctlConfigPath must be an existing file when calling %s spec", specName)
@@ -67,6 +71,8 @@ var _ = Describe("Workload cluster creation", func() {
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, cluster, e2eConfig.GetIntervals, skipCleanup)
 		Expect(os.Unsetenv(AzureResourceGroup)).NotTo(HaveOccurred())
 		Expect(os.Unsetenv(AzureVNetName)).NotTo(HaveOccurred())
+
+		logCheckpoint(specTimes)
 	})
 
 	Context("Creating a single control-plane cluster", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds some logging to the main workload e2e specs, hopefully to sort out whether they are actually running in parallel.

(They are parallelized for me locally when running ./scripts/ci-e2e.sh, so maybe the CI environment is different?)

Example output:
```
INFO: "With 1 worker node" started at Tue, 15 Sep 2020 16:10:24 MDT and ran for 6m6s on node 1 of 3
```

**Which issue(s) this PR fixes**:

Refs #807 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
e2e: log elapsed spec time and Ginkgo node number
```