### PR TITLE
🚀  Fast delete cluster resource group when entire cluster is deleted

### DIFF
--- a/cloud/errors.go
+++ b/cloud/errors.go
@@ -18,11 +18,12 @@ package azure
 
 import (
 	"errors"
-
 	"github.com/Azure/go-autorest/autorest"
 )
 
-// ResourceNotFound parses the error to check if it's a resource not found
+var ErrNotOwned = errors.New("resource is not managed and cannot be deleted")
+
+// ResourceNotFound parses the error to check if it's a resource not found error.
 func ResourceNotFound(err error) bool {
 	derr := autorest.DetailedError{}
 	return errors.As(err, &derr) && derr.StatusCode == 404

--- a/cloud/services/groups/groups_test.go
+++ b/cloud/services/groups/groups_test.go
@@ -19,6 +19,7 @@ package groups
 import (
 	"context"
 	"net/http"
+	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -122,7 +123,7 @@ func TestDeleteGroups(t *testing.T) {
 		},
 		{
 			name:          "skip deletion in unmanaged mode",
-			expectedError: "",
+			expectedError: azure.ErrNotOwned.Error(),
 			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockClientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.ResourceGroup().AnyTimes().Return("my-rg")

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -108,28 +108,34 @@ func (r *azureClusterReconciler) Reconcile(ctx context.Context) error {
 
 // Delete reconciles all the services in pre determined order
 func (r *azureClusterReconciler) Delete(ctx context.Context) error {
-	if err := r.loadBalancerSvc.Delete(ctx); err != nil {
-		return errors.Wrapf(err, "failed to delete load balancer")
-	}
-
-	if err := r.subnetsSvc.Delete(ctx); err != nil {
-		return errors.Wrapf(err, "failed to delete subnet")
-	}
-
-	if err := r.routeTableSvc.Delete(ctx); err != nil {
-		return errors.Wrapf(err, "failed to delete route table")
-	}
-
-	if err := r.securityGroupSvc.Delete(ctx); err != nil {
-		return errors.Wrapf(err, "failed to delete network security group")
-	}
-
-	if err := r.vnetSvc.Delete(ctx); err != nil {
-		return errors.Wrapf(err, "failed to delete virtual network")
-	}
-
 	if err := r.groupsSvc.Delete(ctx); err != nil {
-		return errors.Wrapf(err, "failed to delete resource group")
+		if errors.Is(err, azure.ErrNotOwned) {
+			if err := r.loadBalancerSvc.Delete(ctx); err != nil {
+				return errors.Wrapf(err, "failed to delete load balancer")
+			}
+
+			if err := r.publicIPSvc.Delete(ctx); err != nil {
+				return errors.Wrapf(err, "failed to delete public IP")
+			}
+
+			if err := r.subnetsSvc.Delete(ctx); err != nil {
+				return errors.Wrapf(err, "failed to delete subnet")
+			}
+
+			if err := r.routeTableSvc.Delete(ctx); err != nil {
+				return errors.Wrapf(err, "failed to delete route table")
+			}
+
+			if err := r.securityGroupSvc.Delete(ctx); err != nil {
+				return errors.Wrapf(err, "failed to delete network security group")
+			}
+
+			if err := r.vnetSvc.Delete(ctx); err != nil {
+				return errors.Wrapf(err, "failed to delete virtual network")
+			}
+		} else {
+			return errors.Wrapf(err, "failed to delete resource group")
+		}
 	}
 
 	return nil

--- a/controllers/azurecluster_reconciler_test.go
+++ b/controllers/azurecluster_reconciler_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/mocks"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/resourceskus"
+
+	"testing"
+)
+
+type expect func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder)
+
+func TestAzureClusterReconcilerDelete(t *testing.T) {
+	cases := map[string]struct {
+		expectedError string
+		expect        expect
+	}{
+		"Resource Group is deleted successfully": {
+			expectedError: "",
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder) {
+				gomock.InOrder(
+					grp.Delete(context.TODO()).Return(nil))
+			},
+		},
+		"Resource Group delete fails": {
+			expectedError: "failed to delete resource group: internal error",
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder) {
+				gomock.InOrder(
+					grp.Delete(context.TODO()).Return(errors.New("internal error")))
+			},
+		},
+		"Resource Group not owned by cluster": {
+			expectedError: "",
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder) {
+				gomock.InOrder(
+					grp.Delete(context.TODO()).Return(azure.ErrNotOwned),
+					lb.Delete(context.TODO()),
+					pip.Delete(context.TODO()),
+					sn.Delete(context.TODO()),
+					rt.Delete(context.TODO()),
+					sg.Delete(context.TODO()),
+					vnet.Delete(context.TODO()),
+				)
+			},
+		},
+		"Load Balancer delete fails": {
+			expectedError: "failed to delete load balancer: some error happened",
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder) {
+				gomock.InOrder(
+					grp.Delete(context.TODO()).Return(azure.ErrNotOwned),
+					lb.Delete(context.TODO()).Return(errors.New("some error happened")),
+				)
+			},
+		},
+		"Route table delete fails": {
+			expectedError: "failed to delete route table: some error happened",
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder) {
+				gomock.InOrder(
+					grp.Delete(context.TODO()).Return(azure.ErrNotOwned),
+					lb.Delete(context.TODO()),
+					pip.Delete(context.TODO()),
+					sn.Delete(context.TODO()),
+					rt.Delete(context.TODO()).Return(errors.New("some error happened")),
+				)
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			groupsMock := mocks.NewMockService(mockCtrl)
+			vnetMock := mocks.NewMockService(mockCtrl)
+			sgMock := mocks.NewMockService(mockCtrl)
+			rtMock := mocks.NewMockService(mockCtrl)
+			subnetsMock := mocks.NewMockService(mockCtrl)
+			publicIPMock := mocks.NewMockService(mockCtrl)
+			lbMock := mocks.NewMockService(mockCtrl)
+
+			tc.expect(groupsMock.EXPECT(), vnetMock.EXPECT(), sgMock.EXPECT(), rtMock.EXPECT(), subnetsMock.EXPECT(), publicIPMock.EXPECT(), lbMock.EXPECT())
+
+			r := &azureClusterReconciler{
+				scope:            &scope.ClusterScope{},
+				groupsSvc:        groupsMock,
+				vnetSvc:          vnetMock,
+				securityGroupSvc: sgMock,
+				routeTableSvc:    rtMock,
+				subnetsSvc:       subnetsMock,
+				publicIPSvc:      publicIPMock,
+				loadBalancerSvc:  lbMock,
+				skuCache:         resourceskus.NewStaticCache([]compute.ResourceSku{}),
+			}
+
+			err := r.Delete(context.TODO())
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+
+}

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -282,8 +282,10 @@ func (r *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, machin
 func (r *AzureMachinePoolReconciler) reconcileDelete(ctx context.Context, machinePoolScope *scope.MachinePoolScope, clusterScope *scope.ClusterScope) (_ reconcile.Result, reterr error) {
 	machinePoolScope.Info("Handling deleted AzureMachinePool")
 
-	if err := newAzureMachinePoolService(machinePoolScope, clusterScope).Delete(ctx); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "error deleting AzureCluster %s/%s", clusterScope.Namespace(), clusterScope.ClusterName())
+	if infracontroller.ShouldDeleteIndividualResources(ctx, clusterScope) {
+		if err := newAzureMachinePoolService(machinePoolScope, clusterScope).Delete(ctx); err != nil {
+			return reconcile.Result{}, errors.Wrapf(err, "error deleting AzureCluster %s/%s", clusterScope.Namespace(), clusterScope.ClusterName())
+		}
 	}
 
 	defer func() {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

**What this PR does / why we need it**:  TLDR:
Before:
```
time kubectl delete cluster default-template 
cluster.cluster.x-k8s.io "default-template" deleted
kubectl delete cluster default-template  0.18s user 0.09s system 0% cpu 14:49.77 total
```

After:
```
time kubectl delete cluster default-template              
cluster.cluster.x-k8s.io "default-template" deleted
kubectl delete cluster default-template  0.18s user 0.16s system 0% cpu 8:21.90 total
```

Currently, every Azure resource is deleted serially when a cluster gets deleted. In most cases, it is enough to just delete the resource group. Azure will take care of deleting all resources within that resource group in the proper order.

This does PR attempts to delete the entire resource group and skip deleting individual resources like VMs when 1) the entire cluster is being deleted and 2) when that cluster owns the resource group (which means it gets deleted as part of cluster delete). If these two conditions are not met, normal delete proceeds as before, deleting each resource type by order of dependency.

REVERTED ~This also introduces a "no wait" delete for the resource group delete, which means we don't wait for actual completion. As soon as Azure returns a 200 to confirm that the delete request was received, we return success back to the user and the resource group continues deleting in the background. This is safe for resource groups and resource groups only because it is the last resource type that we delete and no other resources depend on it.~

~What happens if the resource group is still deleting in the background and the user attempts to create a new cluster in that same RG? The user will see errors similar to:~
```
controller-runtime/controller "msg"="Reconciler error" "error"="failed to reconcile cluster services: failed to reconcile virtual network: failed to create virtual network default-template-vnet: network.VirtualNetworksClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=\u003cnil\u003e Code=\"ResourceGroupBeingDeleted\" Message=\"The resource group 'default-template' is in deprovisioning state and cannot perform this operation.\"" "controller"="azurecluster" "name"="default-template" "namespace"="default"
```
~in controller logs until the resource group deletion is completed and the new create can proceed (at which point it does).~

This PR might also help with #937 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

/hold for unit tests

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Directly delete cluster resource group when entire cluster is deleted
```