### PR TITLE
🔧  Apply calico ClusterResourceSet to tilt and dev clusters

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -258,6 +258,12 @@ def capz():
 
     k8s_yaml(blob(yaml))
 
+def calico_crs():
+    local("kubectl delete configmaps calico-addon --ignore-not-found=true")
+    local("kubectl create configmap calico-addon --from-file=templates/addons/calico.yaml")
+    local("kubectl delete configmaps calico-ipv6-addon --ignore-not-found=true")
+    local("kubectl create configmap calico-ipv6-addon --from-file=templates/addons/calico-ipv6.yaml")
+    local("kubectl apply -f templates/addons/calico-resource-set.yaml")
 
 # run worker clusters specified from 'tilt up' or in 'tilt_config.json'
 def flavors():
@@ -384,5 +390,7 @@ if settings.get("deploy_cert_manager"):
 deploy_capi()
 
 capz()
+
+calico_crs()
 
 flavors()

--- a/templates/addons/calico-resource-set.yaml
+++ b/templates/addons/calico-resource-set.yaml
@@ -1,0 +1,27 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: crs-calico
+  namespace: default
+spec:
+  strategy: "ApplyOnce"
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  resources:
+    - name: calico-addon
+      kind: ConfigMap
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: crs-calico-ipv6
+  namespace: default
+spec:
+  strategy: "ApplyOnce"
+  clusterSelector:
+    matchLabels:
+      cni: calico-ipv6
+  resources:
+    - name: calico-ipv6-addon
+      kind: ConfigMap

--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico-ipv6
   name: ${CLUSTER_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:

--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -3,6 +3,8 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
+  labels:
+    cni: "calico"
 spec:
   clusterNetwork:
     pods:

--- a/templates/flavors/ipv6/patches/ipv6.yaml
+++ b/templates/flavors/ipv6/patches/ipv6.yaml
@@ -3,6 +3,8 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
+  labels:
+    cni: "calico-ipv6"
 spec:
   clusterNetwork:
     pods:

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: ${CLUSTER_NAME}-crs-0
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -358,3 +360,24 @@ spec:
   preKubeadmCommands:
   - bash -c /tmp/kubeadm-bootstrap.sh
   useExperimentalRetryJoin: true
+---
+apiVersion: v1
+data: ${CNI_RESOURCES}
+kind: ConfigMap
+metadata:
+  name: cni-${CLUSTER_NAME}-crs-0
+  namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: ${CLUSTER_NAME}-crs-0
+  resources:
+  - kind: ConfigMap
+    name: cni-${CLUSTER_NAME}-crs-0
+  strategy: ApplyOnce

--- a/templates/test/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/cluster-template-prow-machine-pool.yaml
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  labels:
+    cni: ${CLUSTER_NAME}-crs-0
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -193,3 +195,24 @@ spec:
         cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
   useExperimentalRetryJoin: true
+---
+apiVersion: v1
+data: ${CNI_RESOURCES}
+kind: ConfigMap
+metadata:
+  name: cni-${CLUSTER_NAME}-crs-0
+  namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: ${CLUSTER_NAME}-crs-0
+  resources:
+  - kind: ConfigMap
+    name: cni-${CLUSTER_NAME}-crs-0
+  strategy: ApplyOnce

--- a/templates/test/prow-machine-pool/cni-resource-set.yaml
+++ b/templates/test/prow-machine-pool/cni-resource-set.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+data: ${CNI_RESOURCES}
+kind: ConfigMap
+metadata:
+  name: cni-${CLUSTER_NAME}-crs-0
+  namespace: default
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: ${CLUSTER_NAME}-crs-0
+  resources:
+  - kind: ConfigMap
+    name: cni-${CLUSTER_NAME}-crs-0
+  strategy: ApplyOnce

--- a/templates/test/prow-machine-pool/kustomization.yaml
+++ b/templates/test/prow-machine-pool/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 namespace: default
 resources:
   - ../../flavors/machinepool
+  - cni-resource-set.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
+  - ../patches/cni-resource-set.yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- please add an icon to the title of this PR (see ../CONTRIBUTING.md) -->
 <!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), 💚 (`:green_heart:`, testing), 💎 (`:gem:`, refactor), 🔧 (`:wrench:`, dev tooling and chores) or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Use ClusterResourceSets to apply the calico addons for tilt and dev clusters. This allows using local tilt resources to bring up fully functional clusters, without needing to apply CNI manually. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Apply calico ClusterResourceSet to tilt and dev clusters
```
