### PR TITLE
🌱  Change default NSG rule priorities

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -308,7 +308,7 @@ func (s *ClusterScope) SetControlPlaneIngressRules() {
 			&infrav1.IngressRule{
 				Name:             "allow_ssh",
 				Description:      "Allow SSH",
-				Priority:         100,
+				Priority:         2200,
 				Protocol:         infrav1.SecurityGroupProtocolTCP,
 				Source:           to.StringPtr("*"),
 				SourcePorts:      to.StringPtr("*"),
@@ -318,7 +318,7 @@ func (s *ClusterScope) SetControlPlaneIngressRules() {
 			&infrav1.IngressRule{
 				Name:             "allow_apiserver",
 				Description:      "Allow K8s API Server",
-				Priority:         101,
+				Priority:         2201,
 				Protocol:         infrav1.SecurityGroupProtocolTCP,
 				Source:           to.StringPtr("*"),
 				SourcePorts:      to.StringPtr("*"),


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- please add an icon to the title of this PR (see ../CONTRIBUTING.md) -->
 <!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), 💚 (`:green_heart:`, testing), 💎 (`:gem:`, refactor), 🔧 (`:wrench:`, dev tooling and chores) or 🌱 (:seedling:, minor or other) -->
 
**What this PR does / why we need it**: Follow up from https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/830#discussion_r461671624, increases the default rules priority to allow adding higher priority custom rules.
SSH inbound allow is now 2200 (was 100), API Server inbound allow is now 2201 (was 101).


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change default NSG rule priorities: SSH inbound allow is now 2200 (was 100), API Server inbound allow is now 2201 (was 101).
```
