### PR TITLE
🐛 Skips creating secrets for machines cloned from AzureMachineTemplates

### DIFF
--- a/controllers/azurejson_machine_controller.go
+++ b/controllers/azurejson_machine_controller.go
@@ -91,13 +91,13 @@ func (f filterUnclonedMachinesPredicate) Generic(e event.GenericEvent) bool {
 	}
 
 	// when watching machines, we only care about machines users created one-off
-	// outside of machinedeployments/machinesets. if a machine is part of a machineset
+	// outside of machinedeployments/machinesets and using AzureMachineTemplates. if a machine is part of a machineset
 	// or machinedeployment, we already created a secret for the template. All machines
 	// in the machinedeployment will share that one secret.
-	_, isMachineSetNode := e.Meta.GetLabels()[clusterv1.MachineSetLabelName]
-	_, isMachineDeploymentNode := e.Meta.GetLabels()[clusterv1.MachineDeploymentLabelName]
+	gvk := infrav1.GroupVersion.WithKind("AzureMachineTemplate")
+	isClonedFromTemplate := e.Meta.GetAnnotations()[clusterv1.TemplateClonedFromGroupKindAnnotation] == gvk.GroupKind().String()
 
-	return !isMachineSetNode && !isMachineDeploymentNode
+	return !isClonedFromTemplate
 }
 
 // Reconcile reconciles the azure json for a specific machine not in a machine deployment

--- a/controllers/azurejson_machine_controller_test.go
+++ b/controllers/azurejson_machine_controller_test.go
@@ -39,29 +39,27 @@ import (
 
 func TestUnclonedMachinesPredicate(t *testing.T) {
 	cases := map[string]struct {
-		expected bool
-		labels   map[string]string
+		expected    bool
+		labels      map[string]string
+		annotations map[string]string
 	}{
 		"uncloned worker node should return true": {
-			expected: true,
-			labels:   nil,
+			expected:    true,
+			labels:      nil,
+			annotations: nil,
 		},
-		"control plane node should return true": {
+		"uncloned control plane node should return true": {
 			expected: true,
 			labels: map[string]string{
 				clusterv1.MachineControlPlaneLabelName: "",
 			},
+			annotations: nil,
 		},
-		"machineset node should return false": {
+		"cloned node should return false": {
 			expected: false,
-			labels: map[string]string{
-				clusterv1.MachineSetLabelName: "",
-			},
-		},
-		"machinedeployment node should return false": {
-			expected: false,
-			labels: map[string]string{
-				clusterv1.MachineDeploymentLabelName: "",
+			labels:   nil,
+			annotations: map[string]string{
+				clusterv1.TemplateClonedFromGroupKindAnnotation: infrav1.GroupVersion.WithKind("AzureMachineTemplate").GroupKind().String(),
 			},
 		},
 	}
@@ -71,7 +69,8 @@ func TestUnclonedMachinesPredicate(t *testing.T) {
 			t.Parallel()
 			machine := &infrav1.AzureMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: tc.labels,
+					Labels:      tc.labels,
+					Annotations: tc.annotations,
 				},
 			}
 			e := event.GenericEvent{


### PR DESCRIPTION
**What this PR does / why we need it**:
When creating a cluster with KCP managed control planes, I noticed that we create an azure-json secret for the control-plane template but also for each of the control plane nodes. We only use the one created for the template so this change is to prevent creating a secret for each control plane node. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
