### PR TITLE
✨  Exclude credentials from worker-nodes' azure.json

### DIFF
--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -86,7 +86,7 @@ spec:
     files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
@@ -187,7 +187,7 @@ spec:
       files:
       - contentFrom:
           secret:
-            key: azure.json
+            key: worker-node-azure.json
             name: ${CLUSTER_NAME}-md-0-azure-json
         owner: root:root
         path: /etc/kubernetes/azure.json

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -86,7 +86,7 @@ spec:
     files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
@@ -183,7 +183,7 @@ spec:
       files:
       - contentFrom:
           secret:
-            key: azure.json
+            key: worker-node-azure.json
             name: ${CLUSTER_NAME}-md-0-azure-json
         owner: root:root
         path: /etc/kubernetes/azure.json

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -86,7 +86,7 @@ spec:
     files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
@@ -178,7 +178,7 @@ spec:
   files:
   - contentFrom:
       secret:
-        key: azure.json
+        key: worker-node-azure.json
         name: ${CLUSTER_NAME}-mp-0-azure-json
     owner: root:root
     path: /etc/kubernetes/azure.json

--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -86,7 +86,7 @@ spec:
     files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
@@ -185,7 +185,7 @@ spec:
       files:
       - contentFrom:
           secret:
-            key: azure.json
+            key: worker-node-azure.json
             name: ${CLUSTER_NAME}-md-0-azure-json
         owner: root:root
         path: /etc/kubernetes/azure.json

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -86,7 +86,7 @@ spec:
     files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
@@ -189,7 +189,7 @@ spec:
       files:
       - contentFrom:
           secret:
-            key: azure.json
+            key: worker-node-azure.json
             name: ${CLUSTER_NAME}-md-0-azure-json
         owner: root:root
         path: /etc/kubernetes/azure.json

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -86,7 +86,7 @@ spec:
     files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
@@ -183,7 +183,7 @@ spec:
       files:
       - contentFrom:
           secret:
-            key: azure.json
+            key: worker-node-azure.json
             name: ${CLUSTER_NAME}-md-0-azure-json
         owner: root:root
         path: /etc/kubernetes/azure.json

--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -81,7 +81,7 @@ spec:
     - contentFrom:
         secret:
           name: ${CLUSTER_NAME}-control-plane-azure-json
-          key: azure.json
+          key: control-plane-azure.json
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"

--- a/templates/flavors/default/machine-deployment.yaml
+++ b/templates/flavors/default/machine-deployment.yaml
@@ -56,7 +56,7 @@ spec:
       - contentFrom:
           secret:
             name: ${CLUSTER_NAME}-md-0-azure-json
-            key: azure.json
+            key: worker-node-azure.json
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"

--- a/templates/flavors/machinepool/machine-pool-deployment.yaml
+++ b/templates/flavors/machinepool/machine-pool-deployment.yaml
@@ -51,7 +51,7 @@ spec:
   - contentFrom:
       secret:
         name: ${CLUSTER_NAME}-mp-0-azure-json
-        key: azure.json
+        key: worker-node-azure.json
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"

--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -166,8 +166,8 @@ spec:
       permissions: "0744"
     - contentFrom:
         secret:
-          key: azure.json
-          name: azure-secret
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-md-0-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
@@ -354,8 +354,8 @@ spec:
         permissions: "0744"
       - contentFrom:
           secret:
-            key: azure.json
-            name: azure-secret
+            key: control-plane-azure.json
+            name: ${CLUSTER_NAME}-control-plane-azure-json
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -164,8 +164,8 @@ spec:
       permissions: "0744"
     - contentFrom:
         secret:
-          key: azure.json
-          name: azure-secret
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-control-plane-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
       permissions: "0644"
@@ -344,8 +344,8 @@ spec:
     permissions: "0744"
   - contentFrom:
       secret:
-        key: azure.json
-        name: azure-secret
+        key: worker-node-azure.json
+        name: ${CLUSTER_NAME}-mp-0-azure-json
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"

--- a/templates/test/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/cluster-template-prow-machine-pool.yaml
@@ -89,7 +89,7 @@ spec:
     files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
@@ -181,7 +181,7 @@ spec:
   files:
   - contentFrom:
       secret:
-        key: azure.json
+        key: worker-node-azure.json
         name: ${CLUSTER_NAME}-mp-0-azure-json
     owner: root:root
     path: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow.yaml
+++ b/templates/test/cluster-template-prow.yaml
@@ -91,7 +91,7 @@ spec:
     files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
@@ -191,7 +191,7 @@ spec:
       files:
       - contentFrom:
           secret:
-            key: azure.json
+            key: worker-node-azure.json
             name: ${CLUSTER_NAME}-md-0-azure-json
         owner: root:root
         path: /etc/kubernetes/azure.json

--- a/templates/test/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -89,8 +89,8 @@ spec:
       permissions: "0644"
       contentFrom:
         secret:
-          key: azure.json
-          name: azure-secret
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-md-0-azure-json
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
@@ -181,8 +181,8 @@ spec:
           permissions: "0644"
           contentFrom:
             secret:
-              key: azure.json
-              name: azure-secret
+              key: control-plane-azure.json
+              name: ${CLUSTER_NAME}-control-plane-azure-json
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachineTemplate

--- a/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -89,8 +89,8 @@ spec:
       permissions: "0644"
       contentFrom:
         secret:
-          key: azure.json
-          name: azure-secret
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-control-plane-azure-json
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
@@ -179,8 +179,8 @@ spec:
       permissions: "0644"
       contentFrom:
         secret:
-          key: azure.json
-          name: azure-secret
+          key: worker-node-azure.json
+          name: ${CLUSTER_NAME}-mp-0-azure-json
 ---
 apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachinePool

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -27,13 +27,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
-
 	"text/tabwriter"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
-
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR trims credentials from the azure.json file that gets placed on worker nodes. Control plane nodes remain unchanged.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #921 

**Special notes for your reviewer**:
I tested a basic cluster and verified the changes but didn't test every permutation with machine pool, one off machines etc. 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
Removes credentials from azure.json for worker nodes.
```
