### PR TITLE
🐛 Make role assignment name deterministic

### DIFF
--- a/api/v1alpha2/azuremachine_conversion.go
+++ b/api/v1alpha2/azuremachine_conversion.go
@@ -53,6 +53,7 @@ func restoreAzureMachineSpec(restored, dst *infrav1alpha3.AzureMachineSpec) {
 	if len(restored.UserAssignedIdentities) > 0 {
 		dst.UserAssignedIdentities = restored.UserAssignedIdentities
 	}
+	dst.RoleAssignmentName = restored.RoleAssignmentName
 	if restored.AcceleratedNetworking != nil {
 		dst.AcceleratedNetworking = restored.AcceleratedNetworking
 	}

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -574,6 +574,7 @@ func autoConvert_v1alpha3_AzureMachineSpec_To_v1alpha2_AzureMachineSpec(in *v1al
 	}
 	// WARNING: in.Identity requires manual conversion: does not exist in peer-type
 	// WARNING: in.UserAssignedIdentities requires manual conversion: does not exist in peer-type
+	// WARNING: in.RoleAssignmentName requires manual conversion: does not exist in peer-type
 	if err := Convert_v1alpha3_OSDisk_To_v1alpha2_OSDisk(&in.OSDisk, &out.OSDisk, s); err != nil {
 		return err
 	}

--- a/api/v1alpha3/azuremachine_default.go
+++ b/api/v1alpha3/azuremachine_default.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	"encoding/base64"
+	"k8s.io/apimachinery/pkg/util/uuid"
 
 	"golang.org/x/crypto/ssh"
 
@@ -70,6 +71,15 @@ func (m *AzureMachine) SetDataDisksDefaults() {
 		}
 		if disk.CachingType == "" {
 			m.Spec.DataDisks[i].CachingType = "ReadWrite"
+		}
+	}
+}
+
+// SetIdentityDefaults sets the defaults for VM Identity.
+func (m *AzureMachine) SetIdentityDefaults() {
+	if m.Spec.Identity == VMIdentitySystemAssigned {
+		if m.Spec.RoleAssignmentName == "" {
+			m.Spec.RoleAssignmentName = string(uuid.NewUUID())
 		}
 	}
 }

--- a/api/v1alpha3/azuremachine_types.go
+++ b/api/v1alpha3/azuremachine_types.go
@@ -66,6 +66,11 @@ type AzureMachineSpec struct {
 	// +optional
 	UserAssignedIdentities []UserAssignedIdentity `json:"userAssignedIdentities,omitempty"`
 
+	// RoleAssignmentName is the name of the role assignment to create for a system assigned identity. It can be any valid GUID.
+	// If not specified, a random GUID will be generated.
+	// +optional
+	RoleAssignmentName string `json:"roleAssignmentName,omitempty"`
+
 	// OSDisk specifies the parameters for the operating system disk of the machine
 	OSDisk OSDisk `json:"osDisk"`
 

--- a/api/v1alpha3/azuremachine_webhook.go
+++ b/api/v1alpha3/azuremachine_webhook.go
@@ -57,6 +57,10 @@ func (m *AzureMachine) ValidateCreate() error {
 		allErrs = append(allErrs, errs...)
 	}
 
+	if errs := ValidateSystemAssignedIdentity(m.Spec.Identity, "", m.Spec.RoleAssignmentName, field.NewPath("roleAssignmentName")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
 	if errs := ValidateUserAssignedIdentity(m.Spec.Identity, m.Spec.UserAssignedIdentities, field.NewPath("userAssignedIdentities")); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}
@@ -75,6 +79,7 @@ func (m *AzureMachine) ValidateCreate() error {
 func (m *AzureMachine) ValidateUpdate(oldRaw runtime.Object) error {
 	machinelog.Info("validate update", "name", m.Name)
 	var allErrs field.ErrorList
+	old := oldRaw.(*AzureMachine)
 
 	if errs := ValidateImage(m.Spec.Image, field.NewPath("image")); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
@@ -88,6 +93,10 @@ func (m *AzureMachine) ValidateUpdate(oldRaw runtime.Object) error {
 		allErrs = append(allErrs, errs...)
 	}
 
+	if errs := ValidateSystemAssignedIdentity(m.Spec.Identity, old.Spec.RoleAssignmentName, m.Spec.RoleAssignmentName, field.NewPath("roleAssignmentName")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
 	if errs := ValidateUserAssignedIdentity(m.Spec.Identity, m.Spec.UserAssignedIdentities, field.NewPath("userAssignedIdentities")); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}
@@ -95,8 +104,6 @@ func (m *AzureMachine) ValidateUpdate(oldRaw runtime.Object) error {
 	if errs := ValidateDataDisks(m.Spec.DataDisks, field.NewPath("dataDisks")); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}
-
-	old := oldRaw.(*AzureMachine)
 
 	if errs := ValidateManagedDisk(old.Spec.OSDisk.ManagedDisk, m.Spec.OSDisk.ManagedDisk, field.NewPath("osDisk").Child("managedDisk")); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
@@ -134,4 +141,6 @@ func (m *AzureMachine) Default() {
 	}
 
 	m.SetDataDisksDefaults()
+
+	m.SetIdentityDefaults()
 }

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -20,13 +20,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog/klogr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
@@ -226,7 +224,7 @@ func (m *MachineScope) RoleAssignmentSpecs() []azure.RoleAssignmentSpec {
 		return []azure.RoleAssignmentSpec{
 			{
 				MachineName: m.Name(),
-				UUID:        string(uuid.NewUUID()),
+				Name:        m.AzureMachine.Spec.RoleAssignmentName,
 			},
 		}
 	}

--- a/cloud/services/roleassignments/roleassignments.go
+++ b/cloud/services/roleassignments/roleassignments.go
@@ -43,7 +43,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				PrincipalID:      resultVM.Identity.PrincipalID,
 			},
 		}
-		_, err = s.Client.Create(ctx, scope, roleSpec.UUID, params)
+		_, err = s.Client.Create(ctx, scope, roleSpec.Name, params)
 		if err != nil {
 			return errors.Wrapf(err, "cannot assign role to VM system assigned identity")
 		}

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -95,7 +95,7 @@ type VNetSpec struct {
 // RoleAssignmentSpec defines the specification for a Role Assignment.
 type RoleAssignmentSpec struct {
 	MachineName string
-	UUID        string
+	Name        string
 }
 
 // NSGSpec defines the specification for a Security Group.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -454,6 +454,11 @@ spec:
                 description: ProviderID is the unique identifier as specified by the
                   cloud provider.
                 type: string
+              roleAssignmentName:
+                description: RoleAssignmentName is the name of the role assignment
+                  to create for a system assigned identity. It can be any valid GUID.
+                  If not specified, a random GUID will be generated.
+                type: string
               spotVMOptions:
                 description: SpotVMOptions allows the ability to specify the Machine
                   should use a Spot VM

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -399,6 +399,11 @@ spec:
                         description: ProviderID is the unique identifier as specified
                           by the cloud provider.
                         type: string
+                      roleAssignmentName:
+                        description: RoleAssignmentName is the name of the role assignment
+                          to create for a system assigned identity. It can be any
+                          valid GUID. If not specified, a random GUID will be generated.
+                        type: string
                       spotVMOptions:
                         description: SpotVMOptions allows the ability to specify the
                           Machine should use a Spot VM


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- please add an icon to the title of this PR (see ../CONTRIBUTING.md) -->
 <!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), 💚 (`:green_heart:`, testing), 💎 (`:gem:`, refactor), 🔧 (`:wrench:`, dev tooling and chores) or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Using system assigned identity causes `RoleAssignmentExists` errors in logs.

According to Azure docs:
```This template is not idempotent unless the same roleNameGuid value is provided as a parameter for each deployment of the template. If no roleNameGuid is provided, by default a new GUID is generated on each deployment and subsequent deployments will fail with a Conflict: RoleAssignmentExists error.```

https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-template

The solution is to use a deterministic GUID, based on a hash from static information so that the generated string will be the same every time the AzureMachine is reconciled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #953 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make role assignment name deterministic
```
