### PR TITLE
🐛  Leave DNS name empty for outbound public ip

### DIFF
--- a/cloud/services/publicips/publicips_test.go
+++ b/cloud/services/publicips/publicips_test.go
@@ -19,8 +19,9 @@ package publicips
 import (
 	"context"
 	"net/http"
-	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 	"testing"
+
+	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 
@@ -106,10 +107,6 @@ func TestReconcilePublicIP(t *testing.T) {
 						PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 							PublicIPAddressVersion:   network.IPv4,
 							PublicIPAllocationMethod: network.Static,
-							DNSSettings: &network.PublicIPAddressDNSSettings{
-								DomainNameLabel: to.StringPtr("my-publicip-3"),
-								Fqdn:            to.StringPtr(""),
-							},
 						},
 					})).Times(1),
 					m.CreateOrUpdate(context.TODO(), "my-rg", "my-publicip-ipv6", gomockinternal.DiffEq(network.PublicIPAddress{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

/kind bug

 <!-- please add an icon to the title of this PR (see ../CONTRIBUTING.md) -->
 <!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), 💚 (`:green_heart:`, testing), 💎 (`:gem:`, refactor), 🔧 (`:wrench:`, dev tooling and chores) or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
 - to avoid conflict in DNS name, we will not set the DNS record for the outbound public ip
    - only ip needed by azure
    - existing clusters will get their dns removed, but not an issue
    - keep public ip name simple

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #958 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
To avoid conflict in DNS name, we will not set the DNS record for the outbound public ip
```
