### PR TITLE
Fix kcp adoption template azure.json secret key

### DIFF
--- a/test/e2e/data/infrastructure-azure/cluster-template-kcp-adoption.yaml
+++ b/test/e2e/data/infrastructure-azure/cluster-template-kcp-adoption.yaml
@@ -148,7 +148,7 @@ spec:
   files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-0-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json
@@ -236,7 +236,7 @@ spec:
     files:
     - contentFrom:
         secret:
-          key: azure.json
+          key: control-plane-azure.json
           name: ${CLUSTER_NAME}-control-plane-0-azure-json
       owner: root:root
       path: /etc/kubernetes/azure.json


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Fixes the kcp adoption test (https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#periodic-capi-e2e) that has been failing since #955 merged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
