### PR TITLE
Remove calico apply step from create cluster make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ create-cluster: ## Create a workload development Kubernetes cluster on Azure in 
 	EXP_AKS=true \
 	EXP_MACHINE_POOL=true \
 	$(MAKE) create-management-cluster \
-	$(MAKE) create-workload-cluster
+	create-workload-cluster
 
 .PHONY: delete-workload-cluster
 delete-workload-cluster: ## Deletes the example workload Kubernetes cluster

--- a/Makefile
+++ b/Makefile
@@ -453,13 +453,13 @@ create-workload-cluster: $(ENVSUBST)
 	kubectl get secrets $(CLUSTER_NAME)-kubeconfig -o json | jq -r .data.value | base64 --decode > ./kubeconfig
 	timeout --foreground 600 bash -c "while ! kubectl --kubeconfig=./kubeconfig get nodes | grep master; do sleep 1; done"
 
-	# Deploy calico
-	@if [[ "${CLUSTER_TEMPLATE}" == *ipv6* ]]; then \
-		kubectl --kubeconfig=./kubeconfig apply -f templates/addons/calico-ipv6.yaml; \
-	else \
-		kubectl --kubeconfig=./kubeconfig apply -f templates/addons/calico.yaml; \
+	@if [[ "${CLUSTER_TEMPLATE}" == *prow* ]]; then \
+		if [[ "${CLUSTER_TEMPLATE}" == *ipv6* ]]; then \
+			kubectl --kubeconfig=./kubeconfig apply -f templates/addons/calico-ipv6.yaml; \
+		else \
+			kubectl --kubeconfig=./kubeconfig apply -f templates/addons/calico.yaml; \
+		fi \
 	fi
-
 
 	@echo 'run "kubectl --kubeconfig=./kubeconfig ..." to work with the new target cluster'
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind failing-test

**What this PR does / why we need it**:

Forgot to do this as part of #947. Calico apply is no longer needed as the management cluster has calico as ClusterResourceSets. Also fixes the create-cluster make target which currently fails with `make[1]: *** No rule to make target 'make'. `.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
