### PR TITLE
💚 collect workload cluster logs in e2e runs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
 	sigs.k8s.io/cluster-api v0.3.10
 	sigs.k8s.io/controller-runtime v0.5.11
+	sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802
 )
 
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -1,0 +1,84 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"path/filepath"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	kinderrors "sigs.k8s.io/kind/pkg/errors"
+)
+
+// AzureLogCollector collects logs from a CAPZ workload cluster.
+type AzureLogCollector struct{}
+
+// CollectMachineLog collects logs from a machine.
+func (k AzureLogCollector) CollectMachineLog(ctx context.Context,
+	managementClusterClient client.Client, m *clusterv1.Machine, outputPath string) error {
+	cluster, err := util.GetClusterFromMetadata(ctx, managementClusterClient, m.ObjectMeta)
+	if err != nil {
+		return err
+	}
+	controlPlaneEndpoint := cluster.Spec.ControlPlaneEndpoint.Host
+	hostname := m.Spec.InfrastructureRef.Name
+	execToPathFn := func(outputFileName, command string, args ...string) func() error {
+		return func() error {
+			f, err := fileOnHost(filepath.Join(outputPath, outputFileName))
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			return execOnHost(controlPlaneEndpoint, hostname, f, command, args...)
+		}
+	}
+
+	return kinderrors.AggregateConcurrent([]func() error{
+		execToPathFn(
+			"journal.log",
+			"journalctl", "--no-pager", "--output=short-precise",
+		),
+		execToPathFn(
+			"kern.log",
+			"journalctl", "--no-pager", "--output=short-precise", "-k",
+		),
+		execToPathFn(
+			"kubelet-version.txt",
+			"kubelet", "--version",
+		),
+		execToPathFn(
+			"kubelet.log",
+			"journalctl", "--no-pager", "--output=short-precise", "-u", "kubelet.service",
+		),
+		execToPathFn(
+			"containerd.log",
+			"journalctl", "--no-pager", "--output=short-precise", "-u", "containerd.service",
+		),
+		execToPathFn(
+			"cloud-init.log",
+			"cat", "/var/log/cloud-init.log",
+		),
+		execToPathFn(
+			"cloud-init-output.log",
+			"cat", "/var/log/cloud-init-output.log",
+		),
+	})
+}

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -64,6 +64,9 @@ func setupSpecNamespace(ctx context.Context, specName string, clusterProxy frame
 }
 
 func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string, namespace *corev1.Namespace, cancelWatches context.CancelFunc, cluster *clusterv1.Cluster, intervalsGetter func(spec, key string) []interface{}, skipCleanup bool) {
+	Byf("Dumping logs from the %q workload cluster", cluster.Name)
+	clusterProxy.CollectWorkloadClusterLogs(ctx, cluster.Namespace, cluster.Name, filepath.Join(artifactFolder, "clusters", cluster.Name, "machines"))
+
 	Byf("Dumping all the Cluster API resources in the %q namespace", namespace.Name)
 	// Dump all Cluster API related resources to artifacts before deleting them.
 	framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -128,7 +128,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	kubeconfigPath := parts[3]
 
 	e2eConfig = loadE2EConfig(configPath)
-	bootstrapClusterProxy = framework.NewClusterProxy("bootstrap", kubeconfigPath, initScheme())
+	bootstrapClusterProxy = framework.NewClusterProxy("bootstrap", kubeconfigPath, initScheme(),
+		framework.WithMachineLogCollector(AzureLogCollector{}))
 })
 
 // Using a SynchronizedAfterSuite for controlling how to delete resources shared across ParallelNodes (~ginkgo threads).


### PR DESCRIPTION
/kind other

**What this PR does / why we need it**:

This implements the CAPI e2e test framework [`ClusterLogCollector`](https://github.com/kubernetes-sigs/cluster-api/blob/59faa7b1c63ba301cb780836891e7b10098fce34/test/framework/cluster_proxy.go#L81) interface for Azure machines, and connects it so these logs are saved for each node to the test client when cleaning up a test cluster:

- journal.log
- kern.log
- kubelet-version.txt
- kubelet.log
- containerd.log
- cloud-init.log
- cloud-init-output.log

**Which issue(s) this PR fixes**:

Fixes #761

**Special notes for your reviewer**:

The SSH proxy code was adapted from AKS Engine's test/e2e package, thanks 💯 to @CecileRobertMichon.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
💚 collect workload cluster logs in e2e runs
```
