### PR TITLE
Fix USE_CI_VERSION marketplace image version

### DIFF
--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -209,7 +209,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.04.17
+          version: 2020.08.17
       location: ${AZURE_LOCATION}
       osDisk:
         diskSizeGB: 128
@@ -259,7 +259,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.04.17
+          version: 2020.08.17
       location: ${AZURE_LOCATION}
       osDisk:
         diskSizeGB: 128

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -209,7 +209,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: k8s-1dot18dot8-ubuntu-1804
-          version: 2020.04.17
+          version: 2020.08.17
       location: ${AZURE_LOCATION}
       osDisk:
         diskSizeGB: 128
@@ -254,7 +254,7 @@ spec:
         offer: capi
         publisher: cncf-upstream
         sku: k8s-1dot18dot8-ubuntu-1804
-        version: 2020.04.17
+        version: 2020.08.17
     osDisk:
       diskSizeGB: 30
       managedDisk:

--- a/templates/test/patches/control-plane-image-ci-version.yaml
+++ b/templates/test/patches/control-plane-image-ci-version.yaml
@@ -12,4 +12,4 @@ spec:
           publisher: cncf-upstream
           offer: capi
           sku: k8s-1dot18dot8-ubuntu-1804
-          version: "2020.04.17"
+          version: "2020.08.17"

--- a/templates/test/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -198,4 +198,4 @@ spec:
           publisher: cncf-upstream
           offer: capi
           sku: k8s-1dot18dot8-ubuntu-1804
-          version: "2020.04.17"
+          version: "2020.08.17"

--- a/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -195,4 +195,4 @@ spec:
         publisher: cncf-upstream
         offer: capi
         sku: k8s-1dot18dot8-ubuntu-1804
-        version: "2020.04.17"
+        version: "2020.08.17"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: This fixes a regression where the base image k8s version was updated but not the image version which causes errors in tests using ci-entrypoint.sh with `USE_CI_VERSION` == `true`:

```
compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=404 -- Original Error: Code=\"PlatformImageNotFound\" Message=\"The platform image 'cncf-upstream:capi:k8s-1dot18dot8-ubuntu-1804:2020.04.17' is not available.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
