### PR TITLE
💎  cleanup: VM and VNet spec no longer return arrays

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -229,14 +229,12 @@ func (s *ClusterScope) SubnetSpecs() []azure.SubnetSpec {
 	}
 }
 
-// VNetSpecs returns the virtual network specs.
-func (s *ClusterScope) VNetSpecs() []azure.VNetSpec {
-	return []azure.VNetSpec{
-		{
-			ResourceGroup: s.Vnet().ResourceGroup,
-			Name:          s.Vnet().Name,
-			CIDRs:         s.Vnet().CIDRBlocks,
-		},
+// VNetSpec returns the virtual network spec.
+func (s *ClusterScope) VNetSpec() azure.VNetSpec {
+	return azure.VNetSpec{
+		ResourceGroup: s.Vnet().ResourceGroup,
+		Name:          s.Vnet().Name,
+		CIDRs:         s.Vnet().CIDRBlocks,
 	}
 }
 

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -88,23 +88,21 @@ type MachineScope struct {
 	AzureMachine *infrav1.AzureMachine
 }
 
-// VMSpecs returns the VM specs.
-func (m *MachineScope) VMSpecs() []azure.VMSpec {
-	return []azure.VMSpec{
-		{
-			Name:                   m.Name(),
-			Role:                   m.Role(),
-			NICNames:               m.NICNames(),
-			SSHKeyData:             m.AzureMachine.Spec.SSHPublicKey,
-			Size:                   m.AzureMachine.Spec.VMSize,
-			OSDisk:                 m.AzureMachine.Spec.OSDisk,
-			DataDisks:              m.AzureMachine.Spec.DataDisks,
-			Zone:                   m.AvailabilityZone(),
-			Identity:               m.AzureMachine.Spec.Identity,
-			UserAssignedIdentities: m.AzureMachine.Spec.UserAssignedIdentities,
-			SpotVMOptions:          m.AzureMachine.Spec.SpotVMOptions,
-			SecurityProfile:        m.AzureMachine.Spec.SecurityProfile,
-		},
+// VMSpec returns the VM spec.
+func (m *MachineScope) VMSpec() azure.VMSpec {
+	return azure.VMSpec{
+		Name:                   m.Name(),
+		Role:                   m.Role(),
+		NICNames:               m.NICNames(),
+		SSHKeyData:             m.AzureMachine.Spec.SSHPublicKey,
+		Size:                   m.AzureMachine.Spec.VMSize,
+		OSDisk:                 m.AzureMachine.Spec.OSDisk,
+		DataDisks:              m.AzureMachine.Spec.DataDisks,
+		Zone:                   m.AvailabilityZone(),
+		Identity:               m.AzureMachine.Spec.Identity,
+		UserAssignedIdentities: m.AzureMachine.Spec.UserAssignedIdentities,
+		SpotVMOptions:          m.AzureMachine.Spec.SpotVMOptions,
+		SecurityProfile:        m.AzureMachine.Spec.SecurityProfile,
 	}
 }
 

--- a/cloud/scope/managedcontrolplane.go
+++ b/cloud/scope/managedcontrolplane.go
@@ -157,14 +157,12 @@ func (s *ManagedControlPlaneScope) Vnet() *infrav1.VnetSpec {
 	}
 }
 
-// VNetSpecs returns the virtual network specs.
-func (s *ManagedControlPlaneScope) VNetSpecs() []azure.VNetSpec {
-	return []azure.VNetSpec{
-		{
-			ResourceGroup: s.Vnet().ResourceGroup,
-			Name:          s.Vnet().Name,
-			CIDRs:         s.Vnet().CIDRBlocks,
-		},
+// VNetSpec returns the virtual network spec.
+func (s *ManagedControlPlaneScope) VNetSpec() azure.VNetSpec {
+	return azure.VNetSpec{
+		ResourceGroup: s.Vnet().ResourceGroup,
+		Name:          s.Vnet().Name,
+		CIDRs:         s.Vnet().CIDRBlocks,
 	}
 }
 

--- a/cloud/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
+++ b/cloud/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
@@ -302,18 +302,18 @@ func (mr *MockVMScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockVMScope)(nil).AdditionalTags))
 }
 
-// VMSpecs mocks base method.
-func (m *MockVMScope) VMSpecs() []azure.VMSpec {
+// VMSpec mocks base method.
+func (m *MockVMScope) VMSpec() azure.VMSpec {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VMSpecs")
-	ret0, _ := ret[0].([]azure.VMSpec)
+	ret := m.ctrl.Call(m, "VMSpec")
+	ret0, _ := ret[0].(azure.VMSpec)
 	return ret0
 }
 
-// VMSpecs indicates an expected call of VMSpecs.
-func (mr *MockVMScopeMockRecorder) VMSpecs() *gomock.Call {
+// VMSpec indicates an expected call of VMSpec.
+func (mr *MockVMScopeMockRecorder) VMSpec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMSpecs", reflect.TypeOf((*MockVMScope)(nil).VMSpecs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMSpec", reflect.TypeOf((*MockVMScope)(nil).VMSpec))
 }
 
 // GetBootstrapData mocks base method.

--- a/cloud/services/virtualmachines/service.go
+++ b/cloud/services/virtualmachines/service.go
@@ -33,7 +33,7 @@ import (
 type VMScope interface {
 	logr.Logger
 	azure.ClusterDescriber
-	VMSpecs() []azure.VMSpec
+	VMSpec() azure.VMSpec
 	GetBootstrapData(ctx context.Context) (string, error)
 	GetVMImage() (*infrav1.Image, error)
 	SetAnnotation(string, string)

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -284,32 +284,30 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "can create a vm",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:       "my-vm",
-						Role:       infrav1.ControlPlane,
-						NICNames:   []string{"my-nic", "second-nic"},
-						SSHKeyData: "ZmFrZXNzaGtleQo=",
-						Size:       "Standard_D2v3",
-						Zone:       "1",
-						Identity:   infrav1.VMIdentityNone,
-						OSDisk: infrav1.OSDisk{
-							OSType:     "Linux",
-							DiskSizeGB: 128,
-							ManagedDisk: infrav1.ManagedDisk{
-								StorageAccountType: "Premium_LRS",
-							},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:       "my-vm",
+					Role:       infrav1.ControlPlane,
+					NICNames:   []string{"my-nic", "second-nic"},
+					SSHKeyData: "ZmFrZXNzaGtleQo=",
+					Size:       "Standard_D2v3",
+					Zone:       "1",
+					Identity:   infrav1.VMIdentityNone,
+					OSDisk: infrav1.OSDisk{
+						OSType:     "Linux",
+						DiskSizeGB: 128,
+						ManagedDisk: infrav1.ManagedDisk{
+							StorageAccountType: "Premium_LRS",
 						},
-						DataDisks: []infrav1.DataDisk{
-							{
-								NameSuffix: "mydisk",
-								DiskSizeGB: 64,
-								Lun:        to.Int32Ptr(0),
-							},
-						},
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
 					},
+					DataDisks: []infrav1.DataDisk{
+						{
+							NameSuffix: "mydisk",
+							DiskSizeGB: 64,
+							Lun:        to.Int32Ptr(0),
+						},
+					},
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -439,20 +437,18 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "can create a vm with system assigned identity",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:                   "my-vm",
-						Role:                   infrav1.Node,
-						NICNames:               []string{"my-nic"},
-						SSHKeyData:             "fakesshpublickey",
-						Size:                   "Standard_D2v3",
-						Zone:                   "",
-						Identity:               infrav1.VMIdentitySystemAssigned,
-						OSDisk:                 infrav1.OSDisk{},
-						DataDisks:              nil,
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
-					},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:                   "my-vm",
+					Role:                   infrav1.Node,
+					NICNames:               []string{"my-nic"},
+					SSHKeyData:             "fakesshpublickey",
+					Size:                   "Standard_D2v3",
+					Zone:                   "",
+					Identity:               infrav1.VMIdentitySystemAssigned,
+					OSDisk:                 infrav1.OSDisk{},
+					DataDisks:              nil,
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -511,20 +507,18 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "can create a vm with user assigned identity",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:                   "my-vm",
-						Role:                   infrav1.Node,
-						NICNames:               []string{"my-nic"},
-						SSHKeyData:             "fakesshpublickey",
-						Size:                   "Standard_D2v3",
-						Zone:                   "",
-						Identity:               infrav1.VMIdentityUserAssigned,
-						OSDisk:                 infrav1.OSDisk{},
-						DataDisks:              nil,
-						UserAssignedIdentities: []infrav1.UserAssignedIdentity{{ProviderID: "my-user-id"}},
-						SpotVMOptions:          nil,
-					},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:                   "my-vm",
+					Role:                   infrav1.Node,
+					NICNames:               []string{"my-nic"},
+					SSHKeyData:             "fakesshpublickey",
+					Size:                   "Standard_D2v3",
+					Zone:                   "",
+					Identity:               infrav1.VMIdentityUserAssigned,
+					OSDisk:                 infrav1.OSDisk{},
+					DataDisks:              nil,
+					UserAssignedIdentities: []infrav1.UserAssignedIdentity{{ProviderID: "my-user-id"}},
+					SpotVMOptions:          nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -583,20 +577,18 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "can create a spot vm",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:                   "my-vm",
-						Role:                   infrav1.Node,
-						NICNames:               []string{"my-nic"},
-						SSHKeyData:             "fakesshpublickey",
-						Size:                   "Standard_D2v3",
-						Zone:                   "",
-						Identity:               "",
-						OSDisk:                 infrav1.OSDisk{},
-						DataDisks:              nil,
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          &infrav1.SpotVMOptions{},
-					},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:                   "my-vm",
+					Role:                   infrav1.Node,
+					NICNames:               []string{"my-nic"},
+					SSHKeyData:             "fakesshpublickey",
+					Size:                   "Standard_D2v3",
+					Zone:                   "",
+					Identity:               "",
+					OSDisk:                 infrav1.OSDisk{},
+					DataDisks:              nil,
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          &infrav1.SpotVMOptions{},
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -656,26 +648,24 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "can create a vm with encryption",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:       "my-vm",
-						Role:       infrav1.Node,
-						NICNames:   []string{"my-nic"},
-						SSHKeyData: "fakesshpublickey",
-						Size:       "Standard_D2v3",
-						Zone:       "",
-						Identity:   "",
-						OSDisk: infrav1.OSDisk{
-							ManagedDisk: infrav1.ManagedDisk{
-								StorageAccountType: "Premium_LRS",
-								DiskEncryptionSet: &infrav1.DiskEncryptionSetParameters{
-									ID: "my-diskencryptionset-id",
-								},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:       "my-vm",
+					Role:       infrav1.Node,
+					NICNames:   []string{"my-nic"},
+					SSHKeyData: "fakesshpublickey",
+					Size:       "Standard_D2v3",
+					Zone:       "",
+					Identity:   "",
+					OSDisk: infrav1.OSDisk{
+						ManagedDisk: infrav1.ManagedDisk{
+							StorageAccountType: "Premium_LRS",
+							DiskEncryptionSet: &infrav1.DiskEncryptionSetParameters{
+								ID: "my-diskencryptionset-id",
 							},
 						},
-						DataDisks:              nil,
-						UserAssignedIdentities: nil,
 					},
+					DataDisks:              nil,
+					UserAssignedIdentities: nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -734,16 +724,14 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "can create a vm with encryption at host",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:            "my-vm",
-						Role:            infrav1.Node,
-						NICNames:        []string{"my-nic"},
-						SSHKeyData:      "fakesshpublickey",
-						Size:            "Standard_D2v3",
-						OSDisk:          infrav1.OSDisk{},
-						SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: to.BoolPtr(true)},
-					},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:            "my-vm",
+					Role:            infrav1.Node,
+					NICNames:        []string{"my-nic"},
+					SSHKeyData:      "fakesshpublickey",
+					Size:            "Standard_D2v3",
+					OSDisk:          infrav1.OSDisk{},
+					SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: to.BoolPtr(true)},
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -806,16 +794,14 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "creating a vm with encryption at host enabled for unsupported VM type fails",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:            "my-vm",
-						Role:            infrav1.Node,
-						NICNames:        []string{"my-nic"},
-						SSHKeyData:      "fakesshpublickey",
-						Size:            "Standard_D2v3",
-						OSDisk:          infrav1.OSDisk{},
-						SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: to.BoolPtr(true)},
-					},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:            "my-vm",
+					Role:            infrav1.Node,
+					NICNames:        []string{"my-nic"},
+					SSHKeyData:      "fakesshpublickey",
+					Size:            "Standard_D2v3",
+					OSDisk:          infrav1.OSDisk{},
+					SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: to.BoolPtr(true)},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
@@ -864,20 +850,18 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "vm creation fails",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:                   "my-vm",
-						Role:                   infrav1.ControlPlane,
-						NICNames:               []string{"my-nic"},
-						SSHKeyData:             "fakesshpublickey",
-						Size:                   "Standard_D2v3",
-						Zone:                   "",
-						Identity:               "",
-						OSDisk:                 infrav1.OSDisk{},
-						DataDisks:              nil,
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
-					},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:                   "my-vm",
+					Role:                   infrav1.ControlPlane,
+					NICNames:               []string{"my-nic"},
+					SSHKeyData:             "fakesshpublickey",
+					Size:                   "Standard_D2v3",
+					Zone:                   "",
+					Identity:               "",
+					OSDisk:                 infrav1.OSDisk{},
+					DataDisks:              nil,
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -933,32 +917,30 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "cannot create vm if vCPU is less than 2",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:       "my-vm",
-						Role:       infrav1.ControlPlane,
-						NICNames:   []string{"my-nic", "second-nic"},
-						SSHKeyData: "ZmFrZXNzaGtleQo=",
-						Size:       "Standard_D1v3",
-						Zone:       "1",
-						Identity:   infrav1.VMIdentityNone,
-						OSDisk: infrav1.OSDisk{
-							OSType:     "Linux",
-							DiskSizeGB: 128,
-							ManagedDisk: infrav1.ManagedDisk{
-								StorageAccountType: "Premium_LRS",
-							},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:       "my-vm",
+					Role:       infrav1.ControlPlane,
+					NICNames:   []string{"my-nic", "second-nic"},
+					SSHKeyData: "ZmFrZXNzaGtleQo=",
+					Size:       "Standard_D1v3",
+					Zone:       "1",
+					Identity:   infrav1.VMIdentityNone,
+					OSDisk: infrav1.OSDisk{
+						OSType:     "Linux",
+						DiskSizeGB: 128,
+						ManagedDisk: infrav1.ManagedDisk{
+							StorageAccountType: "Premium_LRS",
 						},
-						DataDisks: []infrav1.DataDisk{
-							{
-								NameSuffix: "mydisk",
-								DiskSizeGB: 64,
-								Lun:        to.Int32Ptr(0),
-							},
-						},
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
 					},
+					DataDisks: []infrav1.DataDisk{
+						{
+							NameSuffix: "mydisk",
+							DiskSizeGB: 64,
+							Lun:        to.Int32Ptr(0),
+						},
+					},
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -1001,32 +983,30 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "cannot create vm if memory is less than 2Gi",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:       "my-vm",
-						Role:       infrav1.ControlPlane,
-						NICNames:   []string{"my-nic", "second-nic"},
-						SSHKeyData: "ZmFrZXNzaGtleQo=",
-						Size:       "Standard_D2v3",
-						Zone:       "1",
-						Identity:   infrav1.VMIdentityNone,
-						OSDisk: infrav1.OSDisk{
-							OSType:     "Linux",
-							DiskSizeGB: 128,
-							ManagedDisk: infrav1.ManagedDisk{
-								StorageAccountType: "Premium_LRS",
-							},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:       "my-vm",
+					Role:       infrav1.ControlPlane,
+					NICNames:   []string{"my-nic", "second-nic"},
+					SSHKeyData: "ZmFrZXNzaGtleQo=",
+					Size:       "Standard_D2v3",
+					Zone:       "1",
+					Identity:   infrav1.VMIdentityNone,
+					OSDisk: infrav1.OSDisk{
+						OSType:     "Linux",
+						DiskSizeGB: 128,
+						ManagedDisk: infrav1.ManagedDisk{
+							StorageAccountType: "Premium_LRS",
 						},
-						DataDisks: []infrav1.DataDisk{
-							{
-								NameSuffix: "mydisk",
-								DiskSizeGB: 64,
-								Lun:        to.Int32Ptr(0),
-							},
-						},
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
 					},
+					DataDisks: []infrav1.DataDisk{
+						{
+							NameSuffix: "mydisk",
+							DiskSizeGB: 64,
+							Lun:        to.Int32Ptr(0),
+						},
+					},
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -1069,35 +1049,33 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "cannot create vm if does not support ephemeral os",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:       "my-vm",
-						Role:       infrav1.ControlPlane,
-						NICNames:   []string{"my-nic", "second-nic"},
-						SSHKeyData: "ZmFrZXNzaGtleQo=",
-						Size:       "Standard_D2v3",
-						Zone:       "1",
-						Identity:   infrav1.VMIdentityNone,
-						OSDisk: infrav1.OSDisk{
-							OSType:     "Linux",
-							DiskSizeGB: 128,
-							ManagedDisk: infrav1.ManagedDisk{
-								StorageAccountType: "Premium_LRS",
-							},
-							DiffDiskSettings: &infrav1.DiffDiskSettings{
-								Option: string(compute.Local),
-							},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:       "my-vm",
+					Role:       infrav1.ControlPlane,
+					NICNames:   []string{"my-nic", "second-nic"},
+					SSHKeyData: "ZmFrZXNzaGtleQo=",
+					Size:       "Standard_D2v3",
+					Zone:       "1",
+					Identity:   infrav1.VMIdentityNone,
+					OSDisk: infrav1.OSDisk{
+						OSType:     "Linux",
+						DiskSizeGB: 128,
+						ManagedDisk: infrav1.ManagedDisk{
+							StorageAccountType: "Premium_LRS",
 						},
-						DataDisks: []infrav1.DataDisk{
-							{
-								NameSuffix: "mydisk",
-								DiskSizeGB: 64,
-								Lun:        to.Int32Ptr(0),
-							},
+						DiffDiskSettings: &infrav1.DiffDiskSettings{
+							Option: string(compute.Local),
 						},
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
 					},
+					DataDisks: []infrav1.DataDisk{
+						{
+							NameSuffix: "mydisk",
+							DiskSizeGB: 64,
+							Lun:        to.Int32Ptr(0),
+						},
+					},
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -1144,35 +1122,33 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "can create a vm with EphemeralOSDisk",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:       "my-vm",
-						Role:       infrav1.ControlPlane,
-						NICNames:   []string{"my-nic", "second-nic"},
-						SSHKeyData: "ZmFrZXNzaGtleQo=",
-						Size:       "Standard_D2v3",
-						Zone:       "1",
-						Identity:   infrav1.VMIdentityNone,
-						OSDisk: infrav1.OSDisk{
-							OSType:     "Linux",
-							DiskSizeGB: 128,
-							ManagedDisk: infrav1.ManagedDisk{
-								StorageAccountType: "Premium_LRS",
-							},
-							DiffDiskSettings: &infrav1.DiffDiskSettings{
-								Option: string(compute.Local),
-							},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:       "my-vm",
+					Role:       infrav1.ControlPlane,
+					NICNames:   []string{"my-nic", "second-nic"},
+					SSHKeyData: "ZmFrZXNzaGtleQo=",
+					Size:       "Standard_D2v3",
+					Zone:       "1",
+					Identity:   infrav1.VMIdentityNone,
+					OSDisk: infrav1.OSDisk{
+						OSType:     "Linux",
+						DiskSizeGB: 128,
+						ManagedDisk: infrav1.ManagedDisk{
+							StorageAccountType: "Premium_LRS",
 						},
-						DataDisks: []infrav1.DataDisk{
-							{
-								NameSuffix: "mydisk",
-								DiskSizeGB: 64,
-								Lun:        to.Int32Ptr(0),
-							},
+						DiffDiskSettings: &infrav1.DiffDiskSettings{
+							Option: string(compute.Local),
 						},
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
 					},
+					DataDisks: []infrav1.DataDisk{
+						{
+							NameSuffix: "mydisk",
+							DiskSizeGB: 64,
+							Lun:        to.Int32Ptr(0),
+						},
+					},
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -1309,32 +1285,30 @@ func TestReconcileVM(t *testing.T) {
 		{
 			Name: "can create a vm with a marketplace image using a plan",
 			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:       "my-vm",
-						Role:       infrav1.ControlPlane,
-						NICNames:   []string{"my-nic", "second-nic"},
-						SSHKeyData: "ZmFrZXNzaGtleQo=",
-						Size:       "Standard_D2v3",
-						Zone:       "1",
-						Identity:   infrav1.VMIdentityNone,
-						OSDisk: infrav1.OSDisk{
-							OSType:     "Linux",
-							DiskSizeGB: 128,
-							ManagedDisk: infrav1.ManagedDisk{
-								StorageAccountType: "Premium_LRS",
-							},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:       "my-vm",
+					Role:       infrav1.ControlPlane,
+					NICNames:   []string{"my-nic", "second-nic"},
+					SSHKeyData: "ZmFrZXNzaGtleQo=",
+					Size:       "Standard_D2v3",
+					Zone:       "1",
+					Identity:   infrav1.VMIdentityNone,
+					OSDisk: infrav1.OSDisk{
+						OSType:     "Linux",
+						DiskSizeGB: 128,
+						ManagedDisk: infrav1.ManagedDisk{
+							StorageAccountType: "Premium_LRS",
 						},
-						DataDisks: []infrav1.DataDisk{
-							{
-								NameSuffix: "mydisk",
-								DiskSizeGB: 64,
-								Lun:        to.Int32Ptr(0),
-							},
-						},
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
 					},
+					DataDisks: []infrav1.DataDisk{
+						{
+							NameSuffix: "mydisk",
+							DiskSizeGB: 64,
+							Lun:        to.Int32Ptr(0),
+						},
+					},
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -1514,20 +1488,18 @@ func TestDeleteVM(t *testing.T) {
 			name:          "successfully delete an existing vm",
 			expectedError: "",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:                   "my-existing-vm",
-						Role:                   infrav1.ControlPlane,
-						NICNames:               []string{"my-nic"},
-						SSHKeyData:             "fakesshpublickey",
-						Size:                   "Standard_D2v3",
-						Zone:                   "",
-						Identity:               "",
-						OSDisk:                 infrav1.OSDisk{},
-						DataDisks:              nil,
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
-					},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:                   "my-existing-vm",
+					Role:                   infrav1.ControlPlane,
+					NICNames:               []string{"my-nic"},
+					SSHKeyData:             "fakesshpublickey",
+					Size:                   "Standard_D2v3",
+					Zone:                   "",
+					Identity:               "",
+					OSDisk:                 infrav1.OSDisk{},
+					DataDisks:              nil,
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.ResourceGroup().AnyTimes().Return("my-existing-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
@@ -1538,20 +1510,18 @@ func TestDeleteVM(t *testing.T) {
 			name:          "vm already deleted",
 			expectedError: "",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:                   "my-vm",
-						Role:                   infrav1.ControlPlane,
-						NICNames:               []string{"my-nic"},
-						SSHKeyData:             "fakesshpublickey",
-						Size:                   "Standard_D2v3",
-						Zone:                   "",
-						Identity:               "",
-						OSDisk:                 infrav1.OSDisk{},
-						DataDisks:              nil,
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
-					},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:                   "my-vm",
+					Role:                   infrav1.ControlPlane,
+					NICNames:               []string{"my-nic"},
+					SSHKeyData:             "fakesshpublickey",
+					Size:                   "Standard_D2v3",
+					Zone:                   "",
+					Identity:               "",
+					OSDisk:                 infrav1.OSDisk{},
+					DataDisks:              nil,
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
@@ -1563,20 +1533,18 @@ func TestDeleteVM(t *testing.T) {
 			name:          "vm deletion fails",
 			expectedError: "failed to delete VM my-vm in resource group my-rg: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder) {
-				s.VMSpecs().Return([]azure.VMSpec{
-					{
-						Name:                   "my-vm",
-						Role:                   infrav1.ControlPlane,
-						NICNames:               []string{"my-nic"},
-						SSHKeyData:             "fakesshpublickey",
-						Size:                   "Standard_D2v3",
-						Zone:                   "",
-						Identity:               "",
-						OSDisk:                 infrav1.OSDisk{},
-						DataDisks:              nil,
-						UserAssignedIdentities: nil,
-						SpotVMOptions:          nil,
-					},
+				s.VMSpec().Return(azure.VMSpec{
+					Name:                   "my-vm",
+					Role:                   infrav1.ControlPlane,
+					NICNames:               []string{"my-nic"},
+					SSHKeyData:             "fakesshpublickey",
+					Size:                   "Standard_D2v3",
+					Zone:                   "",
+					Identity:               "",
+					OSDisk:                 infrav1.OSDisk{},
+					DataDisks:              nil,
+					UserAssignedIdentities: nil,
+					SpotVMOptions:          nil,
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())

--- a/cloud/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
+++ b/cloud/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
@@ -314,16 +314,16 @@ func (mr *MockVNetScopeMockRecorder) Vnet() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Vnet", reflect.TypeOf((*MockVNetScope)(nil).Vnet))
 }
 
-// VNetSpecs mocks base method.
-func (m *MockVNetScope) VNetSpecs() []azure.VNetSpec {
+// VNetSpec mocks base method.
+func (m *MockVNetScope) VNetSpec() azure.VNetSpec {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VNetSpecs")
-	ret0, _ := ret[0].([]azure.VNetSpec)
+	ret := m.ctrl.Call(m, "VNetSpec")
+	ret0, _ := ret[0].(azure.VNetSpec)
 	return ret0
 }
 
-// VNetSpecs indicates an expected call of VNetSpecs.
-func (mr *MockVNetScopeMockRecorder) VNetSpecs() *gomock.Call {
+// VNetSpec indicates an expected call of VNetSpec.
+func (mr *MockVNetScopeMockRecorder) VNetSpec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VNetSpecs", reflect.TypeOf((*MockVNetScope)(nil).VNetSpecs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VNetSpec", reflect.TypeOf((*MockVNetScope)(nil).VNetSpec))
 }

--- a/cloud/services/virtualnetworks/service.go
+++ b/cloud/services/virtualnetworks/service.go
@@ -28,7 +28,7 @@ type VNetScope interface {
 	logr.Logger
 	azure.ClusterDescriber
 	Vnet() *infrav1.VnetSpec
-	VNetSpecs() []azure.VNetSpec
+	VNetSpec() azure.VNetSpec
 }
 
 // Service provides operations on azure resources

--- a/cloud/services/virtualnetworks/virtualnetworks_test.go
+++ b/cloud/services/virtualnetworks/virtualnetworks_test.go
@@ -47,12 +47,10 @@ func TestReconcileVnet(t *testing.T) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.ClusterName().AnyTimes().Return("fake-cluster")
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "vnet-exists"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "my-rg",
-						Name:          "vnet-exists",
-						CIDRs:         []string{"10.0.0.0/8"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "my-rg",
+					Name:          "vnet-exists",
+					CIDRs:         []string{"10.0.0.0/8"},
 				})
 				m.Get(gomockinternal.AContext(), "my-rg", "vnet-exists").
 					Return(network.VirtualNetwork{
@@ -78,12 +76,10 @@ func TestReconcileVnet(t *testing.T) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.ClusterName().AnyTimes().Return("fake-cluster")
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "vnet-exists"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "my-rg",
-						Name:          "ipv6-vnet-exists",
-						CIDRs:         []string{"10.0.0.0/8", "2001:1234:5678:9a00::/56"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "my-rg",
+					Name:          "ipv6-vnet-exists",
+					CIDRs:         []string{"10.0.0.0/8", "2001:1234:5678:9a00::/56"},
 				})
 				m.Get(gomockinternal.AContext(), "my-rg", "ipv6-vnet-exists").
 					Return(network.VirtualNetwork{
@@ -114,12 +110,10 @@ func TestReconcileVnet(t *testing.T) {
 				s.Location().AnyTimes().Return("fake-location")
 				s.AdditionalTags().AnyTimes().Return(infrav1.Tags{})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "vnet-new"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "my-rg",
-						Name:          "vnet-new",
-						CIDRs:         []string{"10.0.0.0/8"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "my-rg",
+					Name:          "vnet-new",
+					CIDRs:         []string{"10.0.0.0/8"},
 				})
 				m.Get(gomockinternal.AContext(), "my-rg", "vnet-new").
 					Return(network.VirtualNetwork{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
@@ -136,12 +130,10 @@ func TestReconcileVnet(t *testing.T) {
 				s.Location().AnyTimes().Return("fake-location")
 				s.AdditionalTags().AnyTimes().Return(infrav1.Tags{})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "vnet-new"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "my-rg",
-						Name:          "vnet-ipv6-new",
-						CIDRs:         []string{"10.0.0.0/8", "2001:1234:5678:9a00::/56"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "my-rg",
+					Name:          "vnet-ipv6-new",
+					CIDRs:         []string{"10.0.0.0/8", "2001:1234:5678:9a00::/56"},
 				})
 				m.Get(gomockinternal.AContext(), "my-rg", "vnet-ipv6-new").
 					Return(network.VirtualNetwork{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
@@ -172,12 +164,10 @@ func TestReconcileVnet(t *testing.T) {
 				s.ClusterName().AnyTimes().Return("fake-cluster")
 				s.Location().AnyTimes().Return("fake-location")
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "custom-vnet"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "custom-vnet-rg",
-						Name:          "custom-vnet",
-						CIDRs:         []string{"10.0.0.0/16"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "custom-vnet-rg",
+					Name:          "custom-vnet",
+					CIDRs:         []string{"10.0.0.0/16"},
 				})
 				m.Get(gomockinternal.AContext(), "custom-vnet-rg", "custom-vnet").
 					Return(network.VirtualNetwork{
@@ -203,12 +193,10 @@ func TestReconcileVnet(t *testing.T) {
 				s.Location().AnyTimes().Return("fake-location")
 				s.AdditionalTags().AnyTimes().Return(infrav1.Tags{})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "custom-vnet"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "custom-vnet-rg",
-						Name:          "custom-vnet",
-						CIDRs:         []string{"10.0.0.0/16"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "custom-vnet-rg",
+					Name:          "custom-vnet",
+					CIDRs:         []string{"10.0.0.0/16"},
 				})
 				m.Get(gomockinternal.AContext(), "custom-vnet-rg", "custom-vnet").
 					Return(network.VirtualNetwork{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
@@ -222,12 +210,10 @@ func TestReconcileVnet(t *testing.T) {
 			expect: func(s *mock_virtualnetworks.MockVNetScopeMockRecorder, m *mock_virtualnetworks.MockClientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.ClusterName().AnyTimes().Return("fake-cluster")
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "custom-vnet-rg",
-						Name:          "custom-vnet",
-						CIDRs:         []string{"10.0.0.0/16"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "custom-vnet-rg",
+					Name:          "custom-vnet",
+					CIDRs:         []string{"10.0.0.0/16"},
 				})
 				m.Get(gomockinternal.AContext(), "custom-vnet-rg", "custom-vnet").
 					Return(network.VirtualNetwork{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
@@ -242,12 +228,10 @@ func TestReconcileVnet(t *testing.T) {
 				s.Location().AnyTimes().Return("fake-location")
 				s.AdditionalTags().AnyTimes().Return(infrav1.Tags{})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "custom-vnet"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "custom-vnet-rg",
-						Name:          "custom-vnet",
-						CIDRs:         []string{"10.0.0.0/16"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "custom-vnet-rg",
+					Name:          "custom-vnet",
+					CIDRs:         []string{"10.0.0.0/16"},
 				})
 				m.Get(gomockinternal.AContext(), "custom-vnet-rg", "custom-vnet").
 					Return(network.VirtualNetwork{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
@@ -305,12 +289,10 @@ func TestDeleteVnet(t *testing.T) {
 					"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
 				})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "vnet-exists"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "my-rg",
-						Name:          "vnet-exists",
-						CIDRs:         []string{"10.0.0.0/16"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "my-rg",
+					Name:          "vnet-exists",
+					CIDRs:         []string{"10.0.0.0/16"},
 				})
 				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists")
 			},
@@ -328,12 +310,10 @@ func TestDeleteVnet(t *testing.T) {
 					"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
 				})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "vnet-exists"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "my-rg",
-						Name:          "vnet-exists",
-						CIDRs:         []string{"10.0.0.0/16"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "my-rg",
+					Name:          "vnet-exists",
+					CIDRs:         []string{"10.0.0.0/16"},
 				})
 				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists").
 					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
@@ -348,12 +328,10 @@ func TestDeleteVnet(t *testing.T) {
 				s.Location().AnyTimes().Return("fake-location")
 				s.AdditionalTags().AnyTimes().Return(infrav1.Tags{})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{ResourceGroup: "my-rg", Name: "my-vnet", ID: "azure/custom-vnet/id"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "my-rg",
-						Name:          "my-vnet",
-						CIDRs:         []string{"10.0.0.0/16"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "my-rg",
+					Name:          "my-vnet",
+					CIDRs:         []string{"10.0.0.0/16"},
 				})
 			},
 		},
@@ -370,12 +348,10 @@ func TestDeleteVnet(t *testing.T) {
 					"sigs.k8s.io_cluster-api-provider-azure_role":                 "common",
 				})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "vnet-exists"})
-				s.VNetSpecs().Return([]azure.VNetSpec{
-					{
-						ResourceGroup: "my-rg",
-						Name:          "vnet-exists",
-						CIDRs:         []string{"10.0.0.0/16"},
-					},
+				s.VNetSpec().Return(azure.VNetSpec{
+					ResourceGroup: "my-rg",
+					Name:          "vnet-exists",
+					CIDRs:         []string{"10.0.0.0/16"},
 				})
 				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists").
 					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Honk Server"))


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Follow up from https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1012#issuecomment-718293779. There should only be one VM per AzureMachine and one VNet per AzureCluster so the service should not rely on an array of specs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cleanup: VM and VNet spec no longer return arrays
```
