### PR TITLE
🐛 fix e2e skip for local testing

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -124,18 +124,18 @@ var _ = Describe("Workload cluster creation", func() {
 					AzurePrivateClusterSpec(ctx, func() AzurePrivateClusterSpecInput {
 						return AzurePrivateClusterSpecInput{
 							BootstrapClusterProxy: bootstrapClusterProxy,
-							Namespace:            namespace,
-							ClusterName:          clusterName,
-							ClusterctlConfigPath: clusterctlConfigPath,
-							E2EConfig:            e2eConfig,
-							ArtifactFolder:       artifactFolder,
+							Namespace:             namespace,
+							ClusterName:           clusterName,
+							ClusterctlConfigPath:  clusterctlConfigPath,
+							E2EConfig:             e2eConfig,
+							ArtifactFolder:        artifactFolder,
 						}
 					})
 				})
 			})
 		})
 	} else {
-		Skip("test requires pushing container images to external repository")
+		fmt.Fprintf(GinkgoWriter, "INFO: skipping test requires pushing container images to external repository")
 	}
 
 	It("With 3 control-plane nodes and 2 worker nodes", func() {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

You can't use Skip() outside of a Ginkgo It/Context block I believe, or anyway I got panics when trying to run `./scripts/ci-e2e.sh` locally. Switch to simply log an error. Alternatively, we can move the Skip() inside the It() (or maybe Context()?) in case we want ginkgo to be aware of this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
