### PR TITLE
Handle terminal errors to prevent reconciliation failure loop

### DIFF
--- a/cloud/services/scalesets/scalesets.go
+++ b/cloud/services/scalesets/scalesets.go
@@ -407,7 +407,7 @@ func getSecurityProfile(vmssSpec azure.ScaleSetSpec, sku resourceskus.SKU) (*com
 	}
 
 	if !sku.HasCapability(resourceskus.EncryptionAtHost) {
-		return nil, errors.Errorf("encryption at host is not supported for VM type %s", vmssSpec.Size)
+		return nil, azure.WithTerminalError(errors.Errorf("encryption at host is not supported for VM type %s", vmssSpec.Size))
 	}
 
 	return &compute.SecurityProfile{

--- a/cloud/services/scalesets/scalesets_test.go
+++ b/cloud/services/scalesets/scalesets_test.go
@@ -973,7 +973,7 @@ func TestReconcileVMSS(t *testing.T) {
 		},
 		{
 			name:          "creating a vmss with encryption at host enabled for unsupported VM type fails",
-			expectedError: "encryption at host is not supported for VM type VM_SIZE",
+			expectedError: "reconcile error occurred that cannot be recovered. Object will not be requeued. The actual error is: encryption at host is not supported for VM type VM_SIZE",
 			expect: func(g *gomega.WithT, s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
 				s.ScaleSetSpec().Return(azure.ScaleSetSpec{
 					Name:            "my-vmss",

--- a/cloud/services/virtualmachines/virtualmachines.go
+++ b/cloud/services/virtualmachines/virtualmachines.go
@@ -458,7 +458,7 @@ func getSecurityProfile(vmSpec azure.VMSpec, sku resourceskus.SKU) (*compute.Sec
 	}
 
 	if !sku.HasCapability(resourceskus.EncryptionAtHost) {
-		return nil, errors.Errorf("encryption at host is not supported for VM type %s", vmSpec.Size)
+		return nil, azure.WithTerminalError(errors.Errorf("encryption at host is not supported for VM type %s", vmSpec.Size))
 	}
 
 	return &compute.SecurityProfile{

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -823,7 +823,7 @@ func TestReconcileVM(t *testing.T) {
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
-			ExpectedError: "encryption at host is not supported for VM type Standard_D2v3",
+			ExpectedError: "reconcile error occurred that cannot be recovered. Object will not be requeued. The actual error is: encryption at host is not supported for VM type Standard_D2v3",
 			SetupSKUs: func(svc *Service) {
 				skus := []compute.ResourceSku{
 					{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
This PR introduces a new error type `TerminalError` to handle failures that won't get fixed automatically. 
- Introduces new error type `TerminalError`
- Prevents requeue if there is a terminal error
-  Return terminal error for `encryption at host is not supported` use case

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1014 

**Special notes for your reviewer**:

The PR is still a WIP to get a confirmation on the approach. Also, there is a [discussion](https://kubernetes.slack.com/archives/C8TSNPY4T/p1605026393254100) going on to update conditions to indicate terminal errors.

Only `encryption not supported` error is marked as terminal for now. If this approach is finalized, there should be a followup for identifying and handling other possible terminal errors.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Handle terminal errors to prevent reconciliation failure loop
```
