### PR TITLE
Prevent vm recreation if it was deleted outside of capz

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -200,6 +200,9 @@ const (
 	VMStateSucceeded VMState = "Succeeded"
 	// VMStateUpdating ...
 	VMStateUpdating VMState = "Updating"
+	// VMStateDeleted represents a deleted VM
+	// NOTE: This state is specific to capz, and does not have corresponding mapping in Azure API (https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle#provisioning-states)
+	VMStateDeleted VMState = "Deleted"
 )
 
 // VM describes an Azure virtual machine.

--- a/cloud/errors.go
+++ b/cloud/errors.go
@@ -30,3 +30,6 @@ func ResourceNotFound(err error) bool {
 	derr := autorest.DetailedError{}
 	return errors.As(err, &derr) && derr.StatusCode == 404
 }
+
+// VMDeletedError is returned when a virtual machine is deleted outside of capz
+type VMDeletedError error

--- a/cloud/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
+++ b/cloud/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
@@ -358,6 +358,20 @@ func (mr *MockVMScopeMockRecorder) SetAnnotation(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAnnotation", reflect.TypeOf((*MockVMScope)(nil).SetAnnotation), arg0, arg1)
 }
 
+// ProviderID mocks base method.
+func (m *MockVMScope) ProviderID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProviderID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ProviderID indicates an expected call of ProviderID.
+func (mr *MockVMScopeMockRecorder) ProviderID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderID", reflect.TypeOf((*MockVMScope)(nil).ProviderID))
+}
+
 // SetProviderID mocks base method.
 func (m *MockVMScope) SetProviderID(arg0 string) {
 	m.ctrl.T.Helper()

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -315,6 +315,7 @@ func TestReconcileVM(t *testing.T) {
 				s.AdditionalTags()
 				s.Location().Return("test-location")
 				s.ClusterName().Return("my-cluster")
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				s.GetVMImage().AnyTimes().Return(&infrav1.Image{
@@ -456,6 +457,7 @@ func TestReconcileVM(t *testing.T) {
 				s.AdditionalTags()
 				s.Location().Return("test-location")
 				s.ClusterName().Return("my-cluster")
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				s.GetVMImage().AnyTimes().Return(&infrav1.Image{
@@ -526,6 +528,7 @@ func TestReconcileVM(t *testing.T) {
 				s.AdditionalTags()
 				s.Location().Return("test-location")
 				s.ClusterName().Return("my-cluster")
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				s.GetVMImage().AnyTimes().Return(&infrav1.Image{
@@ -596,6 +599,7 @@ func TestReconcileVM(t *testing.T) {
 				s.AdditionalTags()
 				s.Location().Return("test-location")
 				s.ClusterName().Return("my-cluster")
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				s.GetVMImage().AnyTimes().Return(&infrav1.Image{
@@ -673,6 +677,7 @@ func TestReconcileVM(t *testing.T) {
 				s.AdditionalTags()
 				s.Location().Return("test-location")
 				s.ClusterName().Return("my-cluster")
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				s.GetVMImage().AnyTimes().Return(&infrav1.Image{
@@ -739,6 +744,7 @@ func TestReconcileVM(t *testing.T) {
 				s.AdditionalTags()
 				s.Location().Return("test-location")
 				s.ClusterName().Return("my-cluster")
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				s.GetVMImage().AnyTimes().Return(&infrav1.Image{
@@ -813,6 +819,7 @@ func TestReconcileVM(t *testing.T) {
 						Version:   "1.0",
 					},
 				}, nil)
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
@@ -869,6 +876,7 @@ func TestReconcileVM(t *testing.T) {
 				s.AdditionalTags()
 				s.Location().Return("test-location")
 				s.ClusterName().Return("my-cluster")
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				s.GetVMImage().AnyTimes().Return(&infrav1.Image{
@@ -945,6 +953,7 @@ func TestReconcileVM(t *testing.T) {
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
@@ -1011,6 +1020,7 @@ func TestReconcileVM(t *testing.T) {
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
@@ -1080,6 +1090,7 @@ func TestReconcileVM(t *testing.T) {
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
@@ -1156,6 +1167,7 @@ func TestReconcileVM(t *testing.T) {
 				s.AdditionalTags()
 				s.Location().Return("test-location")
 				s.ClusterName().Return("my-cluster")
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				s.GetVMImage().AnyTimes().Return(&infrav1.Image{
@@ -1316,6 +1328,7 @@ func TestReconcileVM(t *testing.T) {
 				s.AdditionalTags()
 				s.Location().Return("test-location")
 				s.ClusterName().Return("my-cluster")
+				s.ProviderID().Return("")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				s.GetVMImage().AnyTimes().Return(&infrav1.Image{
@@ -1439,6 +1452,23 @@ func TestReconcileVM(t *testing.T) {
 				resourceSkusCache := resourceskus.NewStaticCache(skus)
 				svc.resourceSKUCache = resourceSkusCache
 			},
+		},
+		{
+			Name: "fails when there is a provider id present, but cannot find vm ",
+			Expect: func(g *WithT, s *mock_virtualmachines.MockVMScopeMockRecorder, m *mock_virtualmachines.MockClientMockRecorder, mnic *mock_networkinterfaces.MockClientMockRecorder, mpip *mock_publicips.MockClientMockRecorder) {
+				s.VMSpec().Return(azure.VMSpec{
+					Name: "my-vm",
+				})
+				s.SubscriptionID().AnyTimes().Return("123")
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.ProviderID().Times(2).Return("ExistingVM-ProviderID")
+				s.SetVMState(infrav1.VMStateDeleted)
+				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
+					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+			},
+			ExpectedError: "VM with provider id \"ExistingVM-ProviderID\" has been deleted",
+			SetupSKUs:     func(svc *Service) {},
 		},
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
This PR prevents vm recreation if it was deleted outside of capz to stop from an endless failure loop. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1008 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent vm recreation if it was deleted outside of capz
```
