### PR TITLE
Remove failed provisioning VM deletion logic

### DIFF
--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -309,12 +309,6 @@ func (r *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineSco
 		machineScope.SetFailureMessage(errors.Errorf("Azure VM state is %s", machineScope.VMState()))
 		conditions.MarkFalse(machineScope.AzureMachine, infrav1.VMRunningCondition, infrav1.VMProvisionFailedReason, clusterv1.ConditionSeverityWarning, "")
 		machineScope.SetNotReady()
-		// If VM failed provisioning, delete it so it can be recreated
-		err := ams.DeleteVM(ctx)
-		if err != nil {
-			return reconcile.Result{}, errors.Wrapf(err, "failed to delete VM in a failed state")
-		}
-		return reconcile.Result{}, errors.Wrapf(err, "VM deleted, retry creating in next reconcile")
 	default:
 		machineScope.V(2).Info("VM state is undefined", "id", machineScope.GetVMID())
 		conditions.MarkUnknown(machineScope.AzureMachine, infrav1.VMRunningCondition, "", "")

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/tags"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 
@@ -119,16 +120,5 @@ func (s *azureMachineService) Delete(ctx context.Context) error {
 		return errors.Wrap(err, "failed to delete OS disk")
 	}
 
-	return nil
-}
-
-// Delete deletes the VM and its disk so it can be replaced.
-func (s *azureMachineService) DeleteVM(ctx context.Context) error {
-	if err := s.virtualMachinesSvc.Delete(ctx); err != nil {
-		return errors.Wrapf(err, "failed to delete machine")
-	}
-	if err := s.disksSvc.Delete(ctx); err != nil {
-		return errors.Wrap(err, "failed to delete OS disk")
-	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes the vm deletion logic. 

> There is a piece of code in azure machine reconciliation which deletes the VM if it's in a Failed state. The expectation is that it'll create a new VM in the next reconcile run. But with FailureReason being set before that, this will not happen and will return early in the next run.

**Which issue(s) this PR fixes**
Fixes #1037

**Release note**:
```release-note
Remove failed provisioning VM deletion logic
```
