### PR TITLE
Parse identity parameter correctly in kubectl-capz-ssh

### DIFF
--- a/hack/debugging/kubectl-capz-ssh
+++ b/hack/debugging/kubectl-capz-ssh
@@ -16,7 +16,7 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     shift; user=$1
     ;;
   -i | --identity )
-    shift; user=$1
+    shift; identity=$1
     ;;
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi


### PR DESCRIPTION
**What type of PR is this?**
/kind other

**What this PR does / why we need it**:
Parses identity parameter correctly in [kubectl-capz-ssh](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/64c6f5320fb074da5b272d22917248153c7461fd/hack/debugging/kubectl-capz-ssh#L19)

**Which issue(s) this PR fixes** 
Fixes #1054

**Release note**:
```release-note
NONE
```
