### PR TITLE
update error statement to not show stacktrace in resource status

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -63,12 +63,12 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 
 	err := params.AzureClients.setCredentials(params.AzureCluster.Spec.SubscriptionID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to configure azure settings and credentials from environment")
+		return nil, err
 	}
 
 	helper, err := patch.NewHelper(params.AzureCluster, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, errors.Errorf("failed to init patch helper: %v", err)
 	}
 
 	return &ClusterScope{

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -65,7 +65,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 
 	helper, err := patch.NewHelper(params.AzureMachine, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, errors.Errorf("failed to init patch helper: %v ", err)
 	}
 	return &MachineScope{
 		client:        params.Client,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind bug

**What this PR does / why we need it**:
- update error statement from `Wrapf` to `Errorf` so stacktrace is not shown in the `azurecluster` status when using `kubectl get -o yaml`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1031 


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
