### PR TITLE
vmss: Use computer name and add it to the status

### DIFF
--- a/cloud/converters/vmss.go
+++ b/cloud/converters/vmss.go
@@ -51,7 +51,7 @@ func SDKToVMSS(sdkvmss compute.VirtualMachineScaleSet, sdkinstances []compute.Vi
 			instance := infrav1exp.VMSSVM{
 				ID:         to.String(vm.ID),
 				InstanceID: to.String(vm.InstanceID),
-				Name:       to.String(vm.Name),
+				Name:       to.String(vm.OsProfile.ComputerName),
 				State:      infrav1.VMState(to.String(vm.ProvisioningState)),
 			}
 

--- a/cloud/converters/vmss_test.go
+++ b/cloud/converters/vmss_test.go
@@ -64,6 +64,9 @@ func Test_SDKToVMSS(t *testing.T) {
 							Zones:      to.StringSlicePtr([]string{"zone0"}),
 							VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 								ProvisioningState: to.StringPtr(string(compute.ProvisioningState1Succeeded)),
+								OsProfile: &compute.OSProfile{
+									ComputerName: to.StringPtr("instance-000000"),
+								},
 							},
 						},
 						{
@@ -73,6 +76,9 @@ func Test_SDKToVMSS(t *testing.T) {
 							Zones:      to.StringSlicePtr([]string{"zone1"}),
 							VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 								ProvisioningState: to.StringPtr(string(compute.ProvisioningState1Succeeded)),
+								OsProfile: &compute.OSProfile{
+									ComputerName: to.StringPtr("instance-000001"),
+								},
 							},
 						},
 					}
@@ -95,7 +101,7 @@ func Test_SDKToVMSS(t *testing.T) {
 					expected.Instances[i] = infrav1exp.VMSSVM{
 						ID:               fmt.Sprintf("vm/%d", i),
 						InstanceID:       fmt.Sprintf("%d", i),
-						Name:             fmt.Sprintf("vm%d", i),
+						Name:             fmt.Sprintf("instance-00000%d", i),
 						AvailabilityZone: fmt.Sprintf("zone%d", i),
 						State:            "Succeeded",
 					}

--- a/cloud/scope/machinepool.go
+++ b/cloud/scope/machinepool.go
@@ -175,6 +175,7 @@ func (m *MachinePoolScope) UpdateInstanceStatuses(ctx context.Context, instances
 		instanceStatuses[i] = &infrav1exp.AzureMachinePoolInstanceStatus{
 			ProviderID:        fmt.Sprintf("azure://%s", instance.ID),
 			InstanceID:        instance.InstanceID,
+			InstanceName:      instance.Name,
 			ProvisioningState: &instance.State,
 		}
 

--- a/cloud/services/scalesets/scalesets_test.go
+++ b/cloud/services/scalesets/scalesets_test.go
@@ -118,8 +118,8 @@ func TestGetExistingVMSS(t *testing.T) {
 				Instances: []infrav1exp.VMSSVM{
 					{
 						ID:         "id-1",
-						InstanceID: "id-2",
-						Name:       "instance-0",
+						InstanceID: "1",
+						Name:       "instance-000001",
 						State:      "Succeeded",
 					},
 				},
@@ -141,12 +141,15 @@ func TestGetExistingVMSS(t *testing.T) {
 				}, nil)
 				m.ListInstances(gomockinternal.AContext(), "my-rg", "my-vmss").Return([]compute.VirtualMachineScaleSetVM{
 					{
-						InstanceID: to.StringPtr("id-2"),
+						InstanceID: to.StringPtr("1"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							ProvisioningState: to.StringPtr("Succeeded"),
+							OsProfile: &compute.OSProfile{
+								ComputerName: to.StringPtr("instance-000001"),
+							},
 						},
 						ID:   to.StringPtr("id-1"),
-						Name: to.StringPtr("instance-0"),
+						Name: to.StringPtr("instance-0_1"),
 					},
 				}, nil)
 			},
@@ -261,6 +264,9 @@ func TestReconcileVMSS(t *testing.T) {
 						Name:       to.StringPtr("my-vm"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							ProvisioningState: to.StringPtr("Succeeded"),
+							OsProfile: &compute.OSProfile{
+								ComputerName: to.StringPtr("instance-000001"),
+							},
 						},
 					},
 				}, nil)
@@ -430,6 +436,9 @@ func TestReconcileVMSS(t *testing.T) {
 						Name:       to.StringPtr("my-vm"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							ProvisioningState: to.StringPtr("Succeeded"),
+							OsProfile: &compute.OSProfile{
+								ComputerName: to.StringPtr("instance-000001"),
+							},
 						},
 					},
 				}, nil)
@@ -594,6 +603,9 @@ func TestReconcileVMSS(t *testing.T) {
 						Name:       to.StringPtr("my-vm"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							ProvisioningState: to.StringPtr("Succeeded"),
+							OsProfile: &compute.OSProfile{
+								ComputerName: to.StringPtr("instance-000001"),
+							},
 						},
 					},
 				}, nil)
@@ -870,6 +882,9 @@ func TestReconcileVMSS(t *testing.T) {
 						InstanceID: to.StringPtr("id-2"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							ProvisioningState: to.StringPtr("Succeeded"),
+							OsProfile: &compute.OSProfile{
+								ComputerName: to.StringPtr("instance-000001"),
+							},
 						},
 						ID:   to.StringPtr("id-1"),
 						Name: to.StringPtr("instance-0"),
@@ -943,6 +958,9 @@ func TestReconcileVMSS(t *testing.T) {
 						Name:       to.StringPtr("my-vm"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							ProvisioningState: to.StringPtr("Succeeded"),
+							OsProfile: &compute.OSProfile{
+								ComputerName: to.StringPtr("instance-000001"),
+							},
 						},
 					},
 				}, nil)
@@ -1125,6 +1143,9 @@ func TestReconcileVMSS(t *testing.T) {
 						InstanceID: to.StringPtr("id-2"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							ProvisioningState: to.StringPtr("Succeeded"),
+							OsProfile: &compute.OSProfile{
+								ComputerName: to.StringPtr("instance-000001"),
+							},
 						},
 						ID:   to.StringPtr("id-1"),
 						Name: to.StringPtr("instance-0"),
@@ -1294,6 +1315,9 @@ func TestReconcileVMSS(t *testing.T) {
 						InstanceID: to.StringPtr("id-2"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							ProvisioningState: to.StringPtr("Succeeded"),
+							OsProfile: &compute.OSProfile{
+								ComputerName: to.StringPtr("instance-000001"),
+							},
 						},
 						ID:   to.StringPtr("id-1"),
 						Name: to.StringPtr("instance-0"),
@@ -1383,6 +1407,9 @@ func TestReconcileVMSS(t *testing.T) {
 						Name:       to.StringPtr("my-vm"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							ProvisioningState: to.StringPtr("Succeeded"),
+							OsProfile: &compute.OSProfile{
+								ComputerName: to.StringPtr("instance-000001"),
+							},
 						},
 					},
 				}, nil)

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -441,9 +441,13 @@ spec:
                   description: AzureMachinePoolInstanceStatus provides status information
                     for each instance in the VMSS
                   properties:
-                    instanceName:
+                    instanceID:
                       description: InstanceID is the identification of the Machine
                         Instance within the VMSS
+                      type: string
+                    instanceName:
+                      description: InstanceName is the name of the Machine Instance
+                        within the VMSS
                       type: string
                     latestModelApplied:
                       description: LatestModelApplied indicates the instance is running

--- a/exp/api/v1alpha3/azuremachinepool_types.go
+++ b/exp/api/v1alpha3/azuremachinepool_types.go
@@ -194,7 +194,11 @@ type (
 
 		// InstanceID is the identification of the Machine Instance within the VMSS
 		// +optional
-		InstanceID string `json:"instanceName"`
+		InstanceID string `json:"instanceID"`
+
+		// InstanceName is the name of the Machine Instance within the VMSS
+		// +optional
+		InstanceName string `json:"instanceName"`
 
 		// LatestModelApplied indicates the instance is running the most up-to-date VMSS model. A VMSS model describes
 		// the image version the VM is running. If the instance is not running the latest model, it means the instance


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature
/kind cleanup

**What this PR does / why we need it**:
vmss: Use computer name and add it to the status

Currently, if you check the `Name` field of a VMSS it returns something like `machinepool-template-mp-0_1` and if you try to use the SSH this is not a valid hostname in the Vpc. you will need to use the Computername in that case.

Checking the code this is not used in any place, so I guess it is safe to replace

If this change we get the name as `machinepool-template-mp-0000001` which is valid as a hostname and you can ssh for example.


If we cannot replace this we can create another field called ComputerName and add it to the struct. This is open for discussion if needed.

Also, this PR adds the node name in the status field for the `azuremachinepools.exp.infrastructure.cluster.x-k8s.io` response.

/assign @CecileRobertMichon 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1068

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vmss: Use computer name and add it to the status
```
