### PR TITLE
debug/kubectl-capz-ssh: add AzureMachinePools option to ssh in the vmss nodes

### DIFF
--- a/hack/debugging/Readme.md
+++ b/hack/debugging/Readme.md
@@ -7,18 +7,21 @@ Any scripts that start with kubectl can be used as [kubectl plugins](https://kub
 
 To use as plugins, copy the files to a folder in your path such as:
 
-```shell
+```bash
 cp hack/debugging/kubectl-* /usr/local/bin
 ```
 
 To use as a script:
 
-```
+```bash
 ./hack/debugging/kubectl-capz-ssh
 ```
 
 ### capz-ssh
 Quickly ssh to a node to debug VM join issues.
+
+
+To connect to an Azure Machine:
 
 ```bash
 # find the azure cluster and azure machine you wish to ssh too
@@ -34,13 +37,35 @@ capz-cluster-0-md-0-wbx2r            true    Succeeded
 $ kubectl capz ssh -am capz-cluster-3-control-plane-rcmkh
 ```
 
+To connect to an instance of Azure Machine Pool, you can do the following:
+
+- If you don't know the instance name you can run the list command to get all
+instances of a Machine Pool
+
+```bash
+$ ./hack/debugging/kubectl-capz-ssh  --list-azure-machine-pool  --azure-machine-pool machinepool-template-mp-0
+Utility tool to ssh'ing into CAPZ nodes
+
+Listing Azure Machine Pool machinepool-template-mp-0
+ID      ComputerName
+========================================
+2       machinepool-template-mp-0000002
+3       machinepool-template-mp-0000003
+```
+
+- Then you can connect to a node using the `ID`
+
+```bash
+$ ./hack/debugging/kubectl-capz-ssh  --azure-machine-pool machinepool-template-mp-0 --azure-machine-pool-id 2
+```
+
 ### capz-map
 There are many different CRDs required to deploy a machine (such as azmachine, capimachine, and kubeadm bootstrap).  View how all the configurations are mapped together:
 
 ```bash
 $ kubectl capz map
 AzureCluster: capz-cluster-0
-	AzureMachine: capz-cluster-0-control-plane-5b5fc
-	Machine: capz-cluster-0-control-plane-xhbjh
-	Kubeadmconfig: capz-cluster-0-control-plane-g8gql
+AzureMachine: capz-cluster-0-control-plane-5b5fc
+Machine: capz-cluster-0-control-plane-xhbjh
+Kubeadmconfig: capz-cluster-0-control-plane-g8gql
 ```

--- a/hack/debugging/kubectl-capz-ssh
+++ b/hack/debugging/kubectl-capz-ssh
@@ -1,34 +1,112 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 azurecluster="capz-cluster"
 user="capi"
 identity=~/.ssh/id_rsa
 
-while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
-  -V | --version )
-    echo $version
-    exit
-    ;;
-  -am | --azure-machine )
-    shift; azuremachine=$1
-    ;;
-  -u | --user )
-    shift; user=$1
-    ;;
-  -i | --identity )
-    shift; identity=$1
-    ;;
-esac; shift; done
-if [[ "$1" == '--' ]]; then shift; fi
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
 
-echo "finding address for $azurecluster"
-capimachine=$(kubectl get azuremachine $azuremachine -o json | jq -r '.metadata.ownerReferences | .[]  |  select(.kind == "Machine").name')
-azurecluster=$(kubectl get machine $capimachine -o json | jq -r '.spec.clusterName')
-apiserver=$(kubectl get azurecluster $azurecluster -o json | jq -r '.spec.controlPlaneEndpoint.host')
-echo "found address $apiserver"
+case $key in
+  -h|--help)
+    echo "Utility tool for ssh'ing into CAPZ nodes"
+    echo " "
+    echo "kubectl-capz-ssh [options]"
+    echo " "
+    echo "options:"
+    echo "-h,    --help                       Show brief help"
+    echo "-am,   --azure-machine              Azure Machine name"
+    echo "-amp,  --azure-machine-pool         Azure Machine Pool name"
+    echo "-lamp, --list-azure-machine-pool    List Azure Machine Pool, need --azure-machine-pool to be set as well"
+    echo "-id,   --azure-machine-pool-id      ID of the VMSS instance you want to ssh into"
+    echo "-u,    --user                       User to ssh'ing into"
+    echo "-i,    --identity                   SSH key to be used to ssh'ing into"
+    exit 0
+    ;;
+  -am | --azure-machine)
+  azuremachine="$2"
+  shift # past argument
+  shift # past value
+  ;;
+  -amp | --azure-machine-pool)
+  azuremachinepool="$2"
+  shift # past argument
+  shift # past value
+  ;;
+  -id | --azure-machine-pool-id)
+  azuremachinepoolid="$2"
+  shift # past argument
+  shift # past value
+  ;;
+  -u | --user)
+  user="$2"
+  shift # past argument
+  shift # past value
+  ;;
+  -i | --identity)
+  identity="$2"
+  shift # past argument
+  shift # past value
+  ;;
+  -lamp | --list-azure-machine-pool)
+  listamp=1
+  shift # past argument
+  ;;
+  *)    # unknown option
+  POSITIONAL+=("$1") # save it in an array for later
+  shift # past argument
+  ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
 
-echo "finding address for $azuremachine"
-node=$(kubectl get azuremachine $azuremachine -o json | jq -r '.status.addresses[0].address')
-echo "found address $node"
+echo
+echo "Utility tool to ssh'ing into CAPZ nodes"
+echo
 
-ssh -i $identity -J ${user}@${apiserver} ${user}@${node}
+if [[ "$azuremachinepool" != "" && "$listamp" != "" ]];
+then
+  echo "Listing Azure Machine Pool $azuremachinepool"
+  echo
+  kubectl get azuremachinepools "$azuremachinepool" -o json | jq -r '.status.instances[] | "\(.instanceID)\t\(.instanceName)"' | awk -v FS="," 'BEGIN{print "ID\tComputerName";print "========================================"}{printf "%s\t%s%s",$1,$2,ORS}'
+  exit $?
+fi
+
+if [[ "$azuremachinepool" != "" &&  "$azuremachinepoolid" != "" ]];
+then
+  echo "finding address for $azuremachinepool id $azuremachinepoolid"
+  echo
+  azurecluster=$(kubectl get machinepools $azuremachinepool -o json | jq -r '.metadata.ownerReferences | .[]  |  select(.kind == "Cluster").name')
+  apiserver=$(kubectl get azurecluster $azurecluster -o json | jq -r '.spec.controlPlaneEndpoint.host')
+  echo
+  echo "found address $apiserver"
+
+  echo "finding address for $azuremachinepool node $azuremachinepoolid"
+  echo
+  node=$(kubectl get azuremachinepools $azuremachinepool -o json | jq -cr '.status.instances[] | select( .instanceID | contains("'$azuremachinepoolid'")) | .instanceName')
+  echo
+  echo "found computerName $node"
+  ssh -i $identity -J ${user}@${apiserver} ${user}@${node}
+fi
+
+
+if [[ "$azuremachine" != "" ]];
+then
+  echo "finding address for $azurecluster"
+  echo
+  capimachine=$(kubectl get azuremachine $azuremachine -o json | jq -r '.metadata.ownerReferences | .[]  |  select(.kind == "Machine").name')
+  azurecluster=$(kubectl get machine $capimachine -o json | jq -r '.spec.clusterName')
+  apiserver=$(kubectl get azurecluster $azurecluster -o json | jq -r '.spec.controlPlaneEndpoint.host')
+  echo
+  echo "found address $apiserver"
+
+  echo "finding address for $azuremachine"
+  echo
+  node=$(kubectl get azuremachine $azuremachine -o json | jq -r '.status.addresses[0].address')
+  echo
+  echo "found address $node"
+
+  ssh -i $identity -J ${user}@${apiserver} ${user}@${node}
+fi


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Need this PR to work: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1069

Add new option to be able to ssh into vmss nodes and to list the vmss instances

for example, to list:

```console
$ ./hack/debugging/kubectl-capz-ssh  --list-azure-machine-pool  --azure-machine-pool machinepool-template-mp-0
Utility tool to ssh'ing into CAPZ nodes

Listing Azure Machine Pool machinepool-template-mp-0
ID      ComputerName
========================================
2       machinepool-template-mp-0000002
3       machinepool-template-mp-0000003
```

for example to ssh in a vmss node: 

 ```console
$ ./hack/debugging/kubectl-capz-ssh  --azure-machine-pool machinepool-template-mp-0 --azure-machine-pool-id 2
Utility tool to ssh'ing into CAPZ nodes
finding address for machinepool-template-mp-0 id 2
found address machinepool-template-dd749822.eastus.cloudapp.azure.com

finding address for machinepool-template-mp-0 node 2
found computerName machinepool-template-mp-0000002

The authenticity of host 'machinepool-template-mp-0000002 (<no hostip for proxy command>)' can't be established.
ECDSA key fingerprint is SHA256:TYQjOj3BJMIcVopN+CG6ftSROFSkJhp8XpOU7tGSksE.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'machinepool-template-mp-0000002' (ECDSA) to the list of known hosts.
Welcome to Ubuntu 18.04.5 LTS (GNU/Linux 5.4.0-1031-azure x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Mon Dec  7 15:15:45 UTC 2020

  System load:  0.11               Processes:           132
  Usage of /:   15.3% of 28.90GB   Users logged in:     0
  Memory usage: 5%                 IP address for eth0: 10.1.0.6
  Swap usage:   0%

 * Introducing self-healing high availability clusters in MicroK8s.
   Simple, hardened, Kubernetes for production, from RaspberryPi to DC.

     https://microk8s.io/high-availability

0 packages can be updated.
0 updates are security updates.



The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

capi@machinepool-template-mp-0000002:~$ logout
Connection to machinepool-template-mp-0000002 closed.

```

/assign @CecileRobertMichon 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1058

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
debug/kubectl-capz-ssh: add AzureMachinePools option to ssh in the vmss nodes
```
