### PR TITLE
Add default log container for kubectl

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         control-plane: capz-controller-manager
         aadpodidbinding: capz-controller-aadpodidentity-selector
+      annotations:
+        kubectl.kubernetes.io/default-logs-container: manager
     spec:
       containers:
         - args:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind other

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Sets the default container (https://github.com/kubernetes/kubernetes/pull/87809) when viewing logs from kubectl.

Small but I always forget to append the manager to the end and have to type it a second time :smile: 

```
kubectl logs capz-controller-manager-57b885689f-45hwf
```

instead of

```
kubectl logs capz-controller-manager-57b885689f-45hwf manager
```
kubectl logs <podname>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
set default container for kubectl log command on capz manager pod
```
