### PR TITLE
Align kubectl install scripts and update version to min supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ GINKGO_VER := v1.13.0
 GINKGO_BIN := ginkgo
 GINKGO := $(TOOLS_BIN_DIR)/$(GINKGO_BIN)-$(GINKGO_VER)
 
-KUBECTL_VER := v1.16.13
+KUBECTL_VER := v1.17.16
 KUBECTL_BIN := kubectl
-KUBECTL := $(TOOLS_BIN_DIR)/$(KUBECTL_BIN)-$(KUBECTL_VER)
+KUBECTL := $(KUBECTL_BIN)-$(KUBECTL_VER)
 
 KUBE_APISERVER=$(TOOLS_BIN_DIR)/kube-apiserver
 ETCD=$(TOOLS_BIN_DIR)/etcd
@@ -245,11 +245,7 @@ $(GINKGO): ## Build ginkgo.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/onsi/ginkgo/ginkgo $(GINKGO_BIN) $(GINKGO_VER)
 
 $(KUBECTL): ## Build kubectl
-	mkdir -p $(TOOLS_BIN_DIR)
-	rm -f "$(KUBECTL)*"
-	curl -fsL https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VER)/bin/$(GOOS)/$(GOARCH)/kubectl -o $(KUBECTL)
-	ln -sf "$(KUBECTL)" "$(TOOLS_BIN_DIR)/$(KUBECTL_BIN)"
-	chmod +x "$(TOOLS_BIN_DIR)/$(KUBECTL_BIN)" "$(KUBECTL)"
+	MINIMUM_KUBECTL_VERSION=$(KUBECTL_VER) ./hack/ensure-kubectl.sh
 
 ## --------------------------------------
 ## Linting

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KUBECTL_VERSION=v1.16.7
+MINIMUM_KUBECTL_VERSION=${MINIMUM_KUBECTL_VERSION:-v1.17.16}
 
 # Ensure the kubectl tool exists and is a viable version, or installs it
 verify_kubectl_version() {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change

/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
In https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1036#issuecomment-749767796, I saw we are using kubectl 1.16.x when there was a failure to pull the correct version.  

Looking into it I noticed the `ci-e2e.sh` calls `hack/ensure-kubectl.sh` and the `make` file does something slightly different.  I've updated to use the same script and updated to `1.17`


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

We might want to address all the differences between our `hack/ensure-<tool>.sh` and the `make` file way of installing, such as kustomize.  I didn't do this since the kustomize file is used in lots of places we as this kubectl isn't referenced by the `hack/tools/bin` path.

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/980b22e2e4c9bf24355cf6ff16f7787d35b0a5f5/hack/ensure-kustomize.sh#L21-L22

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/eac5daafbef1ad33ee02c105feea49a1cef906bf/Makefile#L232-L233

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
