### PR TITLE
Loadbalancer Probe uses "/healthz" https endpoint. Suggestion to switch to a different probe.

### DIFF
--- a/cloud/services/loadbalancers/loadbalancers.go
+++ b/cloud/services/loadbalancers/loadbalancers.go
@@ -101,13 +101,12 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		}
 
 		if lbSpec.Role == infrav1.APIServerRole {
-			probeName := "HTTPSProbe"
+			probeName := "TCPProbe"
 			lb.LoadBalancerPropertiesFormat.Probes = &[]network.Probe{
 				{
 					Name: to.StringPtr(probeName),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Protocol:          network.ProbeProtocolHTTPS,
-						RequestPath:       to.StringPtr("/healthz"),
+						Protocol:          network.ProbeProtocolTCP,
 						Port:              to.Int32Ptr(lbSpec.APIServerPort),
 						IntervalInSeconds: to.Int32Ptr(15),
 						NumberOfProbes:    to.Int32Ptr(4),

--- a/cloud/services/loadbalancers/loadbalancers_test.go
+++ b/cloud/services/loadbalancers/loadbalancers_test.go
@@ -130,18 +130,17 @@ func TestReconcileLoadBalancer(t *testing.T) {
 											ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/backendAddressPools/my-publiclb-backendPool"),
 										},
 										Probe: &network.SubResource{
-											ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/probes/HTTPSProbe"),
+											ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/probes/TCPProbe"),
 										},
 									},
 								},
 							},
 							Probes: &[]network.Probe{
 								{
-									Name: to.StringPtr("HTTPSProbe"),
+									Name: to.StringPtr("TCPProbe"),
 									ProbePropertiesFormat: &network.ProbePropertiesFormat{
-										Protocol:          network.ProbeProtocolHTTPS,
+										Protocol:          network.ProbeProtocolTCP,
 										Port:              to.Int32Ptr(6443),
-										RequestPath:       to.StringPtr("/healthz"),
 										IntervalInSeconds: to.Int32Ptr(15),
 										NumberOfProbes:    to.Int32Ptr(4),
 									},
@@ -241,18 +240,17 @@ func TestReconcileLoadBalancer(t *testing.T) {
 											ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/backendAddressPools/my-private-lb-backendPool"),
 										},
 										Probe: &network.SubResource{
-											ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/probes/HTTPSProbe"),
+											ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/probes/TCPProbe"),
 										},
 									},
 								},
 							},
 							Probes: &[]network.Probe{
 								{
-									Name: to.StringPtr("HTTPSProbe"),
+									Name: to.StringPtr("TCPProbe"),
 									ProbePropertiesFormat: &network.ProbePropertiesFormat{
-										Protocol:          network.ProbeProtocolHTTPS,
+										Protocol:          network.ProbeProtocolTCP,
 										Port:              to.Int32Ptr(6443),
-										RequestPath:       to.StringPtr("/healthz"),
 										IntervalInSeconds: to.Int32Ptr(15),
 										NumberOfProbes:    to.Int32Ptr(4),
 									},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

Today the load balancer code creates a healthcheck probe which hits the api-server /healthz endpoint. 

Two issues with this.

1. The /healthz endpoint has been deprecated since kubernetes v1.16 https://kubernetes.io/docs/reference/using-api/health-checks/
2. If you have anonymous-auth for the api-server set to false, this breaks cluster-bring-up since the loadbalancer probe will fail with an auth error.

Not well versed in the azure load balancer so I don't know what the proper fix is, but I tested changing to a TCP probe and it works. 

I assume there is a better solution. AWS seems to have a SSL check that doesn't require this endpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

#1102

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
