### PR TITLE
Add gocyclo to the golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - deadcode
     - errcheck
     - goconst
+    - gocyclo
     - gofmt
     - goimports
     - golint


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds `gocyclo` to the golangci linters

**Which issue(s) this PR fixes**
Fixes #1088

**Special notes for your reviewer**:
On hold until https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1067 is merged 

**Release note**:
```release-note
none
```
