### PR TITLE
Windows upstream e2e 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ EXP_DIR := exp
 GO_INSTALL = ./scripts/go_install.sh
 E2E_DATA_DIR ?= $(ROOT_DIR)/test/e2e/data
 KUBETEST_CONF_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/conformance.yaml)
+KUBETEST_WINDOWS_CONF_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/upstream-windows.yaml)
+KUBETEST_REPO_LIST_PATH ?= $(abspath $(E2E_DATA_DIR)/kubetest/repo-list.yaml)
 
 # set --output-base used for conversion-gen which needs to be different for in GOPATH and outside GOPATH dev
 ifneq ($(abspath $(ROOT_DIR)),$(GOPATH)/src/sigs.k8s.io/cluster-api-provider-azure)
@@ -127,6 +129,7 @@ E2E_CONF_FILE ?= $(ROOT_DIR)/test/e2e/config/azure-dev.yaml
 E2E_CONF_FILE_ENVSUBST := $(ROOT_DIR)/test/e2e/config/azure-dev-envsubst.yaml
 SKIP_CLEANUP ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= false
+WIN_REPO_LIST ?= https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list
 
 # Build time versioning details.
 LDFLAGS := $(shell hack/version.sh)
@@ -195,6 +198,11 @@ test-conformance: ## Run conformance test on workload cluster.
 
 test-conformance-fast: ## Run conformance test on workload cluster using a subset of the conformance suite in parallel.
 	$(MAKE) test-conformance CONFORMANCE_E2E_ARGS="-kubetest.config-file=$(KUBETEST_FAST_CONF_PATH) -kubetest.ginkgo-nodes=5 $(E2E_ARGS)"
+
+.PHONY: test-windows-upstream
+test-windows-upstream: ## Run windows upstream tests on workload cluster.
+	curl --retry $(CURL_RETRIES) $(WIN_REPO_LIST) -o $(KUBETEST_REPO_LIST_PATH)
+	$(MAKE) test-conformance CONFORMANCE_E2E_ARGS="-kubetest.config-file=$(KUBETEST_WINDOWS_CONF_PATH) -kubetest.repo-list-file=$(KUBETEST_REPO_LIST_PATH) $(E2E_ARGS)"
 
 $(KUBE_APISERVER) $(ETCD): ## install test asset kubectl, kube-apiserver, etcd
 	source ./scripts/fetch_ext_bins.sh && fetch_tools

--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -416,23 +416,31 @@ To run the Kubernetes Conformance test suite locally, you can run
 ./scripts/ci-conformance.sh
 ```
 
-With the following environment variables defined, you can build a CAPZ cluster from the HEAD of Kubernetes main branch or release branch, and run the Conformance test suite against it:
+Optional settings are:
 
-| Environment Variable | Value                                                                                                                                                                                                    |
-|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `E2E_ARGS`           | `-kubetest.use-ci-artifacts`                                                                                                                                                                             |
+| Environment Variable | Default Value   | Description |
+|----------------------|-----------------|-------------|
+| `WINDOWS`            | `false` | Run conformance against Windows nodes |
+| `CONFORMANCE_NODES`  | `1` |Number of parallel ginkgo nodes to run     |
+
+With the following environment variables defined, you can build a CAPZ cluster from the HEAD of Kubernetes main branch or release branch, and run the Conformance test suite against it.  This is not enabled for Windows currently.
+
+| Environment Variable | Value  |
+|----------------------|--------|
+| `E2E_ARGS`           | `-kubetest.use-ci-artifacts` |
 | `KUBERNETES_VERSION` | `latest` - extract Kubernetes version from https://dl.k8s.io/ci/latest.txt (main's HEAD)<br>`latest-1.21` - extract Kubernetes version from https://dl.k8s.io/ci/latest-1.21.txt (release branch's HEAD) |
+
 
 With the following environment variables defined, CAPZ runs `./scripts/ci-build-kubernetes.sh` as part of `./scripts/ci-conformance.sh`, which allows developers to build Kubernetes from source and run the Kubernetes Conformance test suite against a CAPZ cluster based on the custom build:
 
-| Environment Variable    | Value                                                                   |
-|-------------------------|-------------------------------------------------------------------------|
-| `AZURE_STORAGE_ACCOUNT` | Your Azure storage account name                                         |
-| `AZURE_STORAGE_KEY`     | Your Azure storage key                                                  |
+| Environment Variable    | Value      |
+|-------------------------|------------|
+| `AZURE_STORAGE_ACCOUNT` | Your Azure storage account name |
+| `AZURE_STORAGE_KEY`     | Your Azure storage key |
 | `JOB_NAME`              | `test` (an enviroment variable used by CI, can be any non-empty string) |
-| `LOCAL_ONLY`            | `false`                                                                 |
-| `REGISTRY`              | Your Registry                                                           |
-| `TEST_K8S`              | `true`                                                                  |
+| `LOCAL_ONLY`            | `false`    |
+| `REGISTRY`              | Your Registry |
+| `TEST_K8S`              | `true`     |
 
 #### Running custom test suites on CAPZ clusters
 

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -76,6 +76,7 @@ export AZURE_CLIENT_SECRET_B64="$(echo -n "$AZURE_CLIENT_SECRET" | base64 | tr -
 export AZURE_LOCATION="${AZURE_LOCATION:-$(get_random_region)}"
 export AZURE_CONTROL_PLANE_MACHINE_TYPE="${AZURE_CONTROL_PLANE_MACHINE_TYPE:-"Standard_D2s_v3"}"
 export AZURE_NODE_MACHINE_TYPE="${AZURE_NODE_MACHINE_TYPE:-"Standard_D2s_v3"}"
+export WINDOWS="${WINDOWS:-false}"
 
 # Generate SSH key.
 AZURE_SSH_PUBLIC_KEY_FILE=${AZURE_SSH_PUBLIC_KEY_FILE:-""}
@@ -93,4 +94,8 @@ cleanup() {
 
 trap cleanup EXIT
 
-make test-conformance
+if [[ "${WINDOWS}" == "true" ]]; then
+  make test-windows-upstream
+else
+  make test-conformance
+fi

--- a/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
@@ -290,6 +290,11 @@ spec:
       New-HnsNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "Ethernet 2" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })
     path: C:/create-external-network.ps1
     permissions: "0744"
+  - content: |
+      # /tmp is assumed created and required for upstream e2e tests to pass
+      New-Item -ItemType Directory -Force -Path C:\tmp\
+    path: C:/create-temp-folder.ps1
+    permissions: "0744"
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
@@ -302,6 +307,7 @@ spec:
   - nssm set kubelet start SERVICE_AUTO_START
   preKubeadmCommands:
   - powershell c:/create-external-network.ps1
+  - powershell C:/create-temp-folder.ps1
   users:
   - groups: Administrators
     name: capi

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -298,6 +298,11 @@ spec:
           New-HnsNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "Ethernet 2" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })
         path: C:/create-external-network.ps1
         permissions: "0744"
+      - content: |
+          # /tmp is assumed created and required for upstream e2e tests to pass
+          New-Item -ItemType Directory -Force -Path C:\tmp\
+        path: C:/create-temp-folder.ps1
+        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
@@ -310,6 +315,7 @@ spec:
       - nssm set kubelet start SERVICE_AUTO_START
       preKubeadmCommands:
       - powershell c:/create-external-network.ps1
+      - powershell C:/create-temp-folder.ps1
       users:
       - groups: Administrators
         name: capi

--- a/templates/test/ci/prow-machine-pool-windows/kustomization.yaml
+++ b/templates/test/ci/prow-machine-pool-windows/kustomization.yaml
@@ -8,6 +8,14 @@ patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/cluster-cni-windows.yaml
   - ../patches/controller-manager.yaml
+patchesJson6902:
+- target:
+    group: bootstrap.cluster.x-k8s.io
+    version: v1alpha4
+    kind: KubeadmConfig
+    name: ${CLUSTER_NAME}-mp-win
+    namespace: default
+  path: patches/windows-tmp-folder.yaml
 configMapGenerator:
   - name: cni-${CLUSTER_NAME}-flannel
     files:

--- a/templates/test/ci/prow-machine-pool-windows/patches/windows-tmp-folder.yaml
+++ b/templates/test/ci/prow-machine-pool-windows/patches/windows-tmp-folder.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: /spec/files/-
+  value:
+    content: |
+      # /tmp is assumed created and required for upstream e2e tests to pass
+      New-Item -ItemType Directory -Force -Path C:\tmp\
+    path: C:/create-temp-folder.ps1
+    permissions: "0744"
+- op: add
+  path: /spec/preKubeadmCommands/-
+  value:
+    powershell C:/create-temp-folder.ps1

--- a/templates/test/ci/prow-windows/kustomization.yaml
+++ b/templates/test/ci/prow-windows/kustomization.yaml
@@ -8,6 +8,14 @@ patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/cluster-cni-windows.yaml
   - ../patches/controller-manager.yaml
+patchesJson6902:
+- target:
+    group: bootstrap.cluster.x-k8s.io
+    version: v1alpha4
+    kind: KubeadmConfigTemplate
+    name: ${CLUSTER_NAME}-md-win
+    namespace: default
+  path: patches/windows-tmp-folder.yaml
 configMapGenerator:
   - name: cni-${CLUSTER_NAME}-flannel
     files:

--- a/templates/test/ci/prow-windows/patches/windows-tmp-folder.yaml
+++ b/templates/test/ci/prow-windows/patches/windows-tmp-folder.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: /spec/template/spec/files/-
+  value:
+    content: |
+      # /tmp is assumed created and required for upstream e2e tests to pass
+      New-Item -ItemType Directory -Force -Path C:\tmp\
+    path: C:/create-temp-folder.ps1
+    permissions: "0744"
+- op: add
+  path: /spec/template/spec/preKubeadmCommands/-
+  value:
+    powershell C:/create-temp-folder.ps1

--- a/test/e2e/data/kubetest/repo-list.yaml
+++ b/test/e2e/data/kubetest/repo-list.yaml
@@ -1,0 +1,3 @@
+gcAuthenticatedRegistry: e2eprivate
+gcEtcdRegistry: k8sprow.azurecr.io/kubernetes-e2e-test-images
+privateRegistry: e2eteam

--- a/test/e2e/data/kubetest/upstream-windows.yaml
+++ b/test/e2e/data/kubetest/upstream-windows.yaml
@@ -1,0 +1,9 @@
+ginkgo.focus: \[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
+ginkgo.skip: \[LinuxOnly\]|\[Serial\]|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute(.*)http.hook.properly 
+disable-log-dump: true
+ginkgo.progress: true
+ginkgo.slowSpecThreshold: 120.0
+ginkgo.flakeAttempts: 0
+ginkgo.trace: true
+ginkgo.v: true
+node-os-distro: windows

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -92,6 +92,9 @@ var (
 	// kubetestConfigFilePath is the path to the kubetest configuration file
 	kubetestConfigFilePath string
 
+	// kubetestRepoListPath
+	kubetestRepoListPath string
+
 	// useCIArtifacts specifies whether or not to use the latest build from the main branch of the Kubernetes repository
 	useCIArtifacts bool
 
@@ -242,7 +245,7 @@ func init() {
 	flag.BoolVar(&skipCleanup, "e2e.skip-resource-cleanup", false, "if true, the resource cleanup after tests will be skipped")
 	flag.BoolVar(&useExistingCluster, "e2e.use-existing-cluster", false, "if true, the test uses the current cluster instead of creating a new one (default discovery rules apply)")
 	flag.StringVar(&kubetestConfigFilePath, "kubetest.config-file", "", "path to the kubetest configuration file")
-
+	flag.StringVar(&kubetestRepoListPath, "kubetest.repo-list-file", "", "path to the kubetest repo-list file")
 }
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -20,10 +20,15 @@ package node
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/windows"
 )
@@ -53,4 +58,83 @@ func GetWindowsVersion(ctx context.Context, clientset *kubernetes.Clientset) (wi
 	default:
 		return windows.LTSC2019, nil
 	}
+}
+
+func TaintNode(clientset *kubernetes.Clientset, options v1.ListOptions, taint *corev1.Taint) error {
+	result, err := clientset.CoreV1().Nodes().List(context.Background(), options)
+	if err != nil {
+		return err
+	}
+
+	if len(result.Items) == 0 {
+		return fmt.Errorf("No Nodes found.")
+	}
+
+	for _, n := range result.Items {
+		newNode, needsUpdate := addOrUpdateTaint(&n, taint)
+		if !needsUpdate {
+			continue
+		}
+
+		err = PatchNodeTaints(clientset, newNode.Name, &n, newNode)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// https://github.com/kubernetes/kubernetes/blob/v1.21.1/staging/src/k8s.io/cloud-provider/node/helpers/taints.go#L91
+func PatchNodeTaints(clientset *kubernetes.Clientset, nodeName string, oldNode *corev1.Node, newNode *corev1.Node) error {
+	oldData, err := json.Marshal(oldNode)
+	if err != nil {
+		return fmt.Errorf("failed to marshal old node %#v for node %q: %v", oldNode, nodeName, err)
+	}
+
+	newTaints := newNode.Spec.Taints
+	newNodeClone := oldNode.DeepCopy()
+	newNodeClone.Spec.Taints = newTaints
+	newData, err := json.Marshal(newNodeClone)
+	if err != nil {
+		return fmt.Errorf("failed to marshal new node %#v for node %q: %v", newNodeClone, nodeName, err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, corev1.Node{})
+	if err != nil {
+		return fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
+	}
+
+	_, err = clientset.CoreV1().Nodes().Patch(context.Background(), nodeName, types.StrategicMergePatchType, patchBytes, v1.PatchOptions{})
+	return err
+}
+
+// From https://github.com/kubernetes/kubernetes/blob/v1.21.1/staging/src/k8s.io/cloud-provider/node/helpers/taints.go#L116
+// addOrUpdateTaint tries to add a taint to annotations list. Returns a new copy of updated Node and true if something was updated
+// false otherwise.
+func addOrUpdateTaint(node *corev1.Node, taint *corev1.Taint) (*corev1.Node, bool) {
+	newNode := node.DeepCopy()
+	nodeTaints := newNode.Spec.Taints
+
+	var newTaints []corev1.Taint
+	updated := false
+	for i := range nodeTaints {
+		if taint.MatchTaint(&nodeTaints[i]) {
+			if equality.Semantic.DeepEqual(*taint, nodeTaints[i]) {
+				return newNode, false
+			}
+			newTaints = append(newTaints, *taint)
+			updated = true
+			continue
+		}
+
+		newTaints = append(newTaints, nodeTaints[i])
+	}
+
+	if !updated {
+		newTaints = append(newTaints, *taint)
+	}
+
+	newNode.Spec.Taints = newTaints
+	return newNode, true
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind other

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Add testing support for upstream windows tests similar to https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#periodic-capz-conformance-k8s-master.

TODO: 

- [ ] ~Add ability to inject kube binaries similiar to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/a3525d2d89821192dbaeef270f46eff09e4c4587/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml~ will follow up with separate pr.  tracking in https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1276
- [x] Create job in test-infra: https://github.com/kubernetes/test-infra/pull/21544

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Some more work needs to be done to make this ready and it relies on: 

Windows doesn't currently have Conformance tests but does have a set of tests that can verify Windows behavior.  Defining Conformance tests for windows is a Work in progress and this set of tests can be updated later.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Windows e2e tests from kubernetes are run against capz workload cluster
```
