### PR TITLE
output kube-system logs from workload clusters

### DIFF
--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -63,6 +63,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow-ipv6.yaml
+++ b/templates/test/cluster-template-prow-ipv6.yaml
@@ -84,6 +84,7 @@ spec:
           cluster-cidr: 2001:1234:5678:9a40::/58
           cluster-name: ${CLUSTER_NAME}
           configure-cloud-routes: "true"
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -63,6 +63,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-windows.yaml
@@ -64,6 +64,7 @@ spec:
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
           configure-cloud-routes: "false"
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/cluster-template-prow-machine-pool.yaml
@@ -63,6 +63,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow-multi-tenancy.yaml
+++ b/templates/test/cluster-template-prow-multi-tenancy.yaml
@@ -68,6 +68,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/cluster-template-prow-nvidia-gpu.yaml
@@ -63,6 +63,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow-private.yaml
+++ b/templates/test/cluster-template-prow-private.yaml
@@ -78,6 +78,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow-windows.yaml
+++ b/templates/test/cluster-template-prow-windows.yaml
@@ -64,6 +64,7 @@ spec:
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
           configure-cloud-routes: "false"
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/cluster-template-prow.yaml
+++ b/templates/test/cluster-template-prow.yaml
@@ -63,6 +63,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
+          v: "4"
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/templates/test/patches/controller-manager.yaml
+++ b/templates/test/patches/controller-manager.yaml
@@ -1,0 +1,10 @@
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      controllerManager:
+        extraArgs:
+          v: "4"

--- a/templates/test/prow-ipv6/kustomization.yaml
+++ b/templates/test/prow-ipv6/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - cni-resource-set.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
+  - ../patches/controller-manager.yaml
   - patches/cluster-cni.yaml
 

--- a/templates/test/prow-machine-pool-ci-version/kustomization.yaml
+++ b/templates/test/prow-machine-pool-ci-version/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ../prow-machine-pool
 patchesStrategicMerge:
   - ../patches/control-plane-image-ci-version.yaml
+  - ../patches/controller-manager.yaml
   - patches/machine-pool-ci-version.yaml

--- a/templates/test/prow-machine-pool-windows/kustomization.yaml
+++ b/templates/test/prow-machine-pool-windows/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/cni-resource-set.yaml
+  - ../patches/controller-manager.yaml
 

--- a/templates/test/prow-machine-pool/kustomization.yaml
+++ b/templates/test/prow-machine-pool/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/cni-resource-set.yaml
+  - ../patches/controller-manager.yaml

--- a/templates/test/prow-multi-tenancy/kustomization.yaml
+++ b/templates/test/prow-multi-tenancy/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - cni-resource-set.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
+  - ../patches/controller-manager.yaml
   - patches/cluster-cni.yaml

--- a/templates/test/prow-nvidia-gpu/kustomization.yaml
+++ b/templates/test/prow-nvidia-gpu/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/cni-resource-set.yaml
+  - ../patches/controller-manager.yaml
 patchesJson6902:
 - path: patches/node-storage-type.yaml
   target:

--- a/templates/test/prow-private/kustomization.yaml
+++ b/templates/test/prow-private/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - cni-resource-set.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
+  - ../patches/controller-manager.yaml
   - patches/cluster-cni.yaml
   - patches/custom-vnet.yaml
 

--- a/templates/test/prow-windows/kustomization.yaml
+++ b/templates/test/prow-windows/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/cni-resource-set.yaml
+  - ../patches/controller-manager.yaml

--- a/templates/test/prow/kustomization.yaml
+++ b/templates/test/prow/kustomization.yaml
@@ -9,3 +9,4 @@ patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/mhc.yaml
   - ../patches/cni-resource-set.yaml
+  - ../patches/controller-manager.yaml

--- a/test/e2e/azure_lb.go
+++ b/test/e2e/azure_lb.go
@@ -27,15 +27,15 @@ import (
 	. "github.com/onsi/gomega"
 	k8snet "k8s.io/utils/net"
 
-	deploymentBuilder "sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/deployment"
-	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/job"
-	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/node"
-	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/windows"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/cluster-api/test/framework"
+
+	deploymentBuilder "sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/deployment"
+	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/job"
+	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/node"
+	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/windows"
 )
 
 // AzureLBSpecInput is the input for AzureLBSpec.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
It's tough to diagnose what's happening in some flaky e2e tests. By collecting kube-system logs we can get a better idea of why tests are failing.

This PR intercepts the call to `CollectWorkloadClusterLogs` so that it can inject code to pull all of the logs for the kube-system pods.

Also, added a slightly higher verbosity to controller manager logging (v=4).

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Collect kube-system logs for workload clusters in e2e tests
```
