### PR TITLE
temporarily disable ILB test for VMSS

### DIFF
--- a/test/e2e/azure_lb.go
+++ b/test/e2e/azure_lb.go
@@ -46,6 +46,7 @@ type AzureLBSpecInput struct {
 	SkipCleanup           bool
 	IPv6                  bool
 	Windows               bool
+	IsVMSS                bool
 }
 
 // AzureLBSpec implements a test that verifies Azure internal and external load balancers can
@@ -112,7 +113,9 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 
 	// TODO: fix and enable this. Internal LBs + IPv6 is currently in preview.
 	// https://docs.microsoft.com/en-us/azure/virtual-network/ipv6-dual-stack-standard-internal-load-balancer-powershell
-	if !input.IPv6 {
+	//
+	// TODO: fix and enable this for VMSS after NRP / CRP sync bug is resolved
+	if !input.IPv6 && !input.IsVMSS {
 		By("creating an internal Load Balancer service")
 
 		ilbService := webDeployment.GetService(ports, deploymentBuilder.InternalLoadbalancer)

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -297,6 +297,7 @@ var _ = Describe("Workload cluster creation", func() {
 						Namespace:             namespace,
 						ClusterName:           clusterName,
 						SkipCleanup:           skipCleanup,
+						IsVMSS:                true,
 					}
 				})
 			})
@@ -485,6 +486,7 @@ var _ = Describe("Workload cluster creation", func() {
 						Namespace:             namespace,
 						ClusterName:           clusterName,
 						SkipCleanup:           skipCleanup,
+						IsVMSS:                true,
 					}
 				})
 			})
@@ -497,6 +499,7 @@ var _ = Describe("Workload cluster creation", func() {
 						ClusterName:           clusterName,
 						SkipCleanup:           skipCleanup,
 						Windows:               true,
+						IsVMSS:                true,
 					}
 				})
 			})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
ILB and ELB tests are failing due to a bug in the Azure resource provider that seems to be induced by adding an ILB to a VMSS node pool, deleting that ILB, and then creating an ELB. This is a temporary resolution for #1115. This should be removed after the bug is fixed in the API.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
