### PR TITLE
Fix CAPI e2e test failure

### DIFF
--- a/cloud/interfaces.go
+++ b/cloud/interfaces.go
@@ -80,6 +80,7 @@ type ClusterDescriber interface {
 	ClusterName() string
 	Location() string
 	AdditionalTags() infrav1.Tags
+	AvailabilitySetEnabled() bool
 }
 
 // ClusterScoper combines the ClusterDescriber and NetworkDescriber interfaces.

--- a/cloud/mocks/service_mock.go
+++ b/cloud/mocks/service_mock.go
@@ -685,6 +685,20 @@ func (mr *MockClusterDescriberMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockClusterDescriber)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockClusterDescriber) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockClusterDescriberMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockClusterDescriber)(nil).AvailabilitySetEnabled))
+}
+
 // MockClusterScoper is a mock of ClusterScoper interface.
 type MockClusterScoper struct {
 	ctrl     *gomock.Controller
@@ -860,6 +874,20 @@ func (m *MockClusterScoper) AdditionalTags() v1alpha3.Tags {
 func (mr *MockClusterScoperMockRecorder) AdditionalTags() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockClusterScoper)(nil).AdditionalTags))
+}
+
+// AvailabilitySetEnabled mocks base method.
+func (m *MockClusterScoper) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockClusterScoperMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockClusterScoper)(nil).AvailabilitySetEnabled))
 }
 
 // Vnet mocks base method.

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -23,19 +23,19 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/utils/net"
-
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/klog/klogr"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
+	"k8s.io/utils/net"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 )
 
 // ClusterScopeParams defines the input parameters used to create a new Scope.
@@ -267,6 +267,11 @@ func (s *ClusterScope) PrivateDNSSpec() *azure.PrivateDNSSpec {
 		}
 	}
 	return spec
+}
+
+// AvailabilitySetEnabled informs control plane machines they should be part of an Availability Set
+func (s *ClusterScope) AvailabilitySetEnabled() bool {
+	return len(s.AvailabilitySetSpecs()) > 0
 }
 
 // AvailabilitySetSpecs returns the availability set specs.

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -28,8 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/klogr"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -37,6 +35,9 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 )
 
 // MachineScopeParams defines the input parameters used to create a new MachineScope.
@@ -311,7 +312,7 @@ func (m *MachineScope) ProviderID() string {
 
 // AvailabilitySet returns the availability set for this machine if available
 func (m *MachineScope) AvailabilitySet() (string, bool) {
-	if m.IsControlPlane() {
+	if m.IsControlPlane() && m.AvailabilitySetEnabled() {
 		return azure.GenerateAvailabilitySetName(m.ClusterName(), azure.ControlPlaneNodeGroup), true
 	}
 

--- a/cloud/scope/managedcontrolplane.go
+++ b/cloud/scope/managedcontrolplane.go
@@ -26,13 +26,12 @@ import (
 	"k8s.io/klog/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
-
-	"sigs.k8s.io/cluster-api/util/patch"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ManagedControlPlaneScopeParams defines the input parameters used to create a new
@@ -117,6 +116,11 @@ func (s *ManagedControlPlaneScope) Location() string {
 		return ""
 	}
 	return s.ControlPlane.Spec.Location
+}
+
+// AvailabilitySetEnabled is always false for a managed control plane
+func (s *ManagedControlPlaneScope) AvailabilitySetEnabled() bool {
+	return false // not applicable for a managed control plane
 }
 
 // AdditionalTags returns AdditionalTags from the ControlPlane spec.

--- a/cloud/services/availabilitysets/availabilitysets.go
+++ b/cloud/services/availabilitysets/availabilitysets.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-
 	"k8s.io/utils/pointer"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"

--- a/cloud/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
+++ b/cloud/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
@@ -300,6 +300,20 @@ func (mr *MockAvailabilitySetScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockAvailabilitySetScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockAvailabilitySetScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockAvailabilitySetScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockAvailabilitySetScope)(nil).AvailabilitySetEnabled))
+}
+
 // AvailabilitySetSpecs mocks base method.
 func (m *MockAvailabilitySetScope) AvailabilitySetSpecs() []azure.AvailabilitySetSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/cloud/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -300,6 +300,20 @@ func (mr *MockBastionScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockBastionScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockBastionScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockBastionScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockBastionScope)(nil).AvailabilitySetEnabled))
+}
+
 // Vnet mocks base method.
 func (m *MockBastionScope) Vnet() *v1alpha3.VnetSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/disks/mock_disks/disks_mock.go
+++ b/cloud/services/disks/mock_disks/disks_mock.go
@@ -300,6 +300,20 @@ func (mr *MockDiskScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockDiskScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockDiskScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockDiskScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockDiskScope)(nil).AvailabilitySetEnabled))
+}
+
 // DiskSpecs mocks base method.
 func (m *MockDiskScope) DiskSpecs() []azure.DiskSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/groups/mock_groups/groups_mock.go
+++ b/cloud/services/groups/mock_groups/groups_mock.go
@@ -298,3 +298,17 @@ func (mr *MockGroupScopeMockRecorder) AdditionalTags() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockGroupScope)(nil).AdditionalTags))
 }
+
+// AvailabilitySetEnabled mocks base method.
+func (m *MockGroupScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockGroupScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockGroupScope)(nil).AvailabilitySetEnabled))
+}

--- a/cloud/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
+++ b/cloud/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
@@ -300,6 +300,20 @@ func (mr *MockInboundNatScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockInboundNatScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockInboundNatScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockInboundNatScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockInboundNatScope)(nil).AvailabilitySetEnabled))
+}
+
 // InboundNatSpecs mocks base method.
 func (m *MockInboundNatScope) InboundNatSpecs() []azure.InboundNatSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/cloud/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -300,6 +300,20 @@ func (mr *MockLBScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockLBScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockLBScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockLBScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockLBScope)(nil).AvailabilitySetEnabled))
+}
+
 // Vnet mocks base method.
 func (m *MockLBScope) Vnet() *v1alpha3.VnetSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
+++ b/cloud/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
@@ -300,6 +300,20 @@ func (mr *MockNICScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockNICScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockNICScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockNICScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockNICScope)(nil).AvailabilitySetEnabled))
+}
+
 // NICSpecs mocks base method.
 func (m *MockNICScope) NICSpecs() []azure.NICSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/privatedns/mock_privatedns/privatedns_mock.go
+++ b/cloud/services/privatedns/mock_privatedns/privatedns_mock.go
@@ -300,6 +300,20 @@ func (mr *MockScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockScope)(nil).AvailabilitySetEnabled))
+}
+
 // PrivateDNSSpec mocks base method.
 func (m *MockScope) PrivateDNSSpec() *azure.PrivateDNSSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/publicips/mock_publicips/publicips_mock.go
+++ b/cloud/services/publicips/mock_publicips/publicips_mock.go
@@ -300,6 +300,20 @@ func (mr *MockPublicIPScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockPublicIPScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockPublicIPScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockPublicIPScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockPublicIPScope)(nil).AvailabilitySetEnabled))
+}
+
 // PublicIPSpecs mocks base method.
 func (m *MockPublicIPScope) PublicIPSpecs() []azure.PublicIPSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/roleassignments/mock_roleassignments/roleassignments_mock.go
+++ b/cloud/services/roleassignments/mock_roleassignments/roleassignments_mock.go
@@ -300,6 +300,20 @@ func (mr *MockRoleAssignmentScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockRoleAssignmentScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockRoleAssignmentScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockRoleAssignmentScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockRoleAssignmentScope)(nil).AvailabilitySetEnabled))
+}
+
 // RoleAssignmentSpecs mocks base method.
 func (m *MockRoleAssignmentScope) RoleAssignmentSpecs() []azure.RoleAssignmentSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/routetables/mock_routetables/routetables_mock.go
+++ b/cloud/services/routetables/mock_routetables/routetables_mock.go
@@ -300,6 +300,20 @@ func (mr *MockRouteTableScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockRouteTableScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockRouteTableScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockRouteTableScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockRouteTableScope)(nil).AvailabilitySetEnabled))
+}
+
 // Vnet mocks base method.
 func (m *MockRouteTableScope) Vnet() *v1alpha3.VnetSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/scalesets/mock_scalesets/scalesets_mock.go
+++ b/cloud/services/scalesets/mock_scalesets/scalesets_mock.go
@@ -302,6 +302,20 @@ func (mr *MockScaleSetScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockScaleSetScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockScaleSetScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockScaleSetScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockScaleSetScope)(nil).AvailabilitySetEnabled))
+}
+
 // ScaleSetSpec mocks base method.
 func (m *MockScaleSetScope) ScaleSetSpec() azure.ScaleSetSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/securitygroups/mock_securitygroups/securitygroups_mock.go
+++ b/cloud/services/securitygroups/mock_securitygroups/securitygroups_mock.go
@@ -300,6 +300,20 @@ func (mr *MockNSGScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockNSGScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockNSGScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockNSGScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockNSGScope)(nil).AvailabilitySetEnabled))
+}
+
 // Vnet mocks base method.
 func (m *MockNSGScope) Vnet() *v1alpha3.VnetSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/subnets/mock_subnets/subnets_mock.go
+++ b/cloud/services/subnets/mock_subnets/subnets_mock.go
@@ -300,6 +300,20 @@ func (mr *MockSubnetScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockSubnetScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockSubnetScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockSubnetScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockSubnetScope)(nil).AvailabilitySetEnabled))
+}
+
 // Vnet mocks base method.
 func (m *MockSubnetScope) Vnet() *v1alpha3.VnetSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/tags/mock_tags/tags_mock.go
+++ b/cloud/services/tags/mock_tags/tags_mock.go
@@ -300,6 +300,20 @@ func (mr *MockTagScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockTagScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockTagScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockTagScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockTagScope)(nil).AvailabilitySetEnabled))
+}
+
 // TagsSpecs mocks base method.
 func (m *MockTagScope) TagsSpecs() []azure.TagsSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
+++ b/cloud/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
@@ -302,6 +302,20 @@ func (mr *MockVMScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockVMScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockVMScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockVMScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockVMScope)(nil).AvailabilitySetEnabled))
+}
+
 // VMSpec mocks base method.
 func (m *MockVMScope) VMSpec() azure.VMSpec {
 	m.ctrl.T.Helper()

--- a/cloud/services/virtualmachines/virtualmachines_test.go
+++ b/cloud/services/virtualmachines/virtualmachines_test.go
@@ -329,6 +329,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomockinternal.DiffEq(compute.VirtualMachine{
 					VirtualMachineProperties: &compute.VirtualMachineProperties{
 						HardwareProfile: &compute.HardwareProfile{VMSize: "Standard_D2v3"},
@@ -471,6 +472,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
 					g.Expect(vm.Identity.Type).To(Equal(compute.ResourceIdentityTypeSystemAssigned))
 					g.Expect(vm.Identity.UserAssignedIdentities).To(HaveLen(0))
@@ -542,6 +544,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
 					g.Expect(vm.Identity.Type).To(Equal(compute.ResourceIdentityTypeUserAssigned))
 					g.Expect(vm.Identity.UserAssignedIdentities).To(Equal(map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{"my-user-id": {}}))
@@ -613,6 +616,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
 					g.Expect(vm.Priority).To(Equal(compute.Spot))
 					g.Expect(vm.EvictionPolicy).To(Equal(compute.Deallocate))
@@ -699,6 +703,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
 					g.Expect(vm.VirtualMachineProperties.StorageProfile.OsDisk.OsType).To(Equal(compute.Windows))
 					g.Expect(*vm.VirtualMachineProperties.OsProfile.AdminPassword).Should(HaveLen(123))
@@ -778,6 +783,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
 					g.Expect(vm.VirtualMachineProperties.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID).To(Equal(to.StringPtr("my-diskencryptionset-id")))
 
@@ -846,6 +852,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
 					g.Expect(*vm.VirtualMachineProperties.SecurityProfile.EncryptionAtHost).To(Equal(true))
 
@@ -1135,6 +1142,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 			},
 			ExpectedError: "failed to create VM my-vm in resource group my-rg: #: Internal Server Error: StatusCode=500",
@@ -1426,6 +1434,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomockinternal.DiffEq(compute.VirtualMachine{
 					VirtualMachineProperties: &compute.VirtualMachineProperties{
 						HardwareProfile: &compute.HardwareProfile{VMSize: "Standard_D2v3"},
@@ -1588,6 +1597,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}, nil)
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
+				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomockinternal.DiffEq(compute.VirtualMachine{
 					Plan: &compute.Plan{
 						Name:      to.StringPtr("sku-id"),

--- a/cloud/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
+++ b/cloud/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
@@ -300,6 +300,20 @@ func (mr *MockVNetScopeMockRecorder) AdditionalTags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockVNetScope)(nil).AdditionalTags))
 }
 
+// AvailabilitySetEnabled mocks base method.
+func (m *MockVNetScope) AvailabilitySetEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
+func (mr *MockVNetScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockVNetScope)(nil).AvailabilitySetEnabled))
+}
+
 // Vnet mocks base method.
 func (m *MockVNetScope) Vnet() *v1alpha3.VnetSpec {
 	m.ctrl.T.Helper()

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -19,20 +19,19 @@ package controllers
 import (
 	"context"
 
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/tags"
-	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
-
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/inboundnatrules"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/resourceskus"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/roleassignments"
-
 	"github.com/pkg/errors"
+
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/scope"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/disks"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/inboundnatrules"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/networkinterfaces"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/publicips"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/resourceskus"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/roleassignments"
+	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/tags"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/virtualmachines"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // azureMachineService is the group of services called by the AzureMachine controller.

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -88,13 +88,15 @@ var (
 
 type (
 	AzureClusterProxy struct {
-		framework.ClusterProxy
+		capi_e2e.ClusterProxy
 	}
 )
 
 func NewAzureClusterProxy(name string, kubeconfigPath string, scheme *runtime.Scheme, options ...framework.Option) *AzureClusterProxy {
+	proxy, ok := framework.NewClusterProxy(name, kubeconfigPath, scheme, options...).(capi_e2e.ClusterProxy)
+	Expect(ok).To(BeTrue(), "framework.NewClusterProxy must implement capi_e2e.ClusterProxy")
 	return &AzureClusterProxy{
-		ClusterProxy: framework.NewClusterProxy(name, kubeconfigPath, scheme, options...),
+		ClusterProxy: proxy,
 	}
 }
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/periodic-cluster-api-provider-azure-capi-e2e/1352267301243588608

error is Panic: interface conversion: *e2e.AzureClusterProxy is not e2e.ClusterProxy: missing method ApplyWithArgs

Within the CAPI test framework a hard cast is taking place. This PR will implement the required interface and ensure that it stays implemented.

Also, there was a bug in the Availability Set functionality which cause a machine in the control plane to attempt to use an AV Set when none was provisioned by the cluster. This PR consolidates the logic for determining when to use an AV Set and corrects the bug.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cluster provisioning failure when using a single control plane node with no Zone defined
```
