### PR TITLE
Availability sets for worker nodes

### DIFF
--- a/cloud/defaults.go
+++ b/cloud/defaults.go
@@ -135,8 +135,10 @@ func GenerateDataDiskName(machineName, nameSuffix string) string {
 	return fmt.Sprintf("%s_%s", machineName, nameSuffix)
 }
 
-// GenerateAvailabilitySetName generates the name of a availability set based on the cluster name and the node group
-// node group identifies the set of nodes that belong to this availability sets. Eg. control-plane
+// GenerateAvailabilitySetName generates the name of a availability set based on the cluster name and the node group.
+// node group identifies the set of nodes that belong to this availability set:
+// For control plane nodes, this will be `control-plane`.
+// For worker nodes, this will be the machine deployment name.
 func GenerateAvailabilitySetName(clusterName, nodeGroup string) string {
 	return fmt.Sprintf("%s_%s-as", clusterName, nodeGroup)
 }

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -269,21 +269,6 @@ func (s *ClusterScope) PrivateDNSSpec() *azure.PrivateDNSSpec {
 	return spec
 }
 
-// AvailabilitySetEnabled informs control plane machines they should be part of an Availability Set
-func (s *ClusterScope) AvailabilitySetEnabled() bool {
-	return len(s.AvailabilitySetSpecs()) > 0
-}
-
-// AvailabilitySetSpecs returns the availability set specs.
-func (s *ClusterScope) AvailabilitySetSpecs() []azure.AvailabilitySetSpec {
-	if len(s.AzureCluster.Status.FailureDomains) == 0 {
-		return []azure.AvailabilitySetSpec{{
-			Name: azure.GenerateAvailabilitySetName(s.ClusterName(), azure.ControlPlaneNodeGroup),
-		}}
-	}
-	return nil
-}
-
 // Vnet returns the cluster Vnet.
 func (s *ClusterScope) Vnet() *infrav1.VnetSpec {
 	return &s.AzureCluster.Spec.NetworkSpec.Vnet
@@ -398,6 +383,11 @@ func (s *ClusterScope) Namespace() string {
 // Location returns the cluster location.
 func (s *ClusterScope) Location() string {
 	return s.AzureCluster.Spec.Location
+}
+
+// AvailabilitySetEnabled informs machines that they should be part of an Availability Set.
+func (s *ClusterScope) AvailabilitySetEnabled() bool {
+	return len(s.AzureCluster.Status.FailureDomains) == 0
 }
 
 // GenerateFQDN generates a fully qualified domain name, based on a hash, cluster name and cluster location.

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -328,8 +328,17 @@ func (m *MachineScope) ProviderID() string {
 
 // AvailabilitySet returns the availability set for this machine if available
 func (m *MachineScope) AvailabilitySet() (string, bool) {
-	if m.IsControlPlane() && m.AvailabilitySetEnabled() {
+	if !m.AvailabilitySetEnabled() {
+		return "", false
+	}
+
+	if m.IsControlPlane() {
 		return azure.GenerateAvailabilitySetName(m.ClusterName(), azure.ControlPlaneNodeGroup), true
+	}
+
+	// get machine deployment name from labels for machines that maybe part of a machine deployment.
+	if mdName, ok := m.Machine.Labels[clusterv1.MachineDeploymentLabelName]; ok {
+		return azure.GenerateAvailabilitySetName(m.ClusterName(), mdName), true
 	}
 
 	return "", false

--- a/cloud/scope/managedcontrolplane.go
+++ b/cloud/scope/managedcontrolplane.go
@@ -241,8 +241,3 @@ func (s *ManagedControlPlaneScope) OutboundLBName(_ string) string {
 func (s *ManagedControlPlaneScope) OutboundPoolName(_ string) string {
 	return "aksOutboundBackendPool" // hard-coded in aks
 }
-
-// FailureDomains returns the failure domains
-func (s *ManagedControlPlaneScope) FailureDomains() clusterv1.FailureDomains {
-	return clusterv1.FailureDomains{}
-}

--- a/cloud/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
+++ b/cloud/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
@@ -26,7 +26,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	v1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 )
 
 // MockAvailabilitySetScope is a mock of AvailabilitySetScope interface.
@@ -328,16 +327,17 @@ func (mr *MockAvailabilitySetScopeMockRecorder) AvailabilitySetEnabled() *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockAvailabilitySetScope)(nil).AvailabilitySetEnabled))
 }
 
-// AvailabilitySetSpecs mocks base method.
-func (m *MockAvailabilitySetScope) AvailabilitySetSpecs() []azure.AvailabilitySetSpec {
+// AvailabilitySet mocks base method.
+func (m *MockAvailabilitySetScope) AvailabilitySet() (string, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailabilitySetSpecs")
-	ret0, _ := ret[0].([]azure.AvailabilitySetSpec)
-	return ret0
+	ret := m.ctrl.Call(m, "AvailabilitySet")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
-// AvailabilitySetSpecs indicates an expected call of AvailabilitySetSpecs.
-func (mr *MockAvailabilitySetScopeMockRecorder) AvailabilitySetSpecs() *gomock.Call {
+// AvailabilitySet indicates an expected call of AvailabilitySet.
+func (mr *MockAvailabilitySetScopeMockRecorder) AvailabilitySet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetSpecs", reflect.TypeOf((*MockAvailabilitySetScope)(nil).AvailabilitySetSpecs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySet", reflect.TypeOf((*MockAvailabilitySetScope)(nil).AvailabilitySet))
 }

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -24,7 +24,6 @@ import (
 
 	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/scope"
-	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/availabilitysets"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/groups"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/loadbalancers"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/privatedns"
@@ -39,17 +38,16 @@ import (
 
 // azureClusterService is the reconciler called by the AzureCluster controller
 type azureClusterService struct {
-	scope               *scope.ClusterScope
-	groupsSvc           azure.Service
-	vnetSvc             azure.Service
-	securityGroupSvc    azure.Service
-	routeTableSvc       azure.Service
-	subnetsSvc          azure.Service
-	publicIPSvc         azure.Service
-	loadBalancerSvc     azure.Service
-	privateDNSSvc       azure.Service
-	availabilitySetsSvc azure.Service
-	skuCache            *resourceskus.Cache
+	scope            *scope.ClusterScope
+	groupsSvc        azure.Service
+	vnetSvc          azure.Service
+	securityGroupSvc azure.Service
+	routeTableSvc    azure.Service
+	subnetsSvc       azure.Service
+	publicIPSvc      azure.Service
+	loadBalancerSvc  azure.Service
+	privateDNSSvc    azure.Service
+	skuCache         *resourceskus.Cache
 }
 
 // newAzureClusterService populates all the services based on input scope
@@ -60,17 +58,16 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 	}
 
 	return &azureClusterService{
-		scope:               scope,
-		groupsSvc:           groups.New(scope),
-		vnetSvc:             virtualnetworks.New(scope),
-		securityGroupSvc:    securitygroups.New(scope),
-		routeTableSvc:       routetables.New(scope),
-		subnetsSvc:          subnets.New(scope),
-		publicIPSvc:         publicips.New(scope),
-		loadBalancerSvc:     loadbalancers.New(scope),
-		privateDNSSvc:       privatedns.New(scope),
-		availabilitySetsSvc: availabilitysets.New(scope, skuCache),
-		skuCache:            skuCache,
+		scope:            scope,
+		groupsSvc:        groups.New(scope),
+		vnetSvc:          virtualnetworks.New(scope),
+		securityGroupSvc: securitygroups.New(scope),
+		routeTableSvc:    routetables.New(scope),
+		subnetsSvc:       subnets.New(scope),
+		publicIPSvc:      publicips.New(scope),
+		loadBalancerSvc:  loadbalancers.New(scope),
+		privateDNSSvc:    privatedns.New(scope),
+		skuCache:         skuCache,
 	}, nil
 }
 
@@ -120,10 +117,6 @@ func (s *azureClusterService) Reconcile(ctx context.Context) error {
 		return errors.Wrapf(err, "failed to reconcile private dns")
 	}
 
-	if err := s.availabilitySetsSvc.Reconcile(ctx); err != nil {
-		return errors.Wrapf(err, "failed to reconcile availability sets")
-	}
-
 	return nil
 }
 
@@ -162,9 +155,6 @@ func (s *azureClusterService) Delete(ctx context.Context) error {
 				return errors.Wrapf(err, "failed to delete virtual network")
 			}
 
-			if err := s.availabilitySetsSvc.Delete(ctx); err != nil {
-				return errors.Wrapf(err, "failed to delete availability sets")
-			}
 		} else {
 			return errors.Wrapf(err, "failed to delete resource group")
 		}

--- a/controllers/azurecluster_reconciler_test.go
+++ b/controllers/azurecluster_reconciler_test.go
@@ -33,7 +33,7 @@ import (
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 )
 
-type expect func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder, as *mocks.MockServiceMockRecorder)
+type expect func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder)
 
 func TestAzureClusterReconcilerDelete(t *testing.T) {
 	cases := map[string]struct {
@@ -42,21 +42,21 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 	}{
 		"Resource Group is deleted successfully": {
 			expectedError: "",
-			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder, as *mocks.MockServiceMockRecorder) {
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder) {
 				gomock.InOrder(
 					grp.Delete(gomockinternal.AContext()).Return(nil))
 			},
 		},
 		"Resource Group delete fails": {
 			expectedError: "failed to delete resource group: internal error",
-			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder, as *mocks.MockServiceMockRecorder) {
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder) {
 				gomock.InOrder(
 					grp.Delete(gomockinternal.AContext()).Return(errors.New("internal error")))
 			},
 		},
 		"Resource Group not owned by cluster": {
 			expectedError: "",
-			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder, as *mocks.MockServiceMockRecorder) {
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder) {
 				gomock.InOrder(
 					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
 					dns.Delete(gomockinternal.AContext()),
@@ -66,13 +66,12 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 					rt.Delete(gomockinternal.AContext()),
 					sg.Delete(gomockinternal.AContext()),
 					vnet.Delete(gomockinternal.AContext()),
-					as.Delete(gomockinternal.AContext()),
 				)
 			},
 		},
 		"Load Balancer delete fails": {
 			expectedError: "failed to delete load balancer: some error happened",
-			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder, as *mocks.MockServiceMockRecorder) {
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder) {
 				gomock.InOrder(
 					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
 					dns.Delete(gomockinternal.AContext()),
@@ -82,7 +81,7 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 		},
 		"Route table delete fails": {
 			expectedError: "failed to delete route table: some error happened",
-			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder, as *mocks.MockServiceMockRecorder) {
+			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder) {
 				gomock.InOrder(
 					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
 					dns.Delete(gomockinternal.AContext()),
@@ -90,22 +89,6 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 					pip.Delete(gomockinternal.AContext()),
 					sn.Delete(gomockinternal.AContext()),
 					rt.Delete(gomockinternal.AContext()).Return(errors.New("some error happened")),
-				)
-			},
-		},
-		"Availability sets delete fails": {
-			expectedError: "failed to delete availability sets: some error happened",
-			expect: func(grp *mocks.MockServiceMockRecorder, vnet *mocks.MockServiceMockRecorder, sg *mocks.MockServiceMockRecorder, rt *mocks.MockServiceMockRecorder, sn *mocks.MockServiceMockRecorder, pip *mocks.MockServiceMockRecorder, lb *mocks.MockServiceMockRecorder, dns *mocks.MockServiceMockRecorder, as *mocks.MockServiceMockRecorder) {
-				gomock.InOrder(
-					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
-					dns.Delete(gomockinternal.AContext()),
-					lb.Delete(gomockinternal.AContext()),
-					pip.Delete(gomockinternal.AContext()),
-					sn.Delete(gomockinternal.AContext()),
-					rt.Delete(gomockinternal.AContext()),
-					sg.Delete(gomockinternal.AContext()),
-					vnet.Delete(gomockinternal.AContext()),
-					as.Delete(gomockinternal.AContext()).Return(errors.New("some error happened")),
 				)
 			},
 		},
@@ -127,24 +110,22 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 			publicIPMock := mocks.NewMockService(mockCtrl)
 			lbMock := mocks.NewMockService(mockCtrl)
 			dnsMock := mocks.NewMockService(mockCtrl)
-			asMock := mocks.NewMockService(mockCtrl)
 
-			tc.expect(groupsMock.EXPECT(), vnetMock.EXPECT(), sgMock.EXPECT(), rtMock.EXPECT(), subnetsMock.EXPECT(), publicIPMock.EXPECT(), lbMock.EXPECT(), dnsMock.EXPECT(), asMock.EXPECT())
+			tc.expect(groupsMock.EXPECT(), vnetMock.EXPECT(), sgMock.EXPECT(), rtMock.EXPECT(), subnetsMock.EXPECT(), publicIPMock.EXPECT(), lbMock.EXPECT(), dnsMock.EXPECT())
 
 			s := &azureClusterService{
 				scope: &scope.ClusterScope{
 					AzureCluster: &infrav1.AzureCluster{},
 				},
-				groupsSvc:           groupsMock,
-				vnetSvc:             vnetMock,
-				securityGroupSvc:    sgMock,
-				routeTableSvc:       rtMock,
-				subnetsSvc:          subnetsMock,
-				publicIPSvc:         publicIPMock,
-				loadBalancerSvc:     lbMock,
-				privateDNSSvc:       dnsMock,
-				skuCache:            resourceskus.NewStaticCache([]compute.ResourceSku{}),
-				availabilitySetsSvc: asMock,
+				groupsSvc:        groupsMock,
+				vnetSvc:          vnetMock,
+				securityGroupSvc: sgMock,
+				routeTableSvc:    rtMock,
+				subnetsSvc:       subnetsMock,
+				publicIPSvc:      publicIPMock,
+				loadBalancerSvc:  lbMock,
+				privateDNSSvc:    dnsMock,
+				skuCache:         resourceskus.NewStaticCache([]compute.ResourceSku{}),
 			}
 
 			err := s.Delete(context.TODO())

--- a/docs/book/src/topics/failure-domains.md
+++ b/docs/book/src/topics/failure-domains.md
@@ -129,3 +129,113 @@ spec:
     name: my-cluster-md-0
 
 ```
+
+## Availability sets when there are no failure domains
+
+Although failure domains provide protection against datacenter failures, not all azure regions support availability zones. In such cases, azure [availability sets](https://docs.microsoft.com/en-us/azure/virtual-machines/manage-availability#configure-multiple-virtual-machines-in-an-availability-set-for-redundancy) can be used to provide redundancy and high availability.
+
+When cluster api detects that the region has no failure domains, it creates availability sets for different groups of virtual machines. The virtual machines, when created, are assigned an availability set based on the group they belong to.
+
+The availability sets created are as follows:
+
+1. For control plane vms, an availability set will be created and suffixed with the string "control-plane".
+2. For Worker node vms, an availability set will be created for each machine deployment, and suffixed with the machine deployment name.
+
+Consider the following cluster configuration:
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  labels:
+    cni: calico
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: AzureCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AzureMachineTemplate
+        name: ${CLUSTER_NAME}-md-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-1
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-1
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AzureMachineTemplate
+        name: ${CLUSTER_NAME}-md-1
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-2
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-2
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AzureMachineTemplate
+        name: ${CLUSTER_NAME}-md-2
+      version: ${KUBERNETES_VERSION}
+```
+
+In the example above, there will be *4* availability sets created, *1* for the control plane, and *1* for each of the *3* machine deployments.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Continuing on the work done in #1099, this PR enables worker nodes to be assigned to availability sets if there are no failure domains available in the region.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #657 

**Special notes for your reviewer**:

- An availability set is created for each machine deployment
- Availability sets are now reconciled as part of `machine` reconciliation instead of `cluster` as in #1099. 
- Availability set is deleted when all the vms that belong to the as are deleted

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
enable availability sets for worker nodes
```
