### PR TITLE
Add a missing code to skip NSG deletion if the vnet is unmanaged

### DIFF
--- a/azure/services/securitygroups/securitygroups.go
+++ b/azure/services/securitygroups/securitygroups.go
@@ -140,6 +140,11 @@ func (s *Service) Delete(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "securitygroups.Service.Delete")
 	defer span.End()
 
+	if !s.Scope.IsVnetManaged() {
+		s.Scope.V(4).Info("Skipping network security group delete in custom VNet mode")
+		return nil
+	}
+
 	for _, nsgSpec := range s.Scope.NSGSpecs() {
 		s.Scope.V(2).Info("deleting security group", "security group", nsgSpec.Name)
 		err := s.client.Delete(ctx, s.Scope.ResourceGroup(), nsgSpec.Name)

--- a/azure/services/securitygroups/securitygroups_test.go
+++ b/azure/services/securitygroups/securitygroups_test.go
@@ -283,6 +283,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.IsVnetManaged().Return(true)
 				m.Delete(gomockinternal.AContext(), "my-rg", "nsg-one")
 				m.Delete(gomockinternal.AContext(), "my-rg", "nsg-two")
 			},
@@ -302,9 +303,17 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.IsVnetManaged().Return(true)
 				m.Delete(gomockinternal.AContext(), "my-rg", "nsg-one").
 					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.Delete(gomockinternal.AContext(), "my-rg", "nsg-two")
+			},
+		},
+		{
+			name: "skipping network security group delete in custom VNet mode",
+			expect: func(s *mock_securitygroups.MockNSGScopeMockRecorder, m *mock_securitygroups.MockclientMockRecorder) {
+				s.IsVnetManaged().Return(false)
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds a missing code to skip NSG deletion if the vnet is unmanaged

**Which issue(s) this PR fixes**
Fixes #1154

**Special notes for your reviewer**:
both `make lint` and `make test` passed locally

**Release note**:
```release-note
Skip NSG deletion if the vnet is unmanaged
```
