### PR TITLE
Fix AzureMachinePool/AzureMachine spot instances max price failing to serialize when using the client

### DIFF
--- a/api/v1alpha3/azuremachine_types.go
+++ b/api/v1alpha3/azuremachine_types.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
@@ -119,8 +120,7 @@ type AzureMachineSpec struct {
 type SpotVMOptions struct {
 	// MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
 	// +optional
-	// +kubebuilder:validation:Type=number
-	MaxPrice *string `json:"maxPrice,omitempty"`
+	MaxPrice *resource.Quantity `json:"maxPrice,omitempty"`
 }
 
 // AzureMachineStatus defines the observed state of AzureMachine

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -959,8 +959,8 @@ func (in *SpotVMOptions) DeepCopyInto(out *SpotVMOptions) {
 	*out = *in
 	if in.MaxPrice != nil {
 		in, out := &in.MaxPrice, &out.MaxPrice
-		*out = new(string)
-		**out = **in
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 }
 

--- a/cloud/converters/spotinstances.go
+++ b/cloud/converters/spotinstances.go
@@ -32,7 +32,7 @@ func GetSpotVMOptions(spotVMOptions *infrav1.SpotVMOptions) (compute.VirtualMach
 	}
 	var billingProfile *compute.BillingProfile
 	if spotVMOptions.MaxPrice != nil {
-		maxPrice, err := strconv.ParseFloat(*spotVMOptions.MaxPrice, 64)
+		maxPrice, err := strconv.ParseFloat(spotVMOptions.MaxPrice.AsDec().String(), 64)
 		if err != nil {
 			return "", "", nil, err
 		}

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -312,9 +312,13 @@ spec:
                       should use a Spot VM
                     properties:
                       maxPrice:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
-                        type: number
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                     type: object
                   sshPublicKey:
                     description: SSHPublicKey is the SSH public key string base64

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -482,9 +482,13 @@ spec:
                   should use a Spot VM
                 properties:
                   maxPrice:
+                    anyOf:
+                    - type: integer
+                    - type: string
                     description: MaxPrice defines the maximum price the user is willing
                       to pay for Spot VM instances
-                    type: number
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                 type: object
               sshPublicKey:
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -427,9 +427,13 @@ spec:
                           Machine should use a Spot VM
                         properties:
                           maxPrice:
+                            anyOf:
+                            - type: integer
+                            - type: string
                             description: MaxPrice defines the maximum price the user
                               is willing to pay for Spot VM instances
-                            type: number
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                         type: object
                       sshPublicKey:
                         type: string


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Previously, when trying to deploy a `AzureMachinePool` (or `AzureMachine`) resource via the Go client, with spot instances enabled, and a set maximum price, you would get a validation error (please check the issue for more information).

This PR changes the type of the `AzureMachinePool.SpotVMOptions.MaxPrice` property to the `apimachinery/pkg/resource` `*Quantity` type.

By using this type we are able to not lose precision when serializing float values, and also able to deploy the resource by applying the CR template, or by using the Go client. [You can read more about the type here](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go).

If we're applying a CR template, we can either specify the `maxPrice` property by using a stringified float value (`"0.1"`), an integer (`1`), or by using `resource.Quantity`'s serialization format (`100m`).

The only drawback is that if we try to specify a float value in the YAML template, we need to put the value in between quotes.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1151

**Special notes for your reviewer**:

Please let me know if there's a better way to achieve this. Thank you.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
Refactor `AzureMachinePool.Spec.Template.SpotVMOptions.MaxPrice` and `AzureMachine.Spec.SpotVMOptions.MaxPrice` types to accept float values using the Go client. Action required: if upgrading a cluster to this version, and you're using spot instances with a set maximum price, you have to manually update the `azuremachinepools.spec.template.spotVMOptions.maxPrice` and `azuremachines.spec.spotVMOptions.maxPrice` fields. Wrapping the value in quotes will do the trick.
```
