### PR TITLE
Add a missing code to skip NSG deletion if the vnet is unmanaged

### DIFF
--- a/cloud/services/securitygroups/securitygroups.go
+++ b/cloud/services/securitygroups/securitygroups.go
@@ -140,6 +140,11 @@ func (s *Service) Delete(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "securitygroups.Service.Delete")
 	defer span.End()
 
+	if !s.Scope.IsVnetManaged() {
+		s.Scope.V(4).Info("Skipping network security group delete in custom VNet mode")
+		return nil
+	}
+
 	for _, nsgSpec := range s.Scope.NSGSpecs() {
 		s.Scope.V(2).Info("deleting security group", "security group", nsgSpec.Name)
 		err := s.client.Delete(ctx, s.Scope.ResourceGroup(), nsgSpec.Name)

--- a/cloud/services/securitygroups/securitygroups_test.go
+++ b/cloud/services/securitygroups/securitygroups_test.go
@@ -283,6 +283,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.IsVnetManaged().Return(true)
 				m.Delete(gomockinternal.AContext(), "my-rg", "nsg-one")
 				m.Delete(gomockinternal.AContext(), "my-rg", "nsg-two")
 			},
@@ -302,9 +303,17 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.IsVnetManaged().Return(true)
 				m.Delete(gomockinternal.AContext(), "my-rg", "nsg-one").
 					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.Delete(gomockinternal.AContext(), "my-rg", "nsg-two")
+			},
+		},
+		{
+			name: "skipping network security group delete in custom VNet mode",
+			expect: func(s *mock_securitygroups.MockNSGScopeMockRecorder, m *mock_securitygroups.MockclientMockRecorder) {
+				s.IsVnetManaged().Return(false)
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 			},
 		},
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Backport of #1156. Clean cherry-pick.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip NSG deletion if the vnet is unmanaged
```
