### PR TITLE
Use apimachinery 'resource.Quantity' type for the AzureMachinePool.SpotVMOptions.MaxPrice property

### DIFF
--- a/api/v1alpha3/azuremachine_types.go
+++ b/api/v1alpha3/azuremachine_types.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/errors"
@@ -119,8 +120,7 @@ type AzureMachineSpec struct {
 type SpotVMOptions struct {
 	// MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
 	// +optional
-	// +kubebuilder:validation:Type=number
-	MaxPrice *string `json:"maxPrice,omitempty"`
+	MaxPrice *resource.Quantity `json:"maxPrice,omitempty"`
 }
 
 // AzureMachineStatus defines the observed state of AzureMachine

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -959,8 +959,8 @@ func (in *SpotVMOptions) DeepCopyInto(out *SpotVMOptions) {
 	*out = *in
 	if in.MaxPrice != nil {
 		in, out := &in.MaxPrice, &out.MaxPrice
-		*out = new(string)
-		**out = **in
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 }
 

--- a/cloud/converters/spotinstances.go
+++ b/cloud/converters/spotinstances.go
@@ -32,7 +32,7 @@ func GetSpotVMOptions(spotVMOptions *infrav1.SpotVMOptions) (compute.VirtualMach
 	}
 	var billingProfile *compute.BillingProfile
 	if spotVMOptions.MaxPrice != nil {
-		maxPrice, err := strconv.ParseFloat(*spotVMOptions.MaxPrice, 64)
+		maxPrice, err := strconv.ParseFloat(spotVMOptions.MaxPrice.AsDec().String(), 64)
 		if err != nil {
 			return "", "", nil, err
 		}

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -312,9 +312,13 @@ spec:
                       should use a Spot VM
                     properties:
                       maxPrice:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: MaxPrice defines the maximum price the user is
                           willing to pay for Spot VM instances
-                        type: number
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                     type: object
                   sshPublicKey:
                     description: SSHPublicKey is the SSH public key string base64

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -482,9 +482,13 @@ spec:
                   should use a Spot VM
                 properties:
                   maxPrice:
+                    anyOf:
+                    - type: integer
+                    - type: string
                     description: MaxPrice defines the maximum price the user is willing
                       to pay for Spot VM instances
-                    type: number
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                 type: object
               sshPublicKey:
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -427,9 +427,13 @@ spec:
                           Machine should use a Spot VM
                         properties:
                           maxPrice:
+                            anyOf:
+                            - type: integer
+                            - type: string
                             description: MaxPrice defines the maximum price the user
                               is willing to pay for Spot VM instances
-                            type: number
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                         type: object
                       sshPublicKey:
                         type: string


### PR DESCRIPTION
By using a quantity type, which is a fixed-point representation of a
number, we are able to not lose precision when serializing floats.
Also, when applying CRs directly, we have the liberty to use stringified
floats, as well as integers or the quantity serialization format.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Backport #1157. Clean cherry-pick.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Refactor `AzureMachinePool.Spec.Template.SpotVMOptions.MaxPrice` and `AzureMachine.Spec.SpotVMOptions.MaxPrice` types to accept float values using the Go client. Action required: if upgrading a cluster to this version, and you're using spot instances with a set maximum price, you have to manually update the `azuremachinepools.spec.template.spotVMOptions.maxPrice` and `azuremachines.spec.spotVMOptions.maxPrice` fields. Wrapping the value in quotes will do the trick.
```
