### PR TITLE
Switch LB Probe to TCP

### DIFF
--- a/azure/services/loadbalancers/loadbalancers.go
+++ b/azure/services/loadbalancers/loadbalancers.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	httpsProbe  = "HTTPSProbe"
+	tcpProbe    = "TCPProbe"
 	lbRuleHTTPS = "LBRuleHTTPS"
 	outboundNAT = "OutboundNATAllProtocols"
 )
@@ -269,7 +269,7 @@ func (s *Service) getLoadBalancingRules(lbSpec azure.LBSpec, frontendIDs []netwo
 						ID: to.StringPtr(azure.AddressPoolID(s.Scope.SubscriptionID(), s.Scope.ResourceGroup(), lbSpec.Name, lbSpec.BackendPoolName)),
 					},
 					Probe: &network.SubResource{
-						ID: to.StringPtr(azure.ProbeID(s.Scope.SubscriptionID(), s.Scope.ResourceGroup(), lbSpec.Name, httpsProbe)),
+						ID: to.StringPtr(azure.ProbeID(s.Scope.SubscriptionID(), s.Scope.ResourceGroup(), lbSpec.Name, tcpProbe)),
 					},
 				},
 			},
@@ -290,10 +290,9 @@ func (s *Service) getProbes(lbSpec azure.LBSpec) []network.Probe {
 	if lbSpec.Role == infrav1.APIServerRole {
 		return []network.Probe{
 			{
-				Name: to.StringPtr(httpsProbe),
+				Name: to.StringPtr(tcpProbe),
 				ProbePropertiesFormat: &network.ProbePropertiesFormat{
-					Protocol:          network.ProbeProtocolHTTPS,
-					RequestPath:       to.StringPtr("/healthz"),
+					Protocol:          network.ProbeProtocolTCP,
 					Port:              to.Int32Ptr(lbSpec.APIServerPort),
 					IntervalInSeconds: to.Int32Ptr(15),
 					NumberOfProbes:    to.Int32Ptr(4),

--- a/azure/services/loadbalancers/loadbalancers_test.go
+++ b/azure/services/loadbalancers/loadbalancers_test.go
@@ -445,18 +445,17 @@ func newDefaultPublicAPIServerLB() network.LoadBalancer {
 							ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/backendAddressPools/my-publiclb-backendPool"),
 						},
 						Probe: &network.SubResource{
-							ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/probes/HTTPSProbe"),
+							ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/probes/TCPProbe"),
 						},
 					},
 				},
 			},
 			Probes: &[]network.Probe{
 				{
-					Name: to.StringPtr(httpsProbe),
+					Name: to.StringPtr(tcpProbe),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Protocol:          network.ProbeProtocolHTTPS,
+						Protocol:          network.ProbeProtocolTCP,
 						Port:              to.Int32Ptr(6443),
-						RequestPath:       to.StringPtr("/healthz"),
 						IntervalInSeconds: to.Int32Ptr(15),
 						NumberOfProbes:    to.Int32Ptr(4),
 					},
@@ -525,7 +524,7 @@ func newDefaultInternalAPIServerLB() network.LoadBalancer {
 							ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/backendAddressPools/my-private-lb-backendPool"),
 						},
 						Probe: &network.SubResource{
-							ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/probes/HTTPSProbe"),
+							ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-private-lb/probes/TCPProbe"),
 						},
 					},
 				},
@@ -533,11 +532,10 @@ func newDefaultInternalAPIServerLB() network.LoadBalancer {
 			OutboundRules: &[]network.OutboundRule{},
 			Probes: &[]network.Probe{
 				{
-					Name: to.StringPtr(httpsProbe),
+					Name: to.StringPtr(tcpProbe),
 					ProbePropertiesFormat: &network.ProbePropertiesFormat{
-						Protocol:          network.ProbeProtocolHTTPS,
+						Protocol:          network.ProbeProtocolTCP,
 						Port:              to.Int32Ptr(6443),
-						RequestPath:       to.StringPtr("/healthz"),
 						IntervalInSeconds: to.Int32Ptr(15),
 						NumberOfProbes:    to.Int32Ptr(4),
 					},


### PR DESCRIPTION
Co-Authored-By: Zach <45979377+zawachte-msft@users.noreply.github.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Rebased #1103. Credit goes to @zawachte-msft.

> Today the load balancer code creates a healthcheck probe which hits the api-server /healthz endpoint.
> Two issues with this.
> The /healthz endpoint has been deprecated since kubernetes v1.16 https://kubernetes.io/docs/reference/using-api/health-checks/
If you have anonymous-auth for the api-server set to false, this breaks cluster-bring-up since the loadbalancer probe will fail with an auth error.
Not well versed in the azure load balancer so I don't know what the proper fix is, but I tested changing to a TCP probe and it works.
> I assume there is a better solution. AWS seems to have a SSL check that doesn't require this endpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1102 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Switch LB Probe to TCP
```
