### PR TITLE
Backport of PR #1164 to release 0.4

### DIFF
--- a/exp/api/v1alpha3/azuremachinepool_types.go
+++ b/exp/api/v1alpha3/azuremachinepool_types.go
@@ -125,7 +125,7 @@ type (
 
 		// Instances is the VM instance status for each VM in the VMSS
 		// +optional
-		Instances []*AzureMachinePoolInstanceStatus `json:"instances"`
+		Instances []*AzureMachinePoolInstanceStatus `json:"instances,omitempty"`
 
 		// Version is the Kubernetes version for the current VMSS model
 		// +optional


### PR DESCRIPTION
This is a backport of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1164 to the 0.4 release branch

**Release note**:
```release-note
Added omitempty option to the AzureMachinePool/Status/Instances field to avoid null errors when the field is not set.
```
