### PR TITLE
Set OS type Linux for managed node pool when submitting Azure API request

### DIFF
--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -53,6 +53,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 	profile := containerservice.AgentPool{
 		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 			VMSize:              containerservice.VMSizeTypes(agentPoolSpec.SKU),
+			OsType:              containerservice.Linux,
 			OsDiskSizeGB:        &agentPoolSpec.OSDiskSizeGB,
 			Count:               &agentPoolSpec.Replicas,
 			Type:                containerservice.VirtualMachineScaleSets,
@@ -87,6 +88,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 		existingProfile := containerservice.AgentPool{
 			ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 				VMSize:              existingPool.ManagedClusterAgentPoolProfileProperties.VMSize,
+				OsType:              containerservice.Linux,
 				OsDiskSizeGB:        existingPool.ManagedClusterAgentPoolProfileProperties.OsDiskSizeGB,
 				Count:               existingPool.ManagedClusterAgentPoolProfileProperties.Count,
 				Type:                containerservice.VirtualMachineScaleSets,

--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -243,6 +243,7 @@ func TestReconcile(t *testing.T) {
 						Count:               to.Int32Ptr(2),
 						OsDiskSizeGB:        to.Int32Ptr(100),
 						VMSize:              containerservice.VMSizeTypesStandardD2sV3,
+						OsType:              containerservice.Linux,
 						OrchestratorVersion: to.StringPtr("9.99.9999"),
 						ProvisioningState:   to.StringPtr("Succeeded"),
 						VnetSubnetID:        to.StringPtr(""),


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds setting of OS type `Linux` for managed node pool when submitting Azure API request.

When this is not set explicitly, Azure API returns the following error when CR is created for an existing AKS cluster:

```
"error creating AzureManagedMachinePool default/aks6pool1: failed to reconcile machine pool aks6pool1: failed to create or update agent pool: failed to begin operation: containerservice.AgentPoolsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code=\"SystemPoolMustBeLinux\" Message=\"System node pool must be linux. Nodepool name: aks6pool1.\"" "controller"="azuremanagedmachinepool" "name"="aks6pool1" "namespace"="default"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1174

OS type `Linux` is currently hardcoded in the `ManagedClusterAgentPoolProfileProperties`.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set OS type Linux for managed node pool when submitting Azure API request
```
