### PR TITLE
Fix handling of AzureMachine terminal errors

### DIFF
--- a/azure/services/availabilitysets/availabilitysets_test.go
+++ b/azure/services/availabilitysets/availabilitysets_test.go
@@ -75,7 +75,7 @@ func TestReconcileAvailabilitySets(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -115,7 +115,7 @@ func TestReconcileAvailabilitySets(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},

--- a/azure/services/networkinterfaces/networkinterfaces.go
+++ b/azure/services/networkinterfaces/networkinterfaces.go
@@ -114,7 +114,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				// set accelerated networking to the capability of the VMSize
 				sku, err := s.resourceSKUCache.Get(ctx, nicSpec.VMSize, resourceskus.VirtualMachines)
 				if err != nil {
-					return errors.Wrapf(err, "failed to get find vm sku %s in compute api", nicSpec.VMSize)
+					return azure.WithTerminalError(errors.Wrapf(err, "failed to get SKU %s in compute api", nicSpec.VMSize))
 				}
 
 				accelNet := sku.HasCapability(resourceskus.AcceleratedNetworking)

--- a/azure/services/networkinterfaces/networkinterfaces_test.go
+++ b/azure/services/networkinterfaces/networkinterfaces_test.go
@@ -434,7 +434,7 @@ func TestReconcileNetworkInterface(t *testing.T) {
 							},
 						},
 					},
-				}),
+				}, ""),
 			}
 
 			err := s.Reconcile(context.TODO())

--- a/azure/services/resourceskus/cache.go
+++ b/azure/services/resourceskus/cache.go
@@ -93,17 +93,11 @@ func GetCache(auth azure.Authorizer, location string) (*Cache, error) {
 	return c.(*Cache), nil
 }
 
-// NewStaticCacheFn returns a function that initializes a cache with data and no ability to refresh. Used for testing.
-func NewStaticCacheFn(data []compute.ResourceSku) NewCacheFunc {
-	return func(azure.Authorizer, string) *Cache {
-		return NewStaticCache(data)
-	}
-}
-
 // NewStaticCache initializes a cache with data and no ability to refresh. Used for testing.
-func NewStaticCache(data []compute.ResourceSku) *Cache {
+func NewStaticCache(data []compute.ResourceSku, location string) *Cache {
 	return &Cache{
-		data: data,
+		data:     data,
+		location: location,
 	}
 }
 
@@ -141,7 +135,7 @@ func (c *Cache) Get(ctx context.Context, name string, kind ResourceType) (SKU, e
 			return SKU(sku), nil
 		}
 	}
-	return SKU{}, fmt.Errorf("resource sku with name '%s' and category '%s' not found", name, string(kind))
+	return SKU{}, fmt.Errorf("resource sku with name '%s' and category '%s' not found in location '%s'", name, string(kind), c.location)
 }
 
 // Map invokes a function over all cached values.

--- a/azure/services/resourceskus/cache_test.go
+++ b/azure/services/resourceskus/cache_test.go
@@ -29,12 +29,14 @@ import (
 func TestCacheGet(t *testing.T) {
 	cases := map[string]struct {
 		sku          string
+		location     string
 		resourceType ResourceType
 		have         []compute.ResourceSku
 		err          string
 	}{
 		"should find": {
 			sku:          "foo",
+			location:     "test",
 			resourceType: "bar",
 			have: []compute.ResourceSku{
 				{
@@ -49,13 +51,14 @@ func TestCacheGet(t *testing.T) {
 		},
 		"should not find": {
 			sku:          "foo",
+			location:     "test",
 			resourceType: "bar",
 			have: []compute.ResourceSku{
 				{
 					Name: to.StringPtr("other"),
 				},
 			},
-			err: "resource sku with name 'foo' and category 'bar' not found",
+			err: "resource sku with name 'foo' and category 'bar' not found in location 'test'",
 		},
 	}
 
@@ -65,7 +68,8 @@ func TestCacheGet(t *testing.T) {
 			t.Parallel()
 
 			cache := &Cache{
-				data: tc.have,
+				data:     tc.have,
+				location: tc.location,
 			}
 
 			val, err := cache.Get(context.Background(), tc.sku, tc.resourceType)

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -274,13 +274,13 @@ func (s *Service) validateSpec(ctx context.Context) error {
 	spec := s.Scope.ScaleSetSpec()
 	sku, err := s.resourceSKUCache.Get(ctx, spec.Size, resourceskus.VirtualMachines)
 	if err != nil {
-		return azure.WithTerminalError(errors.Wrapf(err, "failed to get find SKU %s in compute api", spec.Size))
+		return azure.WithTerminalError(errors.Wrapf(err, "failed to get SKU %s in compute api", spec.Size))
 	}
 
 	// Checking if the requested VM size has at least 2 vCPUS
 	vCPUCapability, err := sku.HasCapabilityWithCapacity(resourceskus.VCPUs, resourceskus.MinimumVCPUS)
 	if err != nil {
-		return azure.WithTerminalError(errors.Wrap(err, "failed to validate the vCPU cabability"))
+		return azure.WithTerminalError(errors.Wrap(err, "failed to validate the vCPU capability"))
 	}
 
 	if !vCPUCapability {
@@ -290,7 +290,7 @@ func (s *Service) validateSpec(ctx context.Context) error {
 	// Checking if the requested VM size has at least 2 Gi of memory
 	MemoryCapability, err := sku.HasCapabilityWithCapacity(resourceskus.MemoryGB, resourceskus.MinimumMemory)
 	if err != nil {
-		return azure.WithTerminalError(errors.Wrap(err, "failed to validate the memory cabability"))
+		return azure.WithTerminalError(errors.Wrap(err, "failed to validate the memory capability"))
 	}
 
 	if !MemoryCapability {
@@ -317,7 +317,7 @@ func (s *Service) buildVMSSFromSpec(ctx context.Context, vmssSpec azure.ScaleSet
 
 	sku, err := s.resourceSKUCache.Get(ctx, vmssSpec.Size, resourceskus.VirtualMachines)
 	if err != nil {
-		return result, errors.Wrapf(err, "failed to get find SKU %s in compute api", vmssSpec.Size)
+		return result, errors.Wrapf(err, "failed to get SKU %s in compute api", vmssSpec.Size)
 	}
 
 	if vmssSpec.AcceleratedNetworking == nil {

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -89,7 +89,7 @@ func TestNewService(t *testing.T) {
 		ClusterScope:     s,
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	actual := NewService(mps, resourceskus.NewStaticCache(nil))
+	actual := NewService(mps, resourceskus.NewStaticCache(nil, ""))
 	g.Expect(actual).ToNot(BeNil())
 }
 
@@ -492,7 +492,7 @@ func TestReconcileVMSS(t *testing.T) {
 		},
 		{
 			name:          "failed to get SKU",
-			expectedError: "reconcile error occurred that cannot be recovered. Object will not be requeued. The actual error is: failed to get find SKU INVALID_VM_SIZE in compute api: resource sku with name 'INVALID_VM_SIZE' and category 'virtualMachines' not found",
+			expectedError: "reconcile error occurred that cannot be recovered. Object will not be requeued. The actual error is: failed to get SKU INVALID_VM_SIZE in compute api: resource sku with name 'INVALID_VM_SIZE' and category 'virtualMachines' not found in location 'test-location'",
 			expect: func(g *WithT, s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
 				s.ScaleSetSpec().Return(azure.ScaleSetSpec{
 					Name:       defaultVMSSName,
@@ -531,7 +531,7 @@ func TestReconcileVMSS(t *testing.T) {
 			s := &Service{
 				Scope:            scopeMock,
 				Client:           clientMock,
-				resourceSKUCache: resourceskus.NewStaticCache(getFakeSkus()),
+				resourceSKUCache: resourceskus.NewStaticCache(getFakeSkus(), "test-location"),
 			}
 
 			err := s.Reconcile(context.TODO())

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -473,7 +473,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -545,7 +545,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -617,7 +617,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -690,7 +690,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -779,7 +779,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 			},
 		},
@@ -856,7 +856,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -930,7 +930,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}
 
-				svc.resourceSKUCache = resourceskus.NewStaticCache(skus)
+				svc.resourceSKUCache = resourceskus.NewStaticCache(skus, "")
 
 			},
 		},
@@ -1086,7 +1086,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -1145,7 +1145,7 @@ func TestReconcileVM(t *testing.T) {
 					},
 				}
 
-				svc.resourceSKUCache = resourceskus.NewStaticCache(skus)
+				svc.resourceSKUCache = resourceskus.NewStaticCache(skus, "")
 			},
 		},
 		{
@@ -1212,7 +1212,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -1252,7 +1252,7 @@ func TestReconcileVM(t *testing.T) {
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
-			ExpectedError: "vm size should be bigger or equal to at least 2 vCPUs",
+			ExpectedError: "reconcile error occurred that cannot be recovered. Object will not be requeued. The actual error is: vm size should be bigger or equal to at least 2 vCPUs",
 			SetupSKUs: func(svc *Service) {
 				skus := []compute.ResourceSku{
 					{
@@ -1279,7 +1279,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -1319,7 +1319,7 @@ func TestReconcileVM(t *testing.T) {
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
-			ExpectedError: "vm memory should be bigger or equal to at least 2Gi",
+			ExpectedError: "reconcile error occurred that cannot be recovered. Object will not be requeued. The actual error is: vm memory should be bigger or equal to at least 2Gi",
 			SetupSKUs: func(svc *Service) {
 				skus := []compute.ResourceSku{
 					{
@@ -1346,7 +1346,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -1389,7 +1389,7 @@ func TestReconcileVM(t *testing.T) {
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
-			ExpectedError: "vm size Standard_D2v3 does not support ephemeral os. select a different vm size or disable ephemeral os",
+			ExpectedError: "reconcile error occurred that cannot be recovered. Object will not be requeued. The actual error is: vm size Standard_D2v3 does not support ephemeral os. select a different vm size or disable ephemeral os",
 			SetupSKUs: func(svc *Service) {
 				skus := []compute.ResourceSku{
 					{
@@ -1420,7 +1420,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -1585,7 +1585,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 
 			},
@@ -1746,7 +1746,7 @@ func TestReconcileVM(t *testing.T) {
 						},
 					},
 				}
-				resourceSkusCache := resourceskus.NewStaticCache(skus)
+				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
 			},
 		},
@@ -1791,7 +1791,7 @@ func TestReconcileVM(t *testing.T) {
 				interfacesClient:       interfaceMock,
 				publicIPsClient:        publicIPMock,
 				availabilitySetsClient: availabilitySetsMock,
-				resourceSKUCache:       resourceskus.NewStaticCache(nil),
+				resourceSKUCache:       resourceskus.NewStaticCache(nil, ""),
 			}
 
 			tc.SetupSKUs(s)

--- a/controllers/azurecluster_reconciler_test.go
+++ b/controllers/azurecluster_reconciler_test.go
@@ -125,7 +125,7 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 				publicIPSvc:      publicIPMock,
 				loadBalancerSvc:  lbMock,
 				privateDNSSvc:    dnsMock,
-				skuCache:         resourceskus.NewStaticCache([]compute.ResourceSku{}),
+				skuCache:         resourceskus.NewStaticCache([]compute.ResourceSku{}, ""),
 			}
 
 			err := s.Delete(context.TODO())


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: We were calling Reconcile twice and returning the error on the first call so the handling of terminal error code was never reached. Also made some more errors in virtualmachines terminal (matching what was already done for scale sets). This now accurately puts your AzureMachine and thus Machine in a failed state if you pass in an incorrect VM size or a VM size that is not available in that particular region.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix handling of AzureMachine terminal errors
```
