### PR TITLE
Reconcile FailureDomains in AzureMachinePool

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -119,6 +119,7 @@ func (m *MachinePoolScope) ScaleSetSpec() azure.ScaleSetSpec {
 		UserAssignedIdentities:  m.AzureMachinePool.Spec.UserAssignedIdentities,
 		SecurityProfile:         m.AzureMachinePool.Spec.Template.SecurityProfile,
 		SpotVMOptions:           m.AzureMachinePool.Spec.Template.SpotVMOptions,
+		FailureDomains:          m.MachinePool.Spec.FailureDomains,
 	}
 }
 

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -124,6 +124,7 @@ func TestGetExistingVMSS(t *testing.T) {
 				Identity: "",
 				Tags:     nil,
 				Capacity: int64(1),
+				Zones:    []string{"1", "3"},
 				Instances: []infrav1exp.VMSSVM{
 					{
 						ID:         "my-vm-id",
@@ -148,6 +149,7 @@ func TestGetExistingVMSS(t *testing.T) {
 					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 						ProvisioningState: to.StringPtr("Succeeded"),
 					},
+					Zones: &[]string{"1", "3"},
 				}, nil)
 				m.ListInstances(gomock.Any(), "my-rg", "my-vmss").Return([]compute.VirtualMachineScaleSetVM{
 					{
@@ -634,15 +636,16 @@ func TestDeleteVMSS(t *testing.T) {
 func getFakeSkus() []compute.ResourceSku {
 	return []compute.ResourceSku{
 		{
-			Name: to.StringPtr("VM_SIZE"),
-			Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Name:         to.StringPtr("VM_SIZE"),
+			ResourceType: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Kind:         to.StringPtr(string(resourceskus.VirtualMachines)),
 			Locations: &[]string{
 				"test-location",
 			},
 			LocationInfo: &[]compute.ResourceSkuLocationInfo{
 				{
 					Location: to.StringPtr("test-location"),
-					Zones:    &[]string{"1"},
+					Zones:    &[]string{"1", "3"},
 				},
 			},
 			Capabilities: &[]compute.ResourceSkuCapabilities{
@@ -661,15 +664,16 @@ func getFakeSkus() []compute.ResourceSku {
 			},
 		},
 		{
-			Name: to.StringPtr("VM_SIZE_AN"),
-			Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Name:         to.StringPtr("VM_SIZE_AN"),
+			ResourceType: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Kind:         to.StringPtr(string(resourceskus.VirtualMachines)),
 			Locations: &[]string{
 				"test-location",
 			},
 			LocationInfo: &[]compute.ResourceSkuLocationInfo{
 				{
 					Location: to.StringPtr("test-location"),
-					Zones:    &[]string{"1"},
+					Zones:    &[]string{"1", "3"},
 				},
 			},
 			Capabilities: &[]compute.ResourceSkuCapabilities{
@@ -688,15 +692,16 @@ func getFakeSkus() []compute.ResourceSku {
 			},
 		},
 		{
-			Name: to.StringPtr("VM_SIZE_1_CPU"),
-			Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Name:         to.StringPtr("VM_SIZE_1_CPU"),
+			ResourceType: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Kind:         to.StringPtr(string(resourceskus.VirtualMachines)),
 			Locations: &[]string{
 				"test-location",
 			},
 			LocationInfo: &[]compute.ResourceSkuLocationInfo{
 				{
 					Location: to.StringPtr("test-location"),
-					Zones:    &[]string{"1"},
+					Zones:    &[]string{"1", "3"},
 				},
 			},
 			Capabilities: &[]compute.ResourceSkuCapabilities{
@@ -715,15 +720,16 @@ func getFakeSkus() []compute.ResourceSku {
 			},
 		},
 		{
-			Name: to.StringPtr("VM_SIZE_1_MEM"),
-			Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Name:         to.StringPtr("VM_SIZE_1_MEM"),
+			ResourceType: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Kind:         to.StringPtr(string(resourceskus.VirtualMachines)),
 			Locations: &[]string{
 				"test-location",
 			},
 			LocationInfo: &[]compute.ResourceSkuLocationInfo{
 				{
 					Location: to.StringPtr("test-location"),
-					Zones:    &[]string{"1"},
+					Zones:    &[]string{"1", "3"},
 				},
 			},
 			Capabilities: &[]compute.ResourceSkuCapabilities{
@@ -742,15 +748,16 @@ func getFakeSkus() []compute.ResourceSku {
 			},
 		},
 		{
-			Name: to.StringPtr("VM_SIZE_EAH"),
-			Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Name:         to.StringPtr("VM_SIZE_EAH"),
+			ResourceType: to.StringPtr(string(resourceskus.VirtualMachines)),
+			Kind:         to.StringPtr(string(resourceskus.VirtualMachines)),
 			Locations: &[]string{
 				"test-location",
 			},
 			LocationInfo: &[]compute.ResourceSkuLocationInfo{
 				{
 					Location: to.StringPtr("test-location"),
-					Zones:    &[]string{"1"},
+					Zones:    &[]string{"1", "3"},
 				},
 			},
 			Capabilities: &[]compute.ResourceSkuCapabilities{
@@ -817,6 +824,7 @@ func newDefaultVMSSSpec() azure.ScaleSetSpec {
 		PublicLBAddressPoolName:      "backendPool",
 		AcceleratedNetworking:        nil,
 		TerminateNotificationTimeout: to.IntPtr(7),
+		FailureDomains:               []string{"1", "3"},
 	}
 }
 
@@ -839,6 +847,7 @@ func newDefaultVMSS() compute.VirtualMachineScaleSet {
 			Tier:     to.StringPtr("Standard"),
 			Capacity: to.Int64Ptr(2),
 		},
+		Zones: &[]string{"1", "3"},
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 			UpgradePolicy: &compute.UpgradePolicy{
 				Mode: compute.UpgradeModeRolling,
@@ -1013,7 +1022,7 @@ func setupDefaultVMSSExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorde
 	s.ResourceGroup().AnyTimes().Return(defaultResourceGroup)
 	s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 	s.AdditionalTags()
-	s.Location().Return("test-location")
+	s.Location().AnyTimes().Return("test-location")
 	s.ClusterName().Return("my-cluster")
 	s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
 	s.GetVMImage().Return(&infrav1.Image{

--- a/azure/types.go
+++ b/azure/types.go
@@ -165,6 +165,7 @@ type ScaleSetSpec struct {
 	UserAssignedIdentities       []infrav1.UserAssignedIdentity
 	SecurityProfile              *infrav1.SecurityProfile
 	SpotVMOptions                *infrav1.SpotVMOptions
+	FailureDomains               []string
 }
 
 // TagsSpec defines the specification for a set of tags.

--- a/util/slice/slice.go
+++ b/util/slice/slice.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slice
+
+// Contains tells whether a Contains x.
+func Contains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
It was not possible to specify the `FailureDomains` when creating a `MachinePool`. This PR tries to reconcile the VMSS created by the `AzureMachinePool` using the selected `FailureDomains`.

**Which issue(s) this PR fixes**:
Fixes #663 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reconcile `FailureDomains` in `AzureMachinePool`

```