### PR TITLE
Accept cluster names that start with a number

### DIFF
--- a/api/v1alpha3/azurecluster_validation.go
+++ b/api/v1alpha3/azurecluster_validation.go
@@ -29,7 +29,7 @@ import (
 const (
 	// can't use: \/"'[]:|<>+=;,.?*@&, Can't start with underscore. Can't end with period or hyphen.
 	// not using . in the name to avoid issues when the name is part of DNS name
-	clusterNameRegex = `^[a-z][a-z0-9-]{0,44}[a-z0-9]$`
+	clusterNameRegex = `^[a-z0-9][a-z0-9-]{0,42}[a-z0-9]$`
 	// max length of 44 to allow for cluster name to be used as a prefix for VMs and other resources that
 	// have limitations as outlined here https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
 	clusterNameMaxLength = 44

--- a/api/v1alpha3/azurecluster_validation_test.go
+++ b/api/v1alpha3/azurecluster_validation_test.go
@@ -67,6 +67,11 @@ func TestClusterNameValidation(t *testing.T) {
 			wantErr:     true,
 		},
 		{
+			name:        "cluster name starting with number",
+			clusterName: "1clustername",
+			wantErr:     false,
+		},
+		{
 			name:        "cluster name with underscore",
 			clusterName: "cluster_name",
 			wantErr:     true,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Trying to create an AzureCluster CR named "1a2b3c" is not allowed. The webhook will prevent it failing with
```
Cluster Name doesn't match regex ^[a-z][a-z0-9-]{0,44}[a-z0-9]$, can contain only lowercase alphanumeric characters and '-', must start/end with an alphanumeric character
```

This PR makes the error message and the validation to match, allowing names that start with a number.

**Which issue(s) this PR fixes**:
Fixes #1179 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Names that start with a number are valid `AzureCluster` names.
```
