### PR TITLE
fix extra single quote in e2e image purge and add second repo job

### DIFF
--- a/hack/ensure-acr-cleanup-schedule.sh
+++ b/hack/ensure-acr-cleanup-schedule.sh
@@ -18,7 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-registry="ci-e2e/cluster-api-azure-controller-amd64"
+e2e_registry="ci-e2e/cluster-api-azure-controller-amd64"
+az acr task create --name midnight_capz_ci_e2e_purge --cmd "acr purge --filter ${e2e_registry}:.* --ago 1d --untagged" \
+  --schedule "0 0 * * *" --registry capzci --context /dev/null
 
-az acr task create --name midnight_ci_e2e_purge --cmd "acr purge --filter '${registry}:.* --ago 1d --untagged" \
+registry="cluster-api-azure-controller-amd64"
+az acr task create --name midnight_capz_purge --cmd "acr purge --filter ${registry}:.* --ago 1d --untagged" \
   --schedule "0 0 * * *" --registry capzci --context /dev/null


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
The nightly image purge job has an error in the script it executes, an errant single quote. This fixes the script and adds a second
purge job which targets repo: cluster-api-azure-controller-amd64.

It appears our CI jobs use both `ci-e2e/cluster-api-azure-controller-amd64` and `cluster-api-azure-controller-amd64`.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix original capzci registry purge job and add second for repo: cluster-api-azure-controller-amd64
```

**Script Output**:
![image](https://user-images.githubusercontent.com/386473/108903318-2dbc1f80-75eb-11eb-9a08-35f0354a46b5.png)