### PR TITLE
do not include customData in AzureMachinePool hash calculation

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
             - --leader-elect
             - "--metrics-bind-addr=127.0.0.1:8080"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},AKS=${EXP_AKS:=false}"
+            - "--v=0"
           image: controller:latest
           imagePullPolicy: Always
           name: manager

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -75,6 +75,9 @@ providers:
       targetName: "cluster-template-windows.yaml"
     - sourcePath: "${PWD}/templates/test/cluster-template-prow-machine-pool-windows.yaml"
       targetName: "cluster-template-machine-pool-windows.yaml"
+    replacements:
+    - old: "--v=0"
+      new: "--v=4"
 
 variables:
   KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.19.7}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
AzureMachinePool will occasionally enter into a cycle where the hash tag calculated from the last model update will be different than the hash calculated for a newly reconciled AzureMachinePool since the bootstrap data secret has been updated since the previous reconcile causing the customData of the VMSS to change, thus changing the hash for the entire model.

This PR removes the customData from the hash calculation and increases test controller log verbosity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related: #1190, #1186, #1182

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not include VMSS customData in the hash tag calculation to correct a reconcile cycle caused when the bootstrap token refreshes.
```
