### PR TITLE
Fix AKS cluster provisioning errors

### DIFF
--- a/exp/api/v1alpha4/azuremanagedcontrolplane_webhook_test.go
+++ b/exp/api/v1alpha4/azuremanagedcontrolplane_webhook_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -245,6 +246,254 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			name:    "AzureManagedControlPlane with invalid version",
 			oldAMCP: createAzureManagedControlPlane(t, "", "v1.18.0", ""),
 			amcp:    createAzureManagedControlPlane(t, "192.168.0.0", "1.999.9", generateSSHPublicKey(true)),
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane SubscriptionID is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:   to.StringPtr("192.168.0.0"),
+					SubscriptionID: "212ec1q8",
+					Version:        "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:   to.StringPtr("192.168.0.0"),
+					SubscriptionID: "212ec1q9",
+					Version:        "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane ResourceGroupName is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:      to.StringPtr("192.168.0.0"),
+					ResourceGroupName: "hello-1",
+					Version:           "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:      to.StringPtr("192.168.0.0"),
+					ResourceGroupName: "hello-2",
+					Version:           "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane NodeResourceGroupName is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:          to.StringPtr("192.168.0.0"),
+					NodeResourceGroupName: "hello-1",
+					Version:               "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:          to.StringPtr("192.168.0.0"),
+					NodeResourceGroupName: "hello-2",
+					Version:               "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane Location is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Location:     "westeurope",
+					Version:      "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Location:     "eastus",
+					Version:      "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane SSHPublicKey is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					SSHPublicKey: generateSSHPublicKey(true),
+					Version:      "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					SSHPublicKey: generateSSHPublicKey(true),
+					Version:      "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane DNSServiceIP is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.1"),
+					Version:      "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane DNSServiceIP is immutable, unsetting is not allowed",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					Version: "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane NetworkPlugin is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:  to.StringPtr("192.168.0.0"),
+					NetworkPlugin: to.StringPtr("azure"),
+					Version:       "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:  to.StringPtr("192.168.0.0"),
+					NetworkPlugin: to.StringPtr("kubenet"),
+					Version:       "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane NetworkPlugin is immutable, unsetting is not allowed",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:  to.StringPtr("192.168.0.0"),
+					NetworkPlugin: to.StringPtr("azure"),
+					Version:       "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane NetworkPolicy is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:  to.StringPtr("192.168.0.0"),
+					NetworkPolicy: to.StringPtr("azure"),
+					Version:       "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:  to.StringPtr("192.168.0.0"),
+					NetworkPolicy: to.StringPtr("calico"),
+					Version:       "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane NetworkPolicy is immutable, unsetting is not allowed",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:  to.StringPtr("192.168.0.0"),
+					NetworkPolicy: to.StringPtr("azure"),
+					Version:       "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane LoadBalancerSKU is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:    to.StringPtr("192.168.0.0"),
+					LoadBalancerSKU: to.StringPtr("Standard"),
+					Version:         "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:    to.StringPtr("192.168.0.0"),
+					LoadBalancerSKU: to.StringPtr("Basic"),
+					Version:         "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane LoadBalancerSKU is immutable, unsetting is not allowed",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP:    to.StringPtr("192.168.0.0"),
+					LoadBalancerSKU: to.StringPtr("Standard"),
+					Version:         "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.18.0",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AzureManagedControlPlane DefaultPoolRef.Name is immutable",
+			oldAMCP: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DefaultPoolRef: v1.LocalObjectReference{
+						Name: "pool-1",
+					},
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.18.0",
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DefaultPoolRef: v1.LocalObjectReference{
+						Name: "pool-2",
+					},
+					DNSServiceIP: to.StringPtr("192.168.0.0"),
+					Version:      "v1.18.0",
+				},
+			},
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind bug

**What this PR does / why we need it**:

Currently when AKS cluster is being created there are many Azure API errors, where some occur almost on every cluster creation, while other occur only every now and then (since Azure API is called from multiple controllers from their own reconciliation loops, so it depends in which order the API calls are made).

Here are some of the examples.

_1. Error when trying to create or update an additional non-system agent pool, which happens when the AKS cluster is still not created_

Error from CAPZ controller logs:
```
error creating AzureManagedMachinePool default/<agenpool name>:
  failed to reconcile machine pool <agenpool name>:
    failed to create or update agent pool:
      failed to begin operation:
        containerservice.AgentPoolsClient#CreateOrUpdate: Failure sending request: StatusCode=0
          -- Original Error: autorest/azure: Service returned an error. Status=\u003cnil\u003e \u003cnil\u003e
```

_2. Error when trying to create or update AKS cluster while agent pool is being created_

Error from Azure activity log (truncated for the sake of readability):

```
{
    "authorization": {
        "action": "Microsoft.ContainerService/managedClusters/write",
        "scope": "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<CLUSTER NAME>/providers/Microsoft.ContainerService/managedClusters/<CLUSTER NAME>"
    },
    "channels": "Operation",
    "eventName": {
        "value": "EndRequest",
        "localizedValue": "End request"
    },
    "category": {
        "value": "Administrative",
        "localizedValue": "Administrative"
    },
    "level": "Error",
    "operationName": {
        "value": "Microsoft.ContainerService/managedClusters/write",
        "localizedValue": "Create or Update Managed Cluster"
    },
    "resourceGroupName": "<CLUSTER NAME>",
    "resourceProviderName": {
        "value": "Microsoft.ContainerService",
        "localizedValue": "Microsoft.ContainerService"
    },
    "resourceType": {
        "value": "Microsoft.ContainerService/managedClusters",
        "localizedValue": "Microsoft.ContainerService/managedClusters"
    },
    "resourceId": "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<CLUSTER NAME>/providers/Microsoft.ContainerService/managedClusters/<CLUSTER NAME>",
    "status": {
        "value": "Failed",
        "localizedValue": "Failed"
    },
    "subStatus": {
        "value": "Conflict",
        "localizedValue": "Conflict (HTTP Status Code: 409)"
    },
    "submissionTimestamp": "2021-02-22T11:25:38.1599708Z",
    "subscriptionId": "<SUBSCRIPTION_ID>",
    "properties": {
        "statusCode": "Conflict",
        "statusMessage": "{\"code\":\"OperationNotAllowed\",\"message\":\"Operation is not allowed: Another operation (<agent pool name> - Creating) is in progress, please wait for it to finish before starting a new operation. See https://aka.ms/aks-pending-operation for more details\"}",
        "eventCategory": "Administrative",
        "entity": "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<CLUSTER NAME>/providers/Microsoft.ContainerService/managedClusters/<CLUSTER NAME>",
        "message": "Microsoft.ContainerService/managedClusters/write",
        "hierarchy": "<SUBSCRIPTION_ID>"
    },
}
```

_3. Throttling error and getting 429 response code due to too many requests. `CreateOrUpdate` request for the managed cluster is sent on every reconciliation loop, even when there are no changes in the cluster CRs_

Error from Azure activity log (truncated for the sake of readability):
```
{
    "authorization": {
        "action": "Microsoft.ContainerService/managedClusters/write",
        "scope": "/subscriptions/<SUBSCRIPTION ID>/resourceGroups/<CLUSTER ID>/providers/Microsoft.ContainerService/managedClusters/<CLUSTER ID>"
    },
    "channels": "Operation",
    "eventName": {
        "value": "EndRequest",
        "localizedValue": "End request"
    },
    "category": {
        "value": "Administrative",
        "localizedValue": "Administrative"
    },
    "eventTimestamp": "2021-02-22T11:24:37.3869786Z",
    "level": "Error",
    "operationName": {
        "value": "Microsoft.ContainerService/managedClusters/write",
        "localizedValue": "Create or Update Managed Cluster"
    },
    "resourceGroupName": "<CLUSTER ID>",
    "resourceProviderName": {
        "value": "Microsoft.ContainerService",
        "localizedValue": "Microsoft.ContainerService"
    },
    "resourceType": {
        "value": "Microsoft.ContainerService/managedClusters",
        "localizedValue": "Microsoft.ContainerService/managedClusters"
    },
    "resourceId": "/subscriptions/<SUBSCRIPTION ID>/resourceGroups/<CLUSTER ID>/providers/Microsoft.ContainerService/managedClusters/<CLUSTER ID>",
    "status": {
        "value": "Failed",
        "localizedValue": "Failed"
    },
    "subStatus": {
        "value": "429",
        "localizedValue": "429"
    },
    "subscriptionId": "<SUBSCRIPTION ID>",
    "properties": {
        "statusCode": "429",
        "serviceRequestId": null,
        "statusMessage": "{\"error\":{\"code\":\"FailedIdentityOperation\",\"message\":\"Identity operation for resource '/subscriptions/<SUBSCRIPTION ID>/resourceGroups/<CLUSTER ID>/providers/Microsoft.ContainerService/managedClusters/<CLUSTER ID>' failed with error 'Failed to perform resource identity operation. Status: '429'. Response: '{\\\"error\\\":{\\\"code\\\":\\\"429\\\",\\\"message\\\":\\\"Request is temporarily throttled because resource /subscriptions/<SUBSCRIPTION ID>/resourcegroups/<CLUSTER ID>/providers/Microsoft.ContainerService/managedClusters/<CLUSTER ID> has issued too many requests. Retry after 20 seconds.\\\"}}'.'.\"}}",
        "eventCategory": "Administrative",
        "entity": "/subscriptions/<SUBSCRIPTION ID>/resourceGroups/<CLUSTER ID>/providers/Microsoft.ContainerService/managedClusters/<CLUSTER ID>",
        "message": "Microsoft.ContainerService/managedClusters/write",
        "hierarchy": "<SUBSCRIPTION ID>"
    },
    "relatedEvents": []
}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #847

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix AKS cluster provisioning errors and validate update of immutable fields in AzureManagedControlPlane webhook.
```
