### PR TITLE
Allow API server LB frontend port to be configured

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -144,6 +144,7 @@ func (s *ClusterScope) LBSpecs() []azure.LBSpec {
 			Name:              s.APIServerLB().Name,
 			SubnetName:        s.ControlPlaneSubnet().Name,
 			FrontendIPConfigs: s.APIServerLB().FrontendIPs,
+			FrontendPort:      s.APIServerLBFrontendPort(),
 			APIServerPort:     s.APIServerPort(),
 			Type:              s.APIServerLB().Type,
 			SKU:               infrav1.SKUStandard,
@@ -455,6 +456,15 @@ func (s *ClusterScope) AdditionalTags() infrav1.Tags {
 		tags = s.AzureCluster.Spec.AdditionalTags.DeepCopy()
 	}
 	return tags
+}
+
+// APIServerLBFrontendPort returns the frontend listen port to use when creating the load balancer.
+func (s *ClusterScope) APIServerLBFrontendPort() int32 {
+	if s.Cluster.Spec.ControlPlaneEndpoint.Port > 0 {
+		return s.Cluster.Spec.ControlPlaneEndpoint.Port
+	}
+
+	return s.APIServerPort()
 }
 
 // APIServerPort returns the APIServerPort to use when creating the load balancer.

--- a/azure/services/loadbalancers/loadbalancers.go
+++ b/azure/services/loadbalancers/loadbalancers.go
@@ -259,7 +259,7 @@ func (s *Service) getLoadBalancingRules(lbSpec azure.LBSpec, frontendIDs []netwo
 				LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 					DisableOutboundSnat:     to.BoolPtr(true),
 					Protocol:                network.TransportProtocolTCP,
-					FrontendPort:            to.Int32Ptr(lbSpec.APIServerPort),
+					FrontendPort:            to.Int32Ptr(lbSpec.FrontendPort),
 					BackendPort:             to.Int32Ptr(lbSpec.APIServerPort),
 					IdleTimeoutInMinutes:    to.Int32Ptr(4),
 					EnableFloatingIP:        to.BoolPtr(false),

--- a/azure/services/loadbalancers/loadbalancers_test.go
+++ b/azure/services/loadbalancers/loadbalancers_test.go
@@ -77,6 +77,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 								},
 							},
 						},
+						FrontendPort:  443,
 						APIServerPort: 6443,
 					},
 				})
@@ -104,6 +105,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 								PrivateIPAddress: "10.0.0.10",
 							},
 						},
+						FrontendPort:  443,
 						APIServerPort: 6443,
 					},
 				})
@@ -152,12 +154,14 @@ func TestReconcileLoadBalancer(t *testing.T) {
 					{
 						Name:          "my-lb",
 						SubnetName:    "my-subnet",
+						FrontendPort:  443,
 						APIServerPort: 6443,
 						Role:          infrav1.APIServerRole,
 						Type:          infrav1.Internal,
 					},
 					{
 						Name:          "my-lb-2",
+						FrontendPort:  443,
 						APIServerPort: 6443,
 						Role:          infrav1.APIServerRole,
 						Type:          infrav1.Public,
@@ -202,6 +206,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 								},
 							},
 						},
+						FrontendPort:  443,
 						APIServerPort: 6443,
 					},
 				})
@@ -232,6 +237,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 								},
 							},
 						},
+						FrontendPort:  443,
 						APIServerPort: 6443,
 					},
 				})
@@ -433,7 +439,7 @@ func newDefaultPublicAPIServerLB() network.LoadBalancer {
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						DisableOutboundSnat:  to.BoolPtr(true),
 						Protocol:             network.TransportProtocolTCP,
-						FrontendPort:         to.Int32Ptr(6443),
+						FrontendPort:         to.Int32Ptr(443),
 						BackendPort:          to.Int32Ptr(6443),
 						IdleTimeoutInMinutes: to.Int32Ptr(4),
 						EnableFloatingIP:     to.BoolPtr(false),
@@ -512,7 +518,7 @@ func newDefaultInternalAPIServerLB() network.LoadBalancer {
 					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
 						DisableOutboundSnat:  to.BoolPtr(true),
 						Protocol:             network.TransportProtocolTCP,
-						FrontendPort:         to.Int32Ptr(6443),
+						FrontendPort:         to.Int32Ptr(443),
 						BackendPort:          to.Int32Ptr(6443),
 						IdleTimeoutInMinutes: to.Int32Ptr(4),
 						EnableFloatingIP:     to.BoolPtr(false),

--- a/azure/types.go
+++ b/azure/types.go
@@ -61,6 +61,7 @@ type LBSpec struct {
 	SubnetName        string
 	BackendPoolName   string
 	FrontendIPConfigs []infrav1.FrontendIP
+	FrontendPort      int32
 	APIServerPort     int32
 }
 

--- a/docs/book/src/topics/api-server-endpoint.md
+++ b/docs/book/src/topics/api-server-endpoint.md
@@ -13,6 +13,12 @@ A `Private` cluster will have an Azure internal load balancer load balancing tra
 
 For more information on Azure load balancing, see [Load Balancer documentation](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview).
 
+### Load Balancer Frontend Port
+
+By default CAPZ configures load balancer frontend port to be the same as configured API Server listen port. API Server listen port defaults to 6443 and can be configured on-demand with `Cluster` CR's `Spec.ClusterNetwork.APIServerPort` field.
+
+To configure API Server Load Balancer frontend port, set `Cluster` CR's `Spec.ControlPlaneEndpoint.Port` to desired value.
+
 <aside class="note warning">
 
 <h1> Warning </h1>


### PR DESCRIPTION
/kind feature

**Description:**
This change allows API server LB frontend port to be configured separately from the API server listen port. The code uses `Cluster` CR's `Spec.ControlPlaneEndpoint.Port` as LB frontend port, given it is defined. Otherwise the API server listen port is used as the implementation was before.

This change implements following proposal: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1240

**Common use case for this would be**:
API LB is listening in default HTTPS port (443) while workload cluster control plane node uses default (6443) for API server listen port.

**Special notes for your reviewer**:
Depending on situation, this might require user action on existing clusters if control plane endpoint port is configured but earlier LB defaulting has been used.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use `Cluster` CR's `Spec.ControlPlaneEndpoint.Port` as LB frontend port if it's defined. User action is needed if the said port is defined but differs from `Spec.ClusterNetwork.APIServerPort`.
```
