### PR TITLE
dont use hard-coded value for manager namespace

### DIFF
--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -21,8 +21,6 @@ import (
 )
 
 const (
-	// ControllerNamespace is the namespace where controller manager will run
-	ControllerNamespace = "capz-system"
 	// ControlPlane machine label
 	ControlPlane string = "control-plane"
 	// Node machine label

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -22,8 +22,6 @@ import (
 )
 
 const (
-	// ControllerNamespace is the namespace where controller manager will run
-	ControllerNamespace = "capz-system"
 	// ControlPlane machine label
 	ControlPlane string = "control-plane"
 	// Node machine label

--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-azure/util/identity"
+	"sigs.k8s.io/cluster-api-provider-azure/util/system"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	clusterctl "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,7 +84,7 @@ func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, resourceMa
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      identity.GetAzureIdentityName(p.AzureCluster.Name, p.AzureCluster.Namespace, p.Identity.Name),
-			Namespace: infrav1.ControllerNamespace,
+			Namespace: system.GetManagerNamespace(),
 			Annotations: map[string]string{
 				aadpodv1.BehaviorKey: "namespaced",
 			},
@@ -104,7 +105,7 @@ func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, resourceMa
 	}
 	err = p.Client.Create(ctx, copiedIdentity)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return nil, errors.Errorf("failed to create copied AzureIdentity %s in %s: %v", copiedIdentity.Name, infrav1.ControllerNamespace, err)
+		return nil, errors.Errorf("failed to create copied AzureIdentity %s in %s: %v", copiedIdentity.Name, system.GetManagerNamespace(), err)
 	}
 
 	azureIdentityBinding := &aadpodv1.AzureIdentityBinding{
@@ -129,7 +130,7 @@ func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, resourceMa
 	}
 	err = p.Client.Create(ctx, azureIdentityBinding)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return nil, errors.Errorf("failed to create AzureIdentityBinding %s in %s: %v", copiedIdentity.Name, infrav1.ControllerNamespace, err)
+		return nil, errors.Errorf("failed to create AzureIdentityBinding %s in %s: %v", copiedIdentity.Name, system.GetManagerNamespace(), err)
 	}
 
 	var spt *adal.ServicePrincipalToken

--- a/controllers/azureidentity_controller.go
+++ b/controllers/azureidentity_controller.go
@@ -31,6 +31,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-azure/util/identity"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
+	"sigs.k8s.io/cluster-api-provider-azure/util/system"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/util"
@@ -111,7 +112,7 @@ func (r *AzureIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// get all the bindings
 	var bindings aadpodv1.AzureIdentityBindingList
-	if err := r.List(ctx, &bindings, client.InNamespace(infrav1.ControllerNamespace)); err != nil {
+	if err := r.List(ctx, &bindings, client.InNamespace(system.GetManagerNamespace())); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -150,7 +151,7 @@ func (r *AzureIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, err
 		}
 		azureIdentity := &aadpodv1.AzureIdentity{}
-		if err := r.Client.Get(ctx, client.ObjectKey{Name: identityName, Namespace: infrav1.ControllerNamespace}, azureIdentity); err != nil {
+		if err := r.Client.Get(ctx, client.ObjectKey{Name: identityName, Namespace: system.GetManagerNamespace()}, azureIdentity); err != nil {
 			log.Error(err, "failed to fetch AzureIdentity")
 			return ctrl.Result{}, err
 		}

--- a/util/system/namespace.go
+++ b/util/system/namespace.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import "os"
+
+const (
+	// NamespaceEnvVarName is the env var coming from DownwardAPI in the manager manifest
+	NamespaceEnvVarName = "POD_NAMESPACE"
+	// DefaultNamespace is the default value from manifest
+	DefaultNamespace = "capz-system"
+)
+
+// GetManagerNamespace return the namespace where the controller is running
+func GetManagerNamespace() string {
+	managerNamespace := os.Getenv(NamespaceEnvVarName)
+	if managerNamespace == "" {
+		managerNamespace = DefaultNamespace
+	}
+	return managerNamespace
+}

--- a/util/system/namespace_test.go
+++ b/util/system/namespace_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"os"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestGetNamespace(t *testing.T) {
+	cases := []struct {
+		Name         string
+		PodNamespace string
+		Expected     string
+	}{
+		{
+			Name:         "env var set to custom namespace",
+			PodNamespace: "capz",
+			Expected:     "capz",
+		},
+		{
+			Name:         "env var empty",
+			PodNamespace: "",
+			Expected:     "capz-system",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			os.Setenv(NamespaceEnvVarName, c.PodNamespace)
+			g.Expect(GetManagerNamespace()).To(gomega.Equal(c.Expected))
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->


 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
- don't use a hard-coded value for the manager namespace when creating an identity binding
- get namespace form Downward API

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1208

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove hardcoded namespace value
```
