### PR TITLE
🐛  Ensure VM and VMSS extensions are applied once

### DIFF
--- a/azure/services/scalesets/mock_scalesets/scalesets_mock.go
+++ b/azure/services/scalesets/mock_scalesets/scalesets_mock.go
@@ -445,6 +445,20 @@ func (mr *MockScaleSetScopeMockRecorder) V(level interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V", reflect.TypeOf((*MockScaleSetScope)(nil).V), level)
 }
 
+// VMSSExtensionSpecs mocks base method.
+func (m *MockScaleSetScope) VMSSExtensionSpecs() []azure.VMSSExtensionSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VMSSExtensionSpecs")
+	ret0, _ := ret[0].([]azure.VMSSExtensionSpec)
+	return ret0
+}
+
+// VMSSExtensionSpecs indicates an expected call of VMSSExtensionSpecs.
+func (mr *MockScaleSetScopeMockRecorder) VMSSExtensionSpecs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMSSExtensionSpecs", reflect.TypeOf((*MockScaleSetScope)(nil).VMSSExtensionSpecs))
+}
+
 // WithName mocks base method.
 func (m *MockScaleSetScope) WithName(name string) logr.Logger {
 	m.ctrl.T.Helper()

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -978,6 +978,20 @@ func newDefaultVMSS() compute.VirtualMachineScaleSet {
 						},
 					},
 				},
+				ExtensionProfile: &compute.VirtualMachineScaleSetExtensionProfile{
+					Extensions: &[]compute.VirtualMachineScaleSetExtension{
+						{
+							Name: to.StringPtr("someExtension"),
+							VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
+								Publisher:          to.StringPtr("somePublisher"),
+								Type:               to.StringPtr("someExtension"),
+								TypeHandlerVersion: to.StringPtr("someVersion"),
+								Settings:           nil,
+								ProtectedSettings:  nil,
+							},
+						},
+					},
+				},
 				ScheduledEventsProfile: &compute.ScheduledEventsProfile{
 					TerminateNotificationProfile: &compute.TerminateNotificationProfile{
 						Enable:           to.BoolPtr(true),
@@ -1066,6 +1080,13 @@ func setupDefaultVMSSExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorde
 			Version:   "1.0",
 		},
 	}, nil)
+	s.VMSSExtensionSpecs().Return([]azure.VMSSExtensionSpec{
+		{
+			Name:      "someExtension",
+			Publisher: "somePublisher",
+			Version:   "someVersion",
+		},
+	}).AnyTimes()
 }
 
 func setupDefaultVMSSUpdateExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorder) {

--- a/azure/services/vmextensions/client.go
+++ b/azure/services/vmextensions/client.go
@@ -27,6 +27,7 @@ import (
 
 // Client wraps go-sdk
 type client interface {
+	Get(ctx context.Context, resourceGroupName, vmName, name string) (compute.VirtualMachineExtension, error)
 	CreateOrUpdate(context.Context, string, string, string, compute.VirtualMachineExtension) error
 	Delete(context.Context, string, string, string) error
 }
@@ -49,6 +50,14 @@ func newVirtualMachineExtensionsClient(subscriptionID string, baseURI string, au
 	vmextensionsClient := compute.NewVirtualMachineExtensionsClientWithBaseURI(baseURI, subscriptionID)
 	azure.SetAutoRestClientDefaults(&vmextensionsClient.Client, authorizer)
 	return vmextensionsClient
+}
+
+// Get the virtual machine extension
+func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmName, name string) (compute.VirtualMachineExtension, error) {
+	ctx, span := tele.Tracer().Start(ctx, "vmextensions.AzureClient.Get")
+	defer span.End()
+
+	return ac.vmextensions.Get(ctx, resourceGroupName, vmName, name, "")
 }
 
 // CreateOrUpdate creates or updates the virtual machine extension

--- a/azure/services/vmextensions/mock_vmextensions/client_mock.go
+++ b/azure/services/vmextensions/mock_vmextensions/client_mock.go
@@ -78,3 +78,18 @@ func (mr *MockclientMockRecorder) Delete(arg0, arg1, arg2, arg3 interface{}) *go
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*Mockclient)(nil).Delete), arg0, arg1, arg2, arg3)
 }
+
+// Get mocks base method.
+func (m *Mockclient) Get(ctx context.Context, resourceGroupName, vmName, name string) (compute.VirtualMachineExtension, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, resourceGroupName, vmName, name)
+	ret0, _ := ret[0].(compute.VirtualMachineExtension)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockclientMockRecorder) Get(ctx, resourceGroupName, vmName, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockclient)(nil).Get), ctx, resourceGroupName, vmName, name)
+}

--- a/azure/services/vmextensions/vmextensions.go
+++ b/azure/services/vmextensions/vmextensions.go
@@ -55,6 +55,11 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	defer span.End()
 
 	for _, extensionSpec := range s.Scope.VMExtensionSpecs() {
+		if _, err := s.client.Get(ctx, s.Scope.ResourceGroup(), extensionSpec.VMName, extensionSpec.Name); err == nil {
+			// check for the extension and don't update if already exists
+			// TODO: set conditions based on extension status
+			continue
+		}
 		s.Scope.V(2).Info("creating VM extension", "vm extension", extensionSpec.Name)
 		err := s.client.CreateOrUpdate(
 			ctx,
@@ -81,6 +86,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 }
 
 // Delete is a no-op. Extensions will be deleted as part of VM deletion.
-func (s *Service) Delete(ctx context.Context) error {
+func (s *Service) Delete(_ context.Context) error {
 	return nil
 }

--- a/azure/services/vmssextensions/client.go
+++ b/azure/services/vmssextensions/client.go
@@ -27,6 +27,7 @@ import (
 
 // Client wraps go-sdk
 type client interface {
+	Get(context.Context, string, string, string) (compute.VirtualMachineScaleSetExtension, error)
 	CreateOrUpdate(context.Context, string, string, string, compute.VirtualMachineScaleSetExtension) error
 	Delete(context.Context, string, string, string) error
 }
@@ -49,6 +50,14 @@ func newVirtualMachineScaleSetExtensionsClient(subscriptionID string, baseURI st
 	vmssextensionsClient := compute.NewVirtualMachineScaleSetExtensionsClientWithBaseURI(baseURI, subscriptionID)
 	azure.SetAutoRestClientDefaults(&vmssextensionsClient.Client, authorizer)
 	return vmssextensionsClient
+}
+
+// Get creates or updates the virtual machine scale set extension
+func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmssName, name string) (compute.VirtualMachineScaleSetExtension, error) {
+	ctx, span := tele.Tracer().Start(ctx, "vmssextensions.AzureClient.Get")
+	defer span.End()
+
+	return ac.vmssextensions.Get(ctx, resourceGroupName, vmssName, name, "")
 }
 
 // CreateOrUpdate creates or updates the virtual machine scale set extension

--- a/azure/services/vmssextensions/mock_vmssextensions/client_mock.go
+++ b/azure/services/vmssextensions/mock_vmssextensions/client_mock.go
@@ -78,3 +78,18 @@ func (mr *MockclientMockRecorder) Delete(arg0, arg1, arg2, arg3 interface{}) *go
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*Mockclient)(nil).Delete), arg0, arg1, arg2, arg3)
 }
+
+// Get mocks base method.
+func (m *Mockclient) Get(arg0 context.Context, arg1, arg2, arg3 string) (compute.VirtualMachineScaleSetExtension, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(compute.VirtualMachineScaleSetExtension)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockclientMockRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockclient)(nil).Get), arg0, arg1, arg2, arg3)
+}

--- a/azure/services/vmssextensions/vmssextensions_test.go
+++ b/azure/services/vmssextensions/vmssextensions_test.go
@@ -39,6 +39,24 @@ func TestReconcileVMSSExtension(t *testing.T) {
 		expect        func(s *mock_vmssextensions.MockVMSSExtensionScopeMockRecorder, m *mock_vmssextensions.MockclientMockRecorder)
 	}{
 		{
+			name:          "extension already exists",
+			expectedError: "",
+			expect: func(s *mock_vmssextensions.MockVMSSExtensionScopeMockRecorder, m *mock_vmssextensions.MockclientMockRecorder) {
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.VMSSExtensionSpecs().Return([]azure.VMSSExtensionSpec{
+					{
+						Name:         "my-extension-1",
+						ScaleSetName: "my-vmss",
+						Publisher:    "some-publisher",
+						Version:      "1.0",
+					},
+				})
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				s.Location().AnyTimes().Return("test-location")
+				m.Get(gomockinternal.AContext(), "my-rg", "my-vmss", "my-extension-1")
+			},
+		},
+		{
 			name:          "reconcile multiple extensions",
 			expectedError: "",
 			expect: func(s *mock_vmssextensions.MockVMSSExtensionScopeMockRecorder, m *mock_vmssextensions.MockclientMockRecorder) {
@@ -59,13 +77,17 @@ func TestReconcileVMSSExtension(t *testing.T) {
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("test-location")
+				m.Get(gomockinternal.AContext(), "my-rg", "my-vmss", "my-extension-1").
+					Return(compute.VirtualMachineScaleSetExtension{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vmss", "my-extension-1", gomock.AssignableToTypeOf(compute.VirtualMachineScaleSetExtension{}))
+				m.Get(gomockinternal.AContext(), "my-rg", "my-vmss", "other-extension").
+					Return(compute.VirtualMachineScaleSetExtension{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vmss", "other-extension", gomock.AssignableToTypeOf(compute.VirtualMachineScaleSetExtension{}))
 			},
 		},
 		{
 			name:          "error creating the extension",
-			expectedError: "failed to create VM extension my-extension-1 on scale set my-vmss in resource group my-rg: #: Internal Server Error: StatusCode=500",
+			expectedError: "failed to create VMSS extension my-extension-1 on scale set my-vmss in resource group my-rg: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_vmssextensions.MockVMSSExtensionScopeMockRecorder, m *mock_vmssextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.VMSSExtensionSpecs().Return([]azure.VMSSExtensionSpec{
@@ -84,6 +106,8 @@ func TestReconcileVMSSExtension(t *testing.T) {
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.Location().AnyTimes().Return("test-location")
+				m.Get(gomockinternal.AContext(), "my-rg", "my-vmss", "my-extension-1").
+					Return(compute.VirtualMachineScaleSetExtension{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vmss", "my-extension-1", gomock.AssignableToTypeOf(compute.VirtualMachineScaleSetExtension{})).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 
 			},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: This is a temporary fix while #603 work is in progress to make sure that we're not making unnecessary PUT calls to VM and VMSS extensions that already exist. It also adds the extension profile directly as part of VMSS create so that the extensions are applied to the VMSS VMs as they are created instead of being applied to the model after they exist.

These changes are already included in #1105 for the most part, breaking them out in a separate PR to speed up the fix and facilitate backporting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure VM and VMSS extensions are applied once
```
