### PR TITLE
Capz should not add tags to managed resource group

### DIFF
--- a/azure/services/groups/groups.go
+++ b/azure/services/groups/groups.go
@@ -58,7 +58,10 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	if _, err := s.client.Get(ctx, s.Scope.ResourceGroup()); err == nil {
 		// resource group already exists, skip creation
 		return nil
+	} else if !azure.ResourceNotFound(err) {
+		return errors.Wrapf(err, "failed to get resource group %s", s.Scope.ResourceGroup())
 	}
+
 	s.Scope.V(2).Info("creating resource group", "resource group", s.Scope.ResourceGroup())
 	group := resources.Group{
 		Location: to.StringPtr(s.Scope.Location()),

--- a/azure/services/groups/groups_test.go
+++ b/azure/services/groups/groups_test.go
@@ -50,6 +50,18 @@ func TestReconcileGroups(t *testing.T) {
 			},
 		},
 		{
+			name:          "return error when querying a resource group",
+			expectedError: "failed to get resource group my-rg: #: Internal Server Error: StatusCode=500",
+			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockclientMockRecorder) {
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				s.Location().AnyTimes().Return("fake-location")
+				s.ClusterName().AnyTimes().Return("fake-cluster")
+				m.Get(gomockinternal.AContext(), "my-rg").Return(resources.Group{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
+			},
+		},
+
+		{
 			name:          "create a resource group",
 			expectedError: "",
 			expect: func(s *mock_groups.MockGroupScopeMockRecorder, m *mock_groups.MockclientMockRecorder) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When delete capz cluster is triggered, capz try to delete the resource group, even through the RG is not created by capz.
Capz should check for err and only continue to createOrUpdate RG when err is resource-not-found, otherwise when azure API have issue it should return some other error, the RG will be updated with owner-tags, then capz will think the RG is managed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes None

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
None
```
