### PR TITLE
[backport-release-0.4] do not include customData in AzureMachinePool hash calculation

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,6 +23,7 @@ spec:
         - args:
             - --enable-leader-election
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},AKS=${EXP_AKS:=false}"
+            - "--v=0"
           image: controller:latest
           imagePullPolicy: Always
           name: manager

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -61,11 +61,14 @@ providers:
       - sourcePath: "${PWD}/templates/test/cluster-template-prow-ci-version.yaml"
         targetName: "cluster-template-conformance-ci-artifacts.yaml"
       - sourcePath: "${PWD}/templates/test/cluster-template-prow-multi-tenancy.yaml"
-        targetName: "cluster-template-multi-tenancy.yaml"        
+        targetName: "cluster-template-multi-tenancy.yaml"
       - sourcePath: "${PWD}/templates/test/cluster-template-prow-windows.yaml"
         targetName: "cluster-template-windows.yaml"
       - sourcePath: "${PWD}/templates/test/cluster-template-prow-machine-pool-windows.yaml"
         targetName: "cluster-template-machine-pool-windows.yaml"
+    replacements:
+      - old: "--v=0"
+        new: "--v=4"
 
 variables:
   KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.19.7}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
cherry-pick of #1197 in release-0.4

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not include VMSS customData in the hash tag calculation to correct a reconcile cycle caused when the bootstrap token refreshes.
```
