### PR TITLE
Add Linux VM extension bootstrap script and conditions

### DIFF
--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -879,7 +879,7 @@ func autoConvert_v1alpha4_AzureMachineSpec_To_v1alpha3_AzureMachineSpec(in *v1al
 func autoConvert_v1alpha3_AzureMachineStatus_To_v1alpha4_AzureMachineStatus(in *AzureMachineStatus, out *v1alpha4.AzureMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
 	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
-	out.VMState = (*v1alpha4.VMState)(unsafe.Pointer(in.VMState))
+	out.VMState = (*v1alpha4.ProvisioningState)(unsafe.Pointer(in.VMState))
 	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*apiv1alpha4.Conditions)(unsafe.Pointer(&in.Conditions))
@@ -1583,7 +1583,7 @@ func autoConvert_v1alpha3_VM_To_v1alpha4_VM(in *VM, out *v1alpha4.VM, s conversi
 		return err
 	}
 	out.StartupScript = in.StartupScript
-	out.State = v1alpha4.VMState(in.State)
+	out.State = v1alpha4.ProvisioningState(in.State)
 	out.Identity = v1alpha4.VMIdentity(in.Identity)
 	out.Tags = *(*v1alpha4.Tags)(unsafe.Pointer(&in.Tags))
 	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))

--- a/api/v1alpha4/azuremachine_types.go
+++ b/api/v1alpha4/azuremachine_types.go
@@ -134,7 +134,7 @@ type AzureMachineStatus struct {
 
 	// VMState is the provisioning state of the Azure virtual machine.
 	// +optional
-	VMState *VMState `json:"vmState,omitempty"`
+	VMState *ProvisioningState `json:"vmState,omitempty"`
 
 	// ErrorReason will be set in the event that there is a terminal problem
 	// reconciling the Machine and will contain a succinct value suitable

--- a/api/v1alpha4/conditions_consts.go
+++ b/api/v1alpha4/conditions_consts.go
@@ -21,11 +21,7 @@ import clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 // AzureCluster Conditions and Reasons
 const (
 	// NetworkInfrastructureReadyCondition reports of current status of cluster infrastructure
-	NetworkInfrastructureReadyCondition = "NetworkInfrastructureReady"
-	// LoadBalancerProvisioningReason API Server endpoint for the loadbalancer
-	LoadBalancerProvisioningReason = "LoadBalancerProvisioning"
-	// LoadBalancerProvisioningFailedReason used for failure during provisioning of loadbalancer.
-	LoadBalancerProvisioningFailedReason = "LoadBalancerProvisioningFailed"
+	NetworkInfrastructureReadyCondition clusterv1.ConditionType = "NetworkInfrastructureReady"
 	// NamespaceNotAllowedByIdentity used to indicate cluster in a namespace not allowed by identity
 	NamespaceNotAllowedByIdentity = "NamespaceNotAllowedByIdentity"
 )
@@ -34,20 +30,36 @@ const (
 const (
 	// VMRunningCondition reports on current status of the Azure VM.
 	VMRunningCondition clusterv1.ConditionType = "VMRunning"
-	// VMNCreatingReason used when the vm creation is in progress.
-	VMNCreatingReason = "VMCreating"
-	// VMNUpdatingReason used when the vm updating is in progress.
-	VMNUpdatingReason = "VMUpdating"
-	// VMNotFoundReason used when the vm couldn't be retrieved.
-	VMNotFoundReason = "VMNotFound"
+	// VMCreatingReason used when the vm creation is in progress.
+	VMCreatingReason = "VMCreating"
+	// VMUpdatingReason used when the vm updating is in progress.
+	VMUpdatingReason = "VMUpdating"
 	// VMDeletingReason used when the vm is in a deleting state.
-	VMDDeletingReason = "VMDeleting"
-	// VMStoppedReason vm is in a stopped state.
-	VMStoppedReason = "VMStopped"
+	VMDeletingReason = "VMDeleting"
 	// VMProvisionFailedReason used for failures during vm provisioning.
 	VMProvisionFailedReason = "VMProvisionFailed"
 	// WaitingForClusterInfrastructureReason used when machine is waiting for cluster infrastructure to be ready before proceeding.
 	WaitingForClusterInfrastructureReason = "WaitingForClusterInfrastructure"
 	// WaitingForBootstrapDataReason used when machine is waiting for bootstrap data to be ready before proceeding.
 	WaitingForBootstrapDataReason = "WaitingForBootstrapData"
+	// BootstrapSucceededCondition reports the result of the execution of the boostrap data on the machine.
+	BootstrapSucceededCondition = "BoostrapSucceeded"
+	// BootstrapInProgressReason is used to indicate the bootstrap data has not finished executing.
+	BootstrapInProgressReason = "BootstrapInProgress"
+	// BootstrapFailedReason is used to indicate the bootstrap process ran into an error.
+	BootstrapFailedReason = "BootstrapFailed"
+)
+
+// AzureMachinePool Conditions and Reasons
+const (
+	// ScaleSetRunningCondition reports on current status of the Azure Scale Set.
+	ScaleSetRunningCondition clusterv1.ConditionType = "ScaleSetRunning"
+	// ScaleSetCreatingReason used when the scale set creation is in progress.
+	ScaleSetCreatingReason = "ScaleSetCreating"
+	// ScaleSetUpdatingReason used when the scale set updating is in progress.
+	ScaleSetUpdatingReason = "ScaleSetUpdating"
+	// ScaleSetDeletingReason used when the scale set is in a deleting state.
+	ScaleSetDeletingReason = "ScaleSetDeleting"
+	// ScaleSetProvisionFailedReason used for failures during scale set provisioning.
+	ScaleSetProvisionFailedReason = "ScaleSetProvisionFailed"
 )

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -203,24 +203,28 @@ type PublicIPSpec struct {
 }
 
 // VMState describes the state of an Azure virtual machine.
+// DEPRECATED: use ProvisioningState
 type VMState string
 
+// ProvisioningState describes the provisioning state of an Azure resource.
+type ProvisioningState string
+
 const (
-	// VMStateCreating ...
-	VMStateCreating VMState = "Creating"
-	// VMStateDeleting ...
-	VMStateDeleting VMState = "Deleting"
-	// VMStateFailed ...
-	VMStateFailed VMState = "Failed"
-	// VMStateMigrating ...
-	VMStateMigrating VMState = "Migrating"
-	// VMStateSucceeded ...
-	VMStateSucceeded VMState = "Succeeded"
-	// VMStateUpdating ...
-	VMStateUpdating VMState = "Updating"
-	// VMStateDeleted represents a deleted VM
-	// NOTE: This state is specific to capz, and does not have corresponding mapping in Azure API (https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle#provisioning-states)
-	VMStateDeleted VMState = "Deleted"
+	// Creating ...
+	Creating ProvisioningState = "Creating"
+	// Deleting ...
+	Deleting ProvisioningState = "Deleting"
+	// Failed ...
+	Failed ProvisioningState = "Failed"
+	// Migrating ...
+	Migrating ProvisioningState = "Migrating"
+	// Succeeded ...
+	Succeeded ProvisioningState = "Succeeded"
+	// Updating ...
+	Updating ProvisioningState = "Updating"
+	// Deleted represents a deleted VM
+	// NOTE: This state is specific to capz, and does not have corresponding mapping in Azure API (https://docs.microsoft.com/en-us/azure/virtual-machines/states-billing#provisioning-states)
+	Deleted ProvisioningState = "Deleted"
 )
 
 // VM describes an Azure virtual machine.
@@ -235,9 +239,9 @@ type VM struct {
 	OSDisk        OSDisk `json:"osDisk,omitempty"`
 	StartupScript string `json:"startupScript,omitempty"`
 	// State - The provisioning state, which only appears in the response.
-	State    VMState    `json:"vmState,omitempty"`
-	Identity VMIdentity `json:"identity,omitempty"`
-	Tags     Tags       `json:"tags,omitempty"`
+	State    ProvisioningState `json:"vmState,omitempty"`
+	Identity VMIdentity        `json:"identity,omitempty"`
+	Tags     Tags              `json:"tags,omitempty"`
 
 	// Addresses contains the addresses associated with the Azure VM.
 	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -421,7 +421,7 @@ func (in *AzureMachineStatus) DeepCopyInto(out *AzureMachineStatus) {
 	}
 	if in.VMState != nil {
 		in, out := &in.VMState, &out.VMState
-		*out = new(VMState)
+		*out = new(ProvisioningState)
 		**out = **in
 	}
 	if in.FailureReason != nil {

--- a/azure/converters/vm.go
+++ b/azure/converters/vm.go
@@ -27,7 +27,7 @@ func SDKToVM(v compute.VirtualMachine) (*infrav1.VM, error) {
 	vm := &infrav1.VM{
 		ID:    to.String(v.ID),
 		Name:  to.String(v.Name),
-		State: infrav1.VMState(to.String(v.ProvisioningState)),
+		State: infrav1.ProvisioningState(to.String(v.ProvisioningState)),
 	}
 
 	if v.VirtualMachineProperties != nil && v.VirtualMachineProperties.HardwareProfile != nil {

--- a/azure/converters/vmss.go
+++ b/azure/converters/vmss.go
@@ -29,7 +29,7 @@ func SDKToVMSS(sdkvmss compute.VirtualMachineScaleSet, sdkinstances []compute.Vi
 	vmss := &infrav1exp.VMSS{
 		ID:    to.String(sdkvmss.ID),
 		Name:  to.String(sdkvmss.Name),
-		State: infrav1.VMState(to.String(sdkvmss.ProvisioningState)),
+		State: infrav1.ProvisioningState(to.String(sdkvmss.ProvisioningState)),
 	}
 
 	if sdkvmss.Sku != nil {
@@ -52,7 +52,7 @@ func SDKToVMSS(sdkvmss compute.VirtualMachineScaleSet, sdkinstances []compute.Vi
 				ID:         to.String(vm.ID),
 				InstanceID: to.String(vm.InstanceID),
 				Name:       to.String(vm.OsProfile.ComputerName),
-				State:      infrav1.VMState(to.String(vm.ProvisioningState)),
+				State:      infrav1.ProvisioningState(to.String(vm.ProvisioningState)),
 			}
 
 			if vm.LatestModelApplied != nil {

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
@@ -241,6 +242,9 @@ func (m *MachineScope) VMExtensionSpecs() []azure.VMExtensionSpec {
 				VMName:    m.Name(),
 				Publisher: publisher,
 				Version:   version,
+				ProtectedSettings: map[string]string{
+					"commandToExecute": azure.BootstrapExtensionCommand(),
+				},
 			},
 		}
 	}
@@ -380,6 +384,52 @@ func (m *MachineScope) SetFailureMessage(v error) {
 // SetFailureReason sets the AzureMachine status failure reason.
 func (m *MachineScope) SetFailureReason(v capierrors.MachineStatusError) {
 	m.AzureMachine.Status.FailureReason = &v
+}
+
+// SetBootstrapConditions sets the AzureMachine BootstrapSucceeded condition based on the extension provisioning states.
+func (m *MachineScope) SetBootstrapConditions(provisioningState string, extensionName string) error {
+	switch infrav1.VMState(provisioningState) {
+	case infrav1.VMStateSucceeded:
+		m.V(4).Info("extension provisioning state is succeeded", "vm extension", extensionName, "virtual machine", m.Name())
+		conditions.MarkTrue(m.AzureMachine, infrav1.BootstrapSucceededCondition)
+		return nil
+	case infrav1.VMStateCreating:
+		m.V(4).Info("extension provisioning state is creating", "vm extension", extensionName, "virtual machine", m.Name())
+		conditions.MarkFalse(m.AzureMachine, infrav1.BootstrapSucceededCondition, infrav1.BootstrapInProgressReason, clusterv1.ConditionSeverityInfo, "")
+		return azure.WithTransientError(errors.New("extension still provisioning"), 30*time.Second)
+	case infrav1.VMStateFailed:
+		m.V(4).Info("extension provisioning state is failed", "vm extension", extensionName, "virtual machine", m.Name())
+		conditions.MarkFalse(m.AzureMachine, infrav1.BootstrapSucceededCondition, infrav1.BootstrapFailedReason, clusterv1.ConditionSeverityError, "")
+		return azure.WithTerminalError(errors.New("extension state failed"))
+	default:
+		return nil
+	}
+}
+
+// UpdateStatus updates the AzureMachine status.
+func (m *MachineScope) UpdateStatus() {
+	switch m.VMState() {
+	case infrav1.VMStateSucceeded:
+		m.V(2).Info("VM is running", "id", m.GetVMID())
+		conditions.MarkTrue(m.AzureMachine, infrav1.VMRunningCondition)
+	case infrav1.VMStateCreating:
+		m.V(2).Info("VM is creating", "id", m.GetVMID())
+		conditions.MarkFalse(m.AzureMachine, infrav1.VMRunningCondition, infrav1.VMCreatingReason, clusterv1.ConditionSeverityInfo, "")
+	case infrav1.VMStateUpdating:
+		m.V(2).Info("VM is updating", "id", m.GetVMID())
+		conditions.MarkFalse(m.AzureMachine, infrav1.VMRunningCondition, infrav1.VMUpdatingReason, clusterv1.ConditionSeverityInfo, "")
+	case infrav1.VMStateDeleting:
+		m.Info("Unexpected VM deletion", "id", m.GetVMID())
+		conditions.MarkFalse(m.AzureMachine, infrav1.VMRunningCondition, infrav1.VMDeletingReason, clusterv1.ConditionSeverityWarning, "")
+	case infrav1.VMStateFailed:
+		m.Error(errors.New("Failed to create or update VM"), "VM is in failed state", "id", m.GetVMID())
+		m.SetFailureReason(capierrors.UpdateMachineError)
+		m.SetFailureMessage(errors.Errorf("Azure VM state is %s", m.VMState()))
+		conditions.MarkFalse(m.AzureMachine, infrav1.VMRunningCondition, infrav1.VMProvisionFailedReason, clusterv1.ConditionSeverityError, "")
+	default:
+		m.V(2).Info("VM state is undefined", "id", m.GetVMID())
+		conditions.MarkUnknown(m.AzureMachine, infrav1.VMRunningCondition, "", "")
+	}
 }
 
 // SetAnnotation sets a key value annotation on the AzureMachine.

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -20,6 +20,10 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/util/conditions"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
@@ -259,6 +263,26 @@ func (m *MachinePoolScope) SetFailureReason(v capierrors.MachineStatusError) {
 	m.AzureMachinePool.Status.FailureReason = &v
 }
 
+// SetBootstrapConditions sets the AzureMachinePool BootstrapSucceeded condition based on the extension provisioning states.
+func (m *MachinePoolScope) SetBootstrapConditions(provisioningState string, extensionName string) error {
+	switch infrav1.ProvisioningState(provisioningState) {
+	case infrav1.Succeeded:
+		m.V(4).Info("extension provisioning state is succeeded", "vm extension", extensionName, "scale set", m.Name())
+		conditions.MarkTrue(m.AzureMachinePool, infrav1.BootstrapSucceededCondition)
+		return nil
+	case infrav1.Creating:
+		m.V(4).Info("extension provisioning state is creating", "vm extension", extensionName, "scale set", m.Name())
+		conditions.MarkFalse(m.AzureMachinePool, infrav1.BootstrapSucceededCondition, infrav1.BootstrapInProgressReason, clusterv1.ConditionSeverityInfo, "")
+		return azure.WithTransientError(errors.New("extension still provisioning"), 30*time.Second)
+	case infrav1.Failed:
+		m.V(4).Info("extension provisioning state is failed", "vm extension", extensionName, "scale set", m.Name())
+		conditions.MarkFalse(m.AzureMachinePool, infrav1.BootstrapSucceededCondition, infrav1.BootstrapFailedReason, clusterv1.ConditionSeverityError, "")
+		return azure.WithTerminalError(errors.New("extension state failed"))
+	default:
+		return nil
+	}
+}
+
 // AdditionalTags merges AdditionalTags from the scope's AzureCluster and AzureMachinePool. If the same key is present in both,
 // the value from AzureMachinePool takes precedence.
 func (m *MachinePoolScope) AdditionalTags() infrav1.Tags {
@@ -368,6 +392,9 @@ func (m *MachinePoolScope) VMSSExtensionSpecs() []azure.VMSSExtensionSpec {
 				ScaleSetName: m.Name(),
 				Publisher:    publisher,
 				Version:      version,
+				ProtectedSettings: map[string]string{
+					"commandToExecute": azure.BootstrapExtensionCommand(),
+				},
 			},
 		}
 	}

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -152,7 +152,7 @@ func (m *MachinePoolScope) SetProviderID(v string) {
 }
 
 // ProvisioningState returns the AzureMachinePool provisioning state.
-func (m *MachinePoolScope) ProvisioningState() infrav1.VMState {
+func (m *MachinePoolScope) ProvisioningState() infrav1.ProvisioningState {
 	if m.AzureMachinePool.Status.ProvisioningState != nil {
 		return *m.AzureMachinePool.Status.ProvisioningState
 	}
@@ -229,14 +229,14 @@ func (m *MachinePoolScope) GetLongRunningOperationState() *infrav1.Future {
 }
 
 // SetProvisioningState sets the AzureMachinePool provisioning state.
-func (m *MachinePoolScope) SetProvisioningState(v infrav1.VMState) {
+func (m *MachinePoolScope) SetProvisioningState(v infrav1.ProvisioningState) {
 	switch {
-	case v == infrav1.VMStateSucceeded && *m.MachinePool.Spec.Replicas == m.AzureMachinePool.Status.Replicas:
+	case v == infrav1.Succeeded && *m.MachinePool.Spec.Replicas == m.AzureMachinePool.Status.Replicas:
 		// vmss is provisioned with enough ready replicas
 		m.AzureMachinePool.Status.ProvisioningState = &v
-	case v == infrav1.VMStateSucceeded && *m.MachinePool.Spec.Replicas != m.AzureMachinePool.Status.Replicas:
+	case v == infrav1.Succeeded && *m.MachinePool.Spec.Replicas != m.AzureMachinePool.Status.Replicas:
 		// not enough ready or too many ready replicas we must still be scaling up or down
-		updatingState := infrav1.VMStateUpdating
+		updatingState := infrav1.Updating
 		m.AzureMachinePool.Status.ProvisioningState = &updatingState
 	default:
 		m.AzureMachinePool.Status.ProvisioningState = &v

--- a/azure/services/scalesets/mock_scalesets/scalesets_mock.go
+++ b/azure/services/scalesets/mock_scalesets/scalesets_mock.go
@@ -378,7 +378,7 @@ func (mr *MockScaleSetScopeMockRecorder) SetProviderID(arg0 interface{}) *gomock
 }
 
 // SetProvisioningState mocks base method.
-func (m *MockScaleSetScope) SetProvisioningState(arg0 v1alpha4.VMState) {
+func (m *MockScaleSetScope) SetProvisioningState(arg0 v1alpha4.ProvisioningState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetProvisioningState", arg0)
 }

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -535,7 +535,7 @@ func (s *Service) generateExtensions() []compute.VirtualMachineScaleSetExtension
 				Type:               to.StringPtr(extensionSpec.Name),
 				TypeHandlerVersion: to.StringPtr(extensionSpec.Version),
 				Settings:           nil,
-				ProtectedSettings:  nil,
+				ProtectedSettings:  extensionSpec.ProtectedSettings,
 			},
 		}
 	}

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -52,7 +52,7 @@ type ScaleSetScope interface {
 	UpdateInstanceStatuses(context.Context, []infrav1exp.VMSSVM) error
 	NeedsK8sVersionUpdate() bool
 	SaveK8sVersion()
-	SetProvisioningState(infrav1.VMState)
+	SetProvisioningState(infrav1.ProvisioningState)
 	SetLongRunningOperationState(*infrav1.Future)
 	GetLongRunningOperationState() *infrav1.Future
 }
@@ -179,7 +179,7 @@ func (s *Service) createVMSS(ctx context.Context) (*infrav1.Future, error) {
 
 	vmss := result.VMSSWithoutHash
 	vmss.Tags = converters.TagsToMap(result.Tags.AddSpecVersionHashTag(result.Hash))
-	s.Scope.SetProvisioningState(infrav1.VMStateCreating)
+	s.Scope.SetProvisioningState(infrav1.Creating)
 	future, err := s.Client.CreateOrUpdateAsync(ctx, s.Scope.ResourceGroup(), spec.Name, vmss)
 	if err != nil {
 		return future, errors.Wrap(err, "cannot create VMSS")
@@ -234,7 +234,7 @@ func (s *Service) patchVMSSIfNeeded(ctx context.Context, infraVMSS *infrav1exp.V
 		return future, errors.Wrap(err, "failed updating VMSS")
 	}
 
-	s.Scope.SetProvisioningState(infrav1.VMStateUpdating)
+	s.Scope.SetProvisioningState(infrav1.Updating)
 	s.Scope.SetLongRunningOperationState(future)
 	s.Scope.V(2).Info("successfully started to update vmss", "scale set", spec.Name)
 	return future, err

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -991,8 +991,9 @@ func newDefaultVMSS() compute.VirtualMachineScaleSet {
 								Publisher:          to.StringPtr("somePublisher"),
 								Type:               to.StringPtr("someExtension"),
 								TypeHandlerVersion: to.StringPtr("someVersion"),
-								Settings:           nil,
-								ProtectedSettings:  nil,
+								ProtectedSettings: map[string]string{
+									"commandToExecute": "echo hello",
+								},
 							},
 						},
 					},
@@ -1087,9 +1088,13 @@ func setupDefaultVMSSExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorde
 	}, nil)
 	s.VMSSExtensionSpecs().Return([]azure.VMSSExtensionSpec{
 		{
-			Name:      "someExtension",
-			Publisher: "somePublisher",
-			Version:   "someVersion",
+			Name:         "someExtension",
+			ScaleSetName: "my-vmss",
+			Publisher:    "somePublisher",
+			Version:      "someVersion",
+			ProtectedSettings: map[string]string{
+				"commandToExecute": "echo hello",
+			},
 		},
 	}).AnyTimes()
 }

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -267,7 +267,7 @@ func TestReconcileVMSS(t *testing.T) {
 				createdVMSS = setupDefaultVMSSInProgressOperationDoneExpectations(g, s, m, createdVMSS, instances)
 				s.SetProviderID(fmt.Sprintf("azure://%s", *createdVMSS.ID))
 				s.SetLongRunningOperationState(nil)
-				s.SetProvisioningState(infrav1.VMStateSucceeded)
+				s.SetProvisioningState(infrav1.Succeeded)
 				s.NeedsK8sVersionUpdate().Return(false)
 				infraVMSS := converters.SDKToVMSS(createdVMSS, instances)
 				s.UpdateInstanceStatuses(gomockinternal.AContext(), infraVMSS.Instances).Return(nil)
@@ -287,7 +287,7 @@ func TestReconcileVMSS(t *testing.T) {
 				instances := newDefaultInstances()
 				vmss = setupDefaultVMSSInProgressOperationDoneExpectations(g, s, m, vmss, instances)
 				s.SetProviderID(fmt.Sprintf("azure://%s", *vmss.ID))
-				s.SetProvisioningState(infrav1.VMStateUpdating)
+				s.SetProvisioningState(infrav1.Updating)
 
 				// create a VMSS patch with an updated hash to match the spec
 				updatedVMSS := newDefaultVMSS()
@@ -315,7 +315,7 @@ func TestReconcileVMSS(t *testing.T) {
 				createdVMSS = setupDefaultVMSSInProgressOperationDoneExpectations(g, s, m, createdVMSS, instances)
 				s.SetProviderID(fmt.Sprintf("azure://%s", *createdVMSS.ID))
 				s.SetLongRunningOperationState(nil)
-				s.SetProvisioningState(infrav1.VMStateSucceeded)
+				s.SetProvisioningState(infrav1.Succeeded)
 				s.NeedsK8sVersionUpdate().Return(false)
 				infraVMSS := converters.SDKToVMSS(createdVMSS, instances)
 				s.UpdateInstanceStatuses(gomockinternal.AContext(), infraVMSS.Instances).Return(nil)
@@ -1042,7 +1042,7 @@ func setHashOnVMSSUpdate(g *WithT, vmss compute.VirtualMachineScaleSet, update c
 func setupDefaultVMSSInProgressOperationDoneExpectations(g *WithT, s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder, createdVMSS compute.VirtualMachineScaleSet, instances []compute.VirtualMachineScaleSetVM) compute.VirtualMachineScaleSet {
 	setHashOnVMSS(g, createdVMSS)
 	createdVMSS.ID = to.StringPtr("vmss-id")
-	createdVMSS.ProvisioningState = to.StringPtr(string(infrav1.VMStateSucceeded))
+	createdVMSS.ProvisioningState = to.StringPtr(string(infrav1.Succeeded))
 	setupDefaultVMSSExpectations(s)
 	future := &infrav1.Future{
 		Type:          PutFuture,
@@ -1061,7 +1061,7 @@ func setupDefaultVMSSStartCreatingExpectations(s *mock_scalesets.MockScaleSetSco
 	s.GetLongRunningOperationState().Return(nil)
 	m.Get(gomockinternal.AContext(), defaultResourceGroup, defaultVMSSName).
 		Return(compute.VirtualMachineScaleSet{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
-	s.SetProvisioningState(infrav1.VMStateCreating)
+	s.SetProvisioningState(infrav1.Creating)
 }
 
 func setupCreatingSucceededExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder, future *infrav1.Future) {
@@ -1102,6 +1102,6 @@ func setupDefaultVMSSExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorde
 func setupDefaultVMSSUpdateExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorder) {
 	setupDefaultVMSSExpectations(s)
 	s.SetProviderID("azure://vmss-id")
-	s.SetProvisioningState(infrav1.VMStateUpdating)
+	s.SetProvisioningState(infrav1.Updating)
 	s.GetLongRunningOperationState().Return(nil)
 }

--- a/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
+++ b/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
@@ -353,7 +353,7 @@ func (mr *MockVMScopeMockRecorder) SetProviderID(arg0 interface{}) *gomock.Call 
 }
 
 // SetVMState mocks base method.
-func (m *MockVMScope) SetVMState(arg0 v1alpha4.VMState) {
+func (m *MockVMScope) SetVMState(arg0 v1alpha4.ProvisioningState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetVMState", arg0)
 }

--- a/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
+++ b/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
@@ -392,6 +392,18 @@ func (mr *MockVMScopeMockRecorder) TenantID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockVMScope)(nil).TenantID))
 }
 
+// UpdateStatus mocks base method.
+func (m *MockVMScope) UpdateStatus() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateStatus")
+}
+
+// UpdateStatus indicates an expected call of UpdateStatus.
+func (mr *MockVMScopeMockRecorder) UpdateStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatus", reflect.TypeOf((*MockVMScope)(nil).UpdateStatus))
+}
+
 // V mocks base method.
 func (m *MockVMScope) V(level int) logr.Logger {
 	m.ctrl.T.Helper()

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -51,7 +51,7 @@ type VMScope interface {
 	AvailabilitySet() (string, bool)
 	SetProviderID(string)
 	SetAddresses([]corev1.NodeAddress)
-	SetVMState(infrav1.VMState)
+	SetVMState(infrav1.ProvisioningState)
 	UpdateStatus()
 }
 
@@ -88,7 +88,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	switch {
 	// VM got deleted outside of capz
 	case err != nil && azure.ResourceNotFound(err) && s.Scope.ProviderID() != "":
-		s.Scope.SetVMState(infrav1.VMStateDeleted)
+		s.Scope.SetVMState(infrav1.Deleted)
 		return azure.VMDeletedError{ProviderID: s.Scope.ProviderID()}
 	case err != nil && !azure.ResourceNotFound(err):
 		return errors.Wrapf(err, "failed to get VM %s", vmSpec.Name)

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -52,6 +52,7 @@ type VMScope interface {
 	SetProviderID(string)
 	SetAddresses([]corev1.NodeAddress)
 	SetVMState(infrav1.VMState)
+	UpdateStatus()
 }
 
 // Service provides operations on azure resources
@@ -97,6 +98,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		s.Scope.SetAnnotation("cluster-api-provider-azure", "true")
 		s.Scope.SetAddresses(existingVM.Addresses)
 		s.Scope.SetVMState(existingVM.State)
+		s.Scope.UpdateStatus()
 	default:
 		s.Scope.V(2).Info("creating VM", "vm", vmSpec.Name)
 		sku, err := s.resourceSKUCache.Get(ctx, vmSpec.Size, resourceskus.VirtualMachines)

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -1760,7 +1760,7 @@ func TestReconcileVM(t *testing.T) {
 				s.ResourceGroup().AnyTimes().Return("my-rg")
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
 				s.ProviderID().Times(2).Return("ExistingVM-ProviderID")
-				s.SetVMState(infrav1.VMStateDeleted)
+				s.SetVMState(infrav1.Deleted)
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm").
 					Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},

--- a/azure/services/vmextensions/client.go
+++ b/azure/services/vmextensions/client.go
@@ -28,7 +28,7 @@ import (
 // Client wraps go-sdk
 type client interface {
 	Get(ctx context.Context, resourceGroupName, vmName, name string) (compute.VirtualMachineExtension, error)
-	CreateOrUpdate(context.Context, string, string, string, compute.VirtualMachineExtension) error
+	CreateOrUpdateAsync(context.Context, string, string, string, compute.VirtualMachineExtension) error
 	Delete(context.Context, string, string, string) error
 }
 
@@ -60,20 +60,12 @@ func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmName, name 
 	return ac.vmextensions.Get(ctx, resourceGroupName, vmName, name, "")
 }
 
-// CreateOrUpdate creates or updates the virtual machine extension
-func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vmName, name string, parameters compute.VirtualMachineExtension) error {
+// CreateOrUpdateAsync creates or updates the virtual machine extension.
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, resourceGroupName, vmName, name string, parameters compute.VirtualMachineExtension) error {
 	ctx, span := tele.Tracer().Start(ctx, "vmextensions.AzureClient.CreateOrUpdate")
 	defer span.End()
 
-	future, err := ac.vmextensions.CreateOrUpdate(ctx, resourceGroupName, vmName, name, parameters)
-	if err != nil {
-		return err
-	}
-	err = future.WaitForCompletionRef(ctx, ac.vmextensions.Client)
-	if err != nil {
-		return err
-	}
-	_, err = future.Result(ac.vmextensions)
+	_, err := ac.vmextensions.CreateOrUpdate(ctx, resourceGroupName, vmName, name, parameters)
 	return err
 }
 

--- a/azure/services/vmextensions/mock_vmextensions/client_mock.go
+++ b/azure/services/vmextensions/mock_vmextensions/client_mock.go
@@ -51,18 +51,18 @@ func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 	return m.recorder
 }
 
-// CreateOrUpdate mocks base method.
-func (m *Mockclient) CreateOrUpdate(arg0 context.Context, arg1, arg2, arg3 string, arg4 compute.VirtualMachineExtension) error {
+// CreateOrUpdateAsync mocks base method.
+func (m *Mockclient) CreateOrUpdateAsync(arg0 context.Context, arg1, arg2, arg3 string, arg4 compute.VirtualMachineExtension) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreateOrUpdate indicates an expected call of CreateOrUpdate.
-func (mr *MockclientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+// CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
+func (mr *MockclientMockRecorder) CreateOrUpdateAsync(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdateAsync), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Delete mocks base method.

--- a/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
+++ b/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
@@ -28,6 +28,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
+	v1alpha40 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 // MockVMExtensionScope is a mock of VMExtensionScope interface.
@@ -253,6 +254,18 @@ func (m *MockVMExtensionScope) ResourceGroup() string {
 func (mr *MockVMExtensionScopeMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockVMExtensionScope)(nil).ResourceGroup))
+}
+
+// SetCondition mocks base method.
+func (m *MockVMExtensionScope) SetCondition(arg0 v1alpha40.ConditionType, arg1 string, arg2 v1alpha40.ConditionSeverity, arg3 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCondition", arg0, arg1, arg2, arg3)
+}
+
+// SetCondition indicates an expected call of SetCondition.
+func (mr *MockVMExtensionScopeMockRecorder) SetCondition(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCondition", reflect.TypeOf((*MockVMExtensionScope)(nil).SetCondition), arg0, arg1, arg2, arg3)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
+++ b/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
@@ -28,7 +28,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
-	v1alpha40 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 // MockVMExtensionScope is a mock of VMExtensionScope interface.
@@ -256,16 +255,18 @@ func (mr *MockVMExtensionScopeMockRecorder) ResourceGroup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockVMExtensionScope)(nil).ResourceGroup))
 }
 
-// SetCondition mocks base method.
-func (m *MockVMExtensionScope) SetCondition(arg0 v1alpha40.ConditionType, arg1 string, arg2 v1alpha40.ConditionSeverity, arg3 bool) {
+// SetBootstrapConditions mocks base method.
+func (m *MockVMExtensionScope) SetBootstrapConditions(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetCondition", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SetBootstrapConditions", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// SetCondition indicates an expected call of SetCondition.
-func (mr *MockVMExtensionScopeMockRecorder) SetCondition(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// SetBootstrapConditions indicates an expected call of SetBootstrapConditions.
+func (mr *MockVMExtensionScopeMockRecorder) SetBootstrapConditions(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCondition", reflect.TypeOf((*MockVMExtensionScope)(nil).SetCondition), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBootstrapConditions", reflect.TypeOf((*MockVMExtensionScope)(nil).SetBootstrapConditions), arg0, arg1)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/services/vmssextensions/client.go
+++ b/azure/services/vmssextensions/client.go
@@ -28,8 +28,6 @@ import (
 // Client wraps go-sdk
 type client interface {
 	Get(context.Context, string, string, string) (compute.VirtualMachineScaleSetExtension, error)
-	CreateOrUpdate(context.Context, string, string, string, compute.VirtualMachineScaleSetExtension) error
-	Delete(context.Context, string, string, string) error
 }
 
 // AzureClient contains the Azure go-sdk Client
@@ -58,38 +56,4 @@ func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmssName, nam
 	defer span.End()
 
 	return ac.vmssextensions.Get(ctx, resourceGroupName, vmssName, name, "")
-}
-
-// CreateOrUpdate creates or updates the virtual machine scale set extension
-func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vmName, name string, parameters compute.VirtualMachineScaleSetExtension) error {
-	ctx, span := tele.Tracer().Start(ctx, "vmssextensions.AzureClient.CreateOrUpdate")
-	defer span.End()
-
-	future, err := ac.vmssextensions.CreateOrUpdate(ctx, resourceGroupName, vmName, name, parameters)
-	if err != nil {
-		return err
-	}
-	err = future.WaitForCompletionRef(ctx, ac.vmssextensions.Client)
-	if err != nil {
-		return err
-	}
-	_, err = future.Result(ac.vmssextensions)
-	return err
-}
-
-// Delete removes the virtual machine scale set extension.
-func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, vmName, name string) error {
-	ctx, span := tele.Tracer().Start(ctx, "vmssextensions.AzureClient.Delete")
-	defer span.End()
-
-	future, err := ac.vmssextensions.Delete(ctx, resourceGroupName, vmName, name)
-	if err != nil {
-		return err
-	}
-	err = future.WaitForCompletionRef(ctx, ac.vmssextensions.Client)
-	if err != nil {
-		return err
-	}
-	_, err = future.Result(ac.vmssextensions)
-	return err
 }

--- a/azure/services/vmssextensions/mock_vmssextensions/client_mock.go
+++ b/azure/services/vmssextensions/mock_vmssextensions/client_mock.go
@@ -51,34 +51,6 @@ func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 	return m.recorder
 }
 
-// CreateOrUpdate mocks base method.
-func (m *Mockclient) CreateOrUpdate(arg0 context.Context, arg1, arg2, arg3 string, arg4 compute.VirtualMachineScaleSetExtension) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateOrUpdate indicates an expected call of CreateOrUpdate.
-func (mr *MockclientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3, arg4)
-}
-
-// Delete mocks base method.
-func (m *Mockclient) Delete(arg0 context.Context, arg1, arg2, arg3 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete.
-func (mr *MockclientMockRecorder) Delete(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*Mockclient)(nil).Delete), arg0, arg1, arg2, arg3)
-}
-
 // Get mocks base method.
 func (m *Mockclient) Get(arg0 context.Context, arg1, arg2, arg3 string) (compute.VirtualMachineScaleSetExtension, error) {
 	m.ctrl.T.Helper()

--- a/azure/services/vmssextensions/mock_vmssextensions/vmssextensions_mock.go
+++ b/azure/services/vmssextensions/mock_vmssextensions/vmssextensions_mock.go
@@ -28,6 +28,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
+	v1alpha40 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 // MockVMSSExtensionScope is a mock of VMSSExtensionScope interface.
@@ -253,6 +254,18 @@ func (m *MockVMSSExtensionScope) ResourceGroup() string {
 func (mr *MockVMSSExtensionScopeMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockVMSSExtensionScope)(nil).ResourceGroup))
+}
+
+// SetCondition mocks base method.
+func (m *MockVMSSExtensionScope) SetCondition(arg0 v1alpha40.ConditionType, arg1 string, arg2 v1alpha40.ConditionSeverity, arg3 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCondition", arg0, arg1, arg2, arg3)
+}
+
+// SetCondition indicates an expected call of SetCondition.
+func (mr *MockVMSSExtensionScopeMockRecorder) SetCondition(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCondition", reflect.TypeOf((*MockVMSSExtensionScope)(nil).SetCondition), arg0, arg1, arg2, arg3)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/services/vmssextensions/mock_vmssextensions/vmssextensions_mock.go
+++ b/azure/services/vmssextensions/mock_vmssextensions/vmssextensions_mock.go
@@ -28,7 +28,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
-	v1alpha40 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 // MockVMSSExtensionScope is a mock of VMSSExtensionScope interface.
@@ -256,16 +255,18 @@ func (mr *MockVMSSExtensionScopeMockRecorder) ResourceGroup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockVMSSExtensionScope)(nil).ResourceGroup))
 }
 
-// SetCondition mocks base method.
-func (m *MockVMSSExtensionScope) SetCondition(arg0 v1alpha40.ConditionType, arg1 string, arg2 v1alpha40.ConditionSeverity, arg3 bool) {
+// SetBootstrapConditions mocks base method.
+func (m *MockVMSSExtensionScope) SetBootstrapConditions(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetCondition", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SetBootstrapConditions", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// SetCondition indicates an expected call of SetCondition.
-func (mr *MockVMSSExtensionScopeMockRecorder) SetCondition(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// SetBootstrapConditions indicates an expected call of SetBootstrapConditions.
+func (mr *MockVMSSExtensionScopeMockRecorder) SetBootstrapConditions(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCondition", reflect.TypeOf((*MockVMSSExtensionScope)(nil).SetCondition), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBootstrapConditions", reflect.TypeOf((*MockVMSSExtensionScope)(nil).SetBootstrapConditions), arg0, arg1)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/types.go
+++ b/azure/types.go
@@ -191,16 +191,18 @@ type AvailabilitySetSpec struct {
 
 // VMExtensionSpec defines the specification for a VM extension.
 type VMExtensionSpec struct {
-	Name      string
-	VMName    string
-	Publisher string
-	Version   string
+	Name              string
+	VMName            string
+	Publisher         string
+	Version           string
+	ProtectedSettings map[string]string
 }
 
 // VMSSExtensionSpec defines the specification for a VMSS extension.
 type VMSSExtensionSpec struct {
-	Name         string
-	ScaleSetName string
-	Publisher    string
-	Version      string
+	Name              string
+	ScaleSetName      string
+	Publisher         string
+	Version           string
+	ProtectedSettings map[string]string
 }

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -296,10 +296,8 @@ func (r *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineSco
 		// Handle transient and terminal errors
 		var reconcileError azure.ReconcileError
 		if errors.As(err, &reconcileError) {
-			r.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "ReconcileError", errors.Wrap(err, "failed to reconcile AzureMachine").Error())
-			conditions.MarkFalse(machineScope.AzureMachine, infrav1.VMRunningCondition, infrav1.VMProvisionFailedReason, clusterv1.ConditionSeverityError, err.Error())
-
 			if reconcileError.IsTerminal() {
+				r.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "ReconcileError", errors.Wrapf(err, "failed to reconcile AzureMachine").Error())
 				machineScope.Error(err, "failed to reconcile AzureMachine", "name", machineScope.Name())
 				machineScope.SetFailureReason(capierrors.CreateMachineError)
 				machineScope.SetFailureMessage(err)
@@ -309,48 +307,17 @@ func (r *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineSco
 			}
 
 			if reconcileError.IsTransient() {
-				machineScope.Error(err, "failed to reconcile AzureMachine", "name", machineScope.Name())
+				machineScope.Error(err, "transient failure to reconcile AzureMachine, retrying", "name", machineScope.Name())
+				machineScope.SetNotReady()
 				return reconcile.Result{RequeueAfter: reconcileError.RequeueAfter()}, nil
 			}
-
-			return reconcile.Result{}, errors.Wrap(err, "failed to reconcile AzureMachine")
 		}
-
-		r.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "Error creating new AzureMachine", errors.Wrap(err, "failed to reconcile AzureMachine").Error())
+		r.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "ReconcileError", errors.Wrapf(err, "failed to reconcile AzureMachine").Error())
 		conditions.MarkFalse(machineScope.AzureMachine, infrav1.VMRunningCondition, infrav1.VMProvisionFailedReason, clusterv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, errors.Wrap(err, "failed to reconcile AzureMachine")
 	}
 
-	switch machineScope.VMState() {
-	case infrav1.VMStateSucceeded:
-		machineScope.V(2).Info("VM is running", "id", machineScope.GetVMID())
-		conditions.MarkTrue(machineScope.AzureMachine, infrav1.VMRunningCondition)
-		machineScope.SetReady()
-	case infrav1.VMStateCreating:
-		machineScope.V(2).Info("VM is creating", "id", machineScope.GetVMID())
-		conditions.MarkFalse(machineScope.AzureMachine, infrav1.VMRunningCondition, infrav1.VMNCreatingReason, clusterv1.ConditionSeverityInfo, "")
-		machineScope.SetNotReady()
-	case infrav1.VMStateUpdating:
-		machineScope.V(2).Info("VM is updating", "id", machineScope.GetVMID())
-		conditions.MarkFalse(machineScope.AzureMachine, infrav1.VMRunningCondition, infrav1.VMNUpdatingReason, clusterv1.ConditionSeverityInfo, "")
-		machineScope.SetNotReady()
-	case infrav1.VMStateDeleting:
-		machineScope.Info("Unexpected VM deletion", "id", machineScope.GetVMID())
-		r.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "UnexpectedVMDeletion", "Unexpected Azure VM deletion")
-		conditions.MarkFalse(machineScope.AzureMachine, infrav1.VMRunningCondition, infrav1.VMDDeletingReason, clusterv1.ConditionSeverityWarning, "")
-		machineScope.SetNotReady()
-	case infrav1.VMStateFailed:
-		machineScope.Error(errors.New("Failed to create or update VM"), "VM is in failed state", "id", machineScope.GetVMID())
-		r.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "FailedVMState", "Azure VM is in failed state")
-		machineScope.SetFailureReason(capierrors.UpdateMachineError)
-		machineScope.SetFailureMessage(errors.Errorf("Azure VM state is %s", machineScope.VMState()))
-		conditions.MarkFalse(machineScope.AzureMachine, infrav1.VMRunningCondition, infrav1.VMProvisionFailedReason, clusterv1.ConditionSeverityWarning, "")
-		machineScope.SetNotReady()
-	default:
-		machineScope.V(2).Info("VM state is undefined", "id", machineScope.GetVMID())
-		conditions.MarkUnknown(machineScope.AzureMachine, infrav1.VMRunningCondition, "", "")
-		machineScope.SetNotReady()
-	}
+	machineScope.SetReady()
 
 	return reconcile.Result{}, nil
 }

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -302,7 +302,7 @@ func (r *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineSco
 				machineScope.SetFailureReason(capierrors.CreateMachineError)
 				machineScope.SetFailureMessage(err)
 				machineScope.SetNotReady()
-				machineScope.SetVMState(infrav1.VMStateFailed)
+				machineScope.SetVMState(infrav1.Failed)
 				return reconcile.Result{}, nil
 			}
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,57 +1,157 @@
 # Troubleshooting Guide
 
-Common issue users might have when using Cluster API Provider for Azure.
+Common issues users might run into when using Cluster API Provider for Azure. This list is work-in-progress. Feel free to open a PR to add to it if you find that useful information is missing.
 
-## Debugging cluster creation
-You will need to review the logs for the components of the control plane nodes and for the workload clusters.  Start your investigation with reviewing the logs of the control plane then move onto the workload cluster that is created.
+## Examples of troubleshooting real-world issues
 
-## Review logs of control plane
-While cluster buildout is running, you can follow the controller logs in a separate window like this:
+### No Azure resources are getting created
+
+This is likely due to missing or invalid Azure credentials. 
+
+Check the CAPZ controller logs on the management cluster:
 
 ```bash
-kubectl get po -o wide --all-namespaces -w # Watch pod creation until azure-provider-controller-manager-0 is available
-
-kubectl logs -n capz-system azure-provider-controller-manager-0 manager -f # Follow the controller logs
+kubectl logs deploy/capz-controller-manager -n capz-system manager
 ```
 
-An error such as the following in the manager could point to a mismatch between a current CAPI and an old CAPZ version:
+If you see an error similar to this:
 
 ```
-E0320 23:33:33.288073       1 controller.go:258] controller-runtime/controller "msg"="Reconciler error" "error"="failed to create AzureMachine VM: failed to create nic capz-cluster-control-plane-7z8ng-nic for machine capz-cluster-control-plane-7z8ng: unable to determine NAT rule for control plane network interface: strconv.Atoi: parsing \"capz-cluster-control-plane-7z8ng\": invalid syntax"  "controller"="azuremachine" "request"={"Namespace":"default","Name":"capz-cluster-control-plane-7z8ng"}
+azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://management.azure.com/subscriptions/123/providers/Microsoft.Compute/skus?%24filter=location+eq+%27eastus2%27&api-version=2019-04-01: StatusCode=401 -- Original Error: adal: Refresh request failed. Status Code = '401'. Response body: {\"error\":\"invalid_client\",\"error_description\":\"AADSTS7000215: Invalid client secret is provided.
 ```
 
-### Remoting to workload clusters
-After the workload cluster is finished deploying you will have a kubeconfig in `./kubeconfig`.
+Make sure the provided Service Principal client ID and client secret are correct and that the password has not expired.
 
-Using the ssh information provided during cluster creation (environment variable `AZURE_SSH_PUBLIC_KEY_B64`), you can debug most issues by SSHing into the VMs that have been created:
+### The AzureCluster infrastructure is provisioned but no virtual machines are coming up
+
+Your Azure subscription might have no quota for the requested VM size in the specified Azure location.
+
+Check the CAPZ controller logs on the management cluster:
+
+```bash
+kubectl logs deploy/capz-controller-manager -n capz-system manager
+```
+
+If you see an error similar to this:
+```
+"error"="failed to reconcile AzureMachine: failed to create virtual machine: failed to create VM capz-md-0-qkg6m in resource group capz-fkl3tp: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=\u003cnil\u003e Code=\"OperationNotAllowed\" Message=\"Operation could not be completed as it results in exceeding approved standardDSv3Family Cores quota.
+```
+
+Follow the [these steps](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/error-resource-quota). Alternatively, you can specify another Azure location and/or VM size during cluster creation.
+
+### A virtual machine is running but the k8s node did not join the cluster
+
+Check the AzureMachine (or AzureMachinePool if using a MachinePool) status:
+```bash
+kubectl get azuremachines -o wide
+```
+
+If you see an output like this:
 
 ```
-# connect to first control node - capi is default linux user created by deployment
-API_SERVER=$(kubectl get azurecluster capz-cluster -o jsonpath='{.status.network.apiServerIp.dnsName}')
+NAME                                       READY   STATE
+default-template-md-0-w78jt                false   Updating
+```
+
+This indicates that the bootstrap script has not yet succeeded. Check the AzureMachine `status.conditions` field for more information.
+
+[Take a look at the cloud-init logs](#checking-cloud-init-logs-ubuntu) for further debugging.
+
+### One or more control plane replicas are missing
+
+Take a look at the KubeadmControlPlane controller logs and look for any potential errors:
+
+```bash
+kubectl logs deploy/capi-kubeadm-control-plane-controller-manager -n capi-kubeadm-control-plane-system manager
+```
+
+In addition, make sure all pods on the workload cluster are healthy, including pods in the `kube-system` namespace.
+
+### Nodes are in NotReady state
+
+Make sure you have installed a CNI on the workload cluster and that all the pods on the workload cluster are in running state.
+
+### Load Balancer service fails to come up
+
+Check the cloud-controller-manager logs on the workload cluster. 
+
+If running the Azure cloud provider in-tree:
+
+```
+kubectl logs kube-controller-manager-<control-plane-node-name> -n kube-system 
+```
+
+If running the Azure cloud provider out-of-tree:
+
+```
+kubectl logs cloud-controller-manager -n kube-system 
+```
+
+
+## Watching Kubernetes resources
+
+To watch progression of all Cluster API resources on the management cluster you can run:
+
+```bash
+kubectl get cluster-api
+```
+
+## Looking at controller logs
+
+To check the CAPZ controller logs on the management cluster, run:
+
+```bash
+kubectl logs deploy/capz-controller-manager -n capz-system manager
+```
+
+### Checking cloud-init logs (Ubuntu)
+
+Cloud-init logs can provide more information on any issues that happened when running the bootstrap script. 
+
+#### Option 1: Using the Azure Portal 
+
+Located in the virtual machine blade, the boot diagnostics option is under the Support and Troubleshooting section in the Azure portal.
+
+For more information, see [here](https://docs.microsoft.com/en-us/azure/virtual-machines/boot-diagnostics#boot-diagnostics-view)
+
+#### Option 2: Using the Azure CLI
+
+```bash
+az vm boot-diagnostics get-boot-log --name MyVirtualMachine --resource-group MyResourceGroup
+```
+
+For more information, see [here](https://docs.microsoft.com/en-us/cli/azure/vm/boot-diagnostics?view=azure-cli-latest).
+
+#### Option 3: With SSH
+
+Using the ssh information provided during cluster creation (environment variable `AZURE_SSH_PUBLIC_KEY_B64`):
+
+
+##### connect to first control node - capi is default linux user created by deployment
+```
+API_SERVER=$(kubectl get azurecluster capz-cluster -o jsonpath='{.spec.controlPlaneEndpoint.host}')
 ssh capi@${API_SERVER}
+```
 
-# list nodes
+##### list nodes
+```
 kubectl get azuremachines
 NAME                               READY   STATE
 capz-cluster-control-plane-2jprg   true    Succeeded
 capz-cluster-control-plane-ck5wv   true    Succeeded
 capz-cluster-control-plane-w4tv6   true    Succeeded
-capz-cluster-md-0-s52wb            true    Succeeded
+capz-cluster-md-0-s52wb            false   Failed
 capz-cluster-md-0-w8xxw            true    Succeeded
+```
 
-# pick node name from output above:
+##### pick node name from output above:
+```
 node=$(kubectl get azuremachine capz-cluster-md-0-s52wb -o jsonpath='{.status.addresses[0].address}')
 ssh -J capi@${apiserver} capi@${node}
 ```
 
-> There are some [provided scripts](/hack/debugging/Readme.md) that can help automate a few common tasks.
-
-Reviewing the following logs on the workload cluster can help with troubleshooting:
-
-- `less /var/lib/waagent/custom-script/download/0/stdout`
-- `journalctl -u cloud-final`
-- `less /var/log/cloud-init-output.log`
-- `journalctl -u kubelet`
+##### look at cloud-init logs
+`less /var/log/cloud-init-output.log`
 
 ## Automated log collection
 
@@ -60,3 +160,5 @@ As part of [CI](../scripts/ci-e2e.sh) there is a [log collection script](hack/..
 ```bash
 ./hack/log/log-dump.sh
 ```
+
+There are also some [provided scripts](/hack/debugging/Readme.md) that can help automate a few common tasks.

--- a/exp/api/v1alpha3/zz_generated.conversion.go
+++ b/exp/api/v1alpha3/zz_generated.conversion.go
@@ -327,7 +327,7 @@ func Convert_v1alpha4_AzureMachinePool_To_v1alpha3_AzureMachinePool(in *v1alpha4
 
 func autoConvert_v1alpha3_AzureMachinePoolInstanceStatus_To_v1alpha4_AzureMachinePoolInstanceStatus(in *AzureMachinePoolInstanceStatus, out *v1alpha4.AzureMachinePoolInstanceStatus, s conversion.Scope) error {
 	out.Version = in.Version
-	out.ProvisioningState = (*clusterapiproviderazureapiv1alpha4.VMState)(unsafe.Pointer(in.ProvisioningState))
+	out.ProvisioningState = (*clusterapiproviderazureapiv1alpha4.ProvisioningState)(unsafe.Pointer(in.ProvisioningState))
 	out.ProviderID = in.ProviderID
 	out.InstanceID = in.InstanceID
 	out.InstanceName = in.InstanceName
@@ -440,7 +440,7 @@ func autoConvert_v1alpha3_AzureMachinePoolStatus_To_v1alpha4_AzureMachinePoolSta
 	out.Replicas = in.Replicas
 	out.Instances = *(*[]*v1alpha4.AzureMachinePoolInstanceStatus)(unsafe.Pointer(&in.Instances))
 	out.Version = in.Version
-	out.ProvisioningState = (*clusterapiproviderazureapiv1alpha4.VMState)(unsafe.Pointer(in.ProvisioningState))
+	out.ProvisioningState = (*clusterapiproviderazureapiv1alpha4.ProvisioningState)(unsafe.Pointer(in.ProvisioningState))
 	out.FailureReason = (*errors.MachineStatusError)(unsafe.Pointer(in.FailureReason))
 	out.FailureMessage = (*string)(unsafe.Pointer(in.FailureMessage))
 	out.Conditions = *(*apiv1alpha4.Conditions)(unsafe.Pointer(&in.Conditions))
@@ -958,7 +958,7 @@ func autoConvert_v1alpha3_VMSS_To_v1alpha4_VMSS(in *VMSS, out *v1alpha4.VMSS, s 
 	if err := Convert_v1alpha3_Image_To_v1alpha4_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
-	out.State = clusterapiproviderazureapiv1alpha4.VMState(in.State)
+	out.State = clusterapiproviderazureapiv1alpha4.ProvisioningState(in.State)
 	out.Identity = clusterapiproviderazureapiv1alpha4.VMIdentity(in.Identity)
 	out.Tags = *(*clusterapiproviderazureapiv1alpha4.Tags)(unsafe.Pointer(&in.Tags))
 	out.Instances = *(*[]v1alpha4.VMSSVM)(unsafe.Pointer(&in.Instances))
@@ -996,7 +996,7 @@ func autoConvert_v1alpha3_VMSSVM_To_v1alpha4_VMSSVM(in *VMSSVM, out *v1alpha4.VM
 	out.InstanceID = in.InstanceID
 	out.Name = in.Name
 	out.AvailabilityZone = in.AvailabilityZone
-	out.State = clusterapiproviderazureapiv1alpha4.VMState(in.State)
+	out.State = clusterapiproviderazureapiv1alpha4.ProvisioningState(in.State)
 	out.LatestModelApplied = in.LatestModelApplied
 	return nil
 }

--- a/exp/api/v1alpha4/azuremachinepool_types.go
+++ b/exp/api/v1alpha4/azuremachinepool_types.go
@@ -133,7 +133,7 @@ type (
 
 		// ProvisioningState is the provisioning state of the Azure virtual machine.
 		// +optional
-		ProvisioningState *infrav1.VMState `json:"provisioningState,omitempty"`
+		ProvisioningState *infrav1.ProvisioningState `json:"provisioningState,omitempty"`
 
 		// FailureReason will be set in the event that there is a terminal problem
 		// reconciling the MachinePool and will contain a succinct value suitable
@@ -191,7 +191,7 @@ type (
 
 		// ProvisioningState is the provisioning state of the Azure virtual machine instance.
 		// +optional
-		ProvisioningState *infrav1.VMState `json:"provisioningState"`
+		ProvisioningState *infrav1.ProvisioningState `json:"provisioningState"`
 
 		// ProviderID is the provider identification of the VMSS Instance
 		// +optional

--- a/exp/api/v1alpha4/types.go
+++ b/exp/api/v1alpha4/types.go
@@ -23,25 +23,25 @@ import (
 type (
 	// VMSSVM defines a VM in a virtual machine scale set.
 	VMSSVM struct {
-		ID                 string          `json:"id,omitempty"`
-		InstanceID         string          `json:"instanceID,omitempty"`
-		Name               string          `json:"name,omitempty"`
-		AvailabilityZone   string          `json:"availabilityZone,omitempty"`
-		State              infrav1.VMState `json:"vmState,omitempty"`
-		LatestModelApplied bool            `json:"latestModelApplied,omitempty"`
+		ID                 string                    `json:"id,omitempty"`
+		InstanceID         string                    `json:"instanceID,omitempty"`
+		Name               string                    `json:"name,omitempty"`
+		AvailabilityZone   string                    `json:"availabilityZone,omitempty"`
+		State              infrav1.ProvisioningState `json:"vmState,omitempty"`
+		LatestModelApplied bool                      `json:"latestModelApplied,omitempty"`
 	}
 
 	// VMSS defines a virtual machine scale set.
 	VMSS struct {
-		ID        string             `json:"id,omitempty"`
-		Name      string             `json:"name,omitempty"`
-		Sku       string             `json:"sku,omitempty"`
-		Capacity  int64              `json:"capacity,omitempty"`
-		Zones     []string           `json:"zones,omitempty"`
-		Image     infrav1.Image      `json:"image,omitempty"`
-		State     infrav1.VMState    `json:"vmState,omitempty"`
-		Identity  infrav1.VMIdentity `json:"identity,omitempty"`
-		Tags      infrav1.Tags       `json:"tags,omitempty"`
-		Instances []VMSSVM           `json:"instances,omitempty"`
+		ID        string                    `json:"id,omitempty"`
+		Name      string                    `json:"name,omitempty"`
+		Sku       string                    `json:"sku,omitempty"`
+		Capacity  int64                     `json:"capacity,omitempty"`
+		Zones     []string                  `json:"zones,omitempty"`
+		Image     infrav1.Image             `json:"image,omitempty"`
+		State     infrav1.ProvisioningState `json:"vmState,omitempty"`
+		Identity  infrav1.VMIdentity        `json:"identity,omitempty"`
+		Tags      infrav1.Tags              `json:"tags,omitempty"`
+		Instances []VMSSVM                  `json:"instances,omitempty"`
 	}
 )

--- a/exp/api/v1alpha4/zz_generated.deepcopy.go
+++ b/exp/api/v1alpha4/zz_generated.deepcopy.go
@@ -59,7 +59,7 @@ func (in *AzureMachinePoolInstanceStatus) DeepCopyInto(out *AzureMachinePoolInst
 	*out = *in
 	if in.ProvisioningState != nil {
 		in, out := &in.ProvisioningState, &out.ProvisioningState
-		*out = new(apiv1alpha4.VMState)
+		*out = new(apiv1alpha4.ProvisioningState)
 		**out = **in
 	}
 }
@@ -155,7 +155,7 @@ func (in *AzureMachinePoolStatus) DeepCopyInto(out *AzureMachinePoolStatus) {
 	}
 	if in.ProvisioningState != nil {
 		in, out := &in.ProvisioningState, &out.ProvisioningState
-		*out = new(apiv1alpha4.VMState)
+		*out = new(apiv1alpha4.ProvisioningState)
 		**out = **in
 	}
 	if in.FailureReason != nil {

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -297,15 +297,15 @@ func (r *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, machin
 	}
 
 	switch machinePoolScope.ProvisioningState() {
-	case infrav1.VMStateSucceeded:
+	case infrav1.Succeeded:
 		machinePoolScope.V(2).Info("Scale Set is running", "id", machinePoolScope.ProviderID())
 		conditions.MarkTrue(machinePoolScope.AzureMachinePool, infrav1.ScaleSetRunningCondition)
 		machinePoolScope.SetReady()
-	case infrav1.VMStateCreating:
+	case infrav1.Creating:
 		machinePoolScope.V(2).Info("Scale Set is creating", "id", machinePoolScope.ProviderID())
 		conditions.MarkFalse(machinePoolScope.AzureMachinePool, infrav1.ScaleSetRunningCondition, infrav1.ScaleSetCreatingReason, clusterv1.ConditionSeverityInfo, "")
 		machinePoolScope.SetNotReady()
-	case infrav1.VMStateUpdating:
+	case infrav1.Updating:
 		machinePoolScope.V(2).Info("Scale Set is updating", "id", machinePoolScope.ProviderID())
 		conditions.MarkFalse(machinePoolScope.AzureMachinePool, infrav1.ScaleSetRunningCondition, infrav1.ScaleSetUpdatingReason, clusterv1.ConditionSeverityInfo, "")
 		machinePoolScope.SetNotReady()
@@ -313,12 +313,12 @@ func (r *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, machin
 		return reconcile.Result{
 			RequeueAfter: 30 * time.Second,
 		}, nil
-	case infrav1.VMStateDeleting:
+	case infrav1.Deleting:
 		machinePoolScope.Info("Unexpected scale set deletion", "id", machinePoolScope.ProviderID())
 		r.Recorder.Eventf(machinePoolScope.AzureMachinePool, corev1.EventTypeWarning, "UnexpectedVMDeletion", "Unexpected Azure scale set deletion")
 		conditions.MarkFalse(machinePoolScope.AzureMachinePool, infrav1.VMRunningCondition, infrav1.ScaleSetDeletingReason, clusterv1.ConditionSeverityWarning, "")
 		machinePoolScope.SetNotReady()
-	case infrav1.VMStateFailed:
+	case infrav1.Failed:
 		machinePoolScope.SetNotReady()
 		machinePoolScope.Error(errors.New("Failed to create or update scale set"), "Scale Set is in failed state", "id", machinePoolScope.ProviderID())
 		r.Recorder.Eventf(machinePoolScope.AzureMachinePool, corev1.EventTypeWarning, "FailedVMState", "Azure scale set is in failed state")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Implements bootstrap failure detection using conditions and VM extensions as proposed in #1076.

This is what a user will see when an AzureMachine has been successfully provisioned but has not yet finished running the bootstrap script:
```
$ k get azuremachine default-template-md-0-w78jt
NAME                                       READY   STATE
default-template-md-0-w78jt                false   Updating
```

```
status:
    conditions:
  - lastTransitionTime: "2021-03-17T00:02:14Z"
    reason: VMUpdating
    severity: Info
    status: "False"
    type: Ready
  - lastTransitionTime: "2021-03-17T00:02:14Z"
    reason: BootstrapInProgress
    severity: Info
    status: "False"
    type: BoostrapSucceeded
  - lastTransitionTime: "2021-03-17T00:02:14Z"
    reason: VMUpdating
    severity: Info
    status: "False"
    type: VMRunning
```

After the bootstrap script has executed successfully, the AzureMachine status shows:

```
$ k get azuremachine default-template-md-0-w78jt
NAME                                       READY   STATE
default-template-md-0-w78jt                true    Succeeded
```

```
status:
  conditions:
  - lastTransitionTime: "2021-03-16T23:56:17Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2021-03-16T23:56:17Z"
    status: "True"
    type: BoostrapSucceeded
  - lastTransitionTime: "2021-03-16T23:56:17Z"
    status: "True"
    type: VMRunning
```

If for some reason the bootstrap script fails to execute, the status will show:

```
$ k get azuremachines default-template-md-0-ppjmh
NAME                                       READY   STATE
default-template-md-0-ppjmh                false   Failed
```

```
  conditions:
  - lastTransitionTime: "2021-03-17T00:22:39Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2021-03-17T00:22:39Z"
    reason: BootstrapFailed
    severity: Error
    status: "False"
    type: BoostrapSucceeded
  - lastTransitionTime: "2021-03-17T00:22:39Z"
    status: "True"
    type: VMRunning
```

Also renames type "VMState" to "ProvisioningState" to be more generic and match Azure naming. **This is a breaking change** for anyone importing CAPZ types, but should have no impact on user templates and existing CRDs (conversion from v1alpha3 to v1alpha4 is auto-generated).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #603 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Linux VM extension bootstrap script and conditions
Renames type "VMState" to "ProvisioningState"
```
