### PR TITLE
Update Cert Manager Tilt Module to v1.1.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -17,7 +17,7 @@ settings = {
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
     "capi_version": "nightly_master_20210310",
-    "cert_manager_version": "v0.16.1",
+    "cert_manager_version": "v1.1.0",
     "kubernetes_version": "v1.19.7",
     "aks_kubernetes_version": "v1.18.8"
 }

--- a/tilt_modules/cert_manager/README.md
+++ b/tilt_modules/cert_manager/README.md
@@ -21,6 +21,6 @@ have to pull the images over the network each time.
 
 The full list of parameters accepted by `deploy_cert_manager` includes:
 - `registry` from which images should be pulled, defaults to `quay.io/jetstack`
-- `version` of cert-manager to install, defaults to `v1.0.1`
+- `version` of cert-manager to install, defaults to `v1.1.0`
 - `load_to_kind` (see above), defaults to `False`
 - `kind_cluster_name`, defaults to `kind`

--- a/tilt_modules/cert_manager/Tiltfile
+++ b/tilt_modules/cert_manager/Tiltfile
@@ -4,15 +4,15 @@ kind: Namespace
 metadata:
   name: cert-manager-test
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/{cert_manager_api_version}
 kind: Issuer
 metadata:
   name: test-selfsigned
   namespace: cert-manager-test
 spec:
-  selfSigned: {}
+  selfSigned: {{}}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/{cert_manager_api_version}
 kind: Certificate
 metadata:
   name: selfsigned-cert
@@ -26,27 +26,28 @@ spec:
 """
 
 # Deploys cert manager to your environment
-def deploy_cert_manager(registry="quay.io/jetstack", version="v1.0.1", load_to_kind=False, kind_cluster_name="kind"):
+def deploy_cert_manager(registry="quay.io/jetstack", version="v1.1.0", load_to_kind=False, kind_cluster_name="kind"):
     silent=True
 
-    # check if cert-mamager is already installed, otherwise pre-load images & apply the manifest
-    # NB. this is required until https://github.com/jetstack/cert-manager/issues/3121 is addressed otherwise
-    # when applying the manifest twice to same cluster kubectl get stuck
-    existsCheck = str(local("kubectl get namespaces", quiet=silent, echo_off=silent))
-    if existsCheck.find("cert-manager") == -1:
-        if load_to_kind == True:
-            print("Loading images to kind")
-            # Prepull all the cert-manager images to your local environment and then load them directly into kind. This speeds up
-            # setup if you're repeatedly destroying and recreating your kind cluster, as it doesn't have to pull the images over
-            # the network each time.
-            images = ["cert-manager-controller", "cert-manager-cainjector", "cert-manager-webhook"]
-            for image in images:
-                local("docker pull {}/{}:{}".format(registry, image, version), quiet=silent, echo_off=silent)
-                local("kind load docker-image --name {} {}/{}:{}".format(kind_cluster_name, registry, image, version), quiet=silent, echo_off=silent)
+    if version.startswith('v0'):
+        cert_manager_test_resources_versioned = cert_manager_test_resources.format(cert_manager_api_version='v1alpha2')
+    else:
+        cert_manager_test_resources_versioned = cert_manager_test_resources.format(cert_manager_api_version='v1')
+    if load_to_kind == True:
+        print("Loading images to kind")
+        # Prepull all the cert-manager images to your local environment and then load them directly into kind. This speeds up
+        # setup if you're repeatedly destroying and recreating your kind cluster, as it doesn't have to pull the images over
+        # the network each time.
+        images = ["cert-manager-controller", "cert-manager-cainjector", "cert-manager-webhook"]
+        for image in images:
+            local("docker pull {}/{}:{}".format(registry, image, version), quiet=silent, echo_off=silent)
+            local("kind load docker-image --name {} {}/{}:{}".format(kind_cluster_name, registry, image, version), quiet=silent, echo_off=silent)
 
-        # apply the cert-manager manifest
-        print("Installing cert-manager")
-        local("kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/{}/cert-manager.yaml".format(version), quiet=silent, echo_off=silent)
+    # apply the cert-manager manifest
+    # Applying the same manifest twice to same cluster kubectl get stuck with older versions of kubernetes/cert-manager.
+    # https://github.com/jetstack/cert-manager/issues/3121
+    print("Installing cert-manager")
+    local("kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/{}/cert-manager.yaml".format(version), quiet=silent, echo_off=silent)
 
     # verifies cert-manager is properly working (https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation)
     # 1. wait for the cert-manager to be running
@@ -57,6 +58,6 @@ def deploy_cert_manager(registry="quay.io/jetstack", version="v1.0.1", load_to_k
 
     # 2. create a test certificate
     print("Testing cert-manager")
-    local("cat << EOF | kubectl apply -f - " + cert_manager_test_resources + "EOF", quiet=silent, echo_off=silent)
+    local("cat << EOF | kubectl apply -f - " + cert_manager_test_resources_versioned + "EOF", quiet=silent, echo_off=silent)
     local("kubectl wait --for=condition=Ready --timeout=300s -n cert-manager-test certificate/selfsigned-cert ", quiet=silent, echo_off=silent)
-    local("cat << EOF | kubectl delete -f - " + cert_manager_test_resources + "EOF", quiet=silent, echo_off=silent)
+    local("cat << EOF | kubectl delete -f - " + cert_manager_test_resources_versioned + "EOF", quiet=silent, echo_off=silent)


### PR DESCRIPTION
This changes the default cert-manager version for Tilt, updates apiVersions in cert_manager_test_resources to the latest available, and removes jetstack/cert-manager workaround.

```release-note
NONE
```
