### PR TITLE
ci: add build provenance tags to E2E-created clusters

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -89,6 +89,11 @@ export AZURE_SSH_PUBLIC_KEY_B64=$(cat "${AZURE_SSH_PUBLIC_KEY_FILE}" | base64 | 
 # timestamp is in RFC-3339 format to match kubetest
 export TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 export JOB_NAME="${JOB_NAME:-"cluster-api-provider-azure-e2e"}"
+if [ -n "${REPO_OWNER}" ] && [ -n "${REPO_NAME}" ] && [ -n "${PULL_BASE_SHA}" ]; then
+    export BUILD_PROVENANCE="${REPO_OWNER}/${REPO_NAME}:${PULL_BASE_SHA}"
+else
+    export BUILD_PROVENANCE="canary"
+fi
 
 cleanup() {
     ${REPO_ROOT}/hack/log/redact.sh || true

--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/cluster-template-prow-external-cloud-provider.yaml
@@ -27,6 +27,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/cluster-template-prow-ipv6.yaml
+++ b/templates/test/cluster-template-prow-ipv6.yaml
@@ -29,6 +29,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-windows.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/cluster-template-prow-machine-pool.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/cluster-template-prow-multi-tenancy.yaml
+++ b/templates/test/cluster-template-prow-multi-tenancy.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   identityRef:

--- a/templates/test/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/cluster-template-prow-nvidia-gpu.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/cluster-template-prow-private.yaml
+++ b/templates/test/cluster-template-prow-private.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/cluster-template-prow-windows.yaml
+++ b/templates/test/cluster-template-prow-windows.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/cluster-template-prow.yaml
+++ b/templates/test/cluster-template-prow.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: default
 spec:
   additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
   location: ${AZURE_LOCATION}

--- a/templates/test/patches/tags.yaml
+++ b/templates/test/patches/tags.yaml
@@ -6,3 +6,4 @@ spec:
   additionalTags:
     jobName: ${JOB_NAME}
     creationTimestamp: ${TIMESTAMP}
+    buildProvenance: ${BUILD_PROVENANCE}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind other

(PS requesting we add a `/kind` value of "E2E" and/or "CI" and/or "test")

**What this PR does / why we need it**:

This PR adds a standard `buildProvenance` tag to the AzureCluster resource created by E2E tests. If it's possible to compose a string from the concatenation of `REPO_OWNER` + `REPO_NAME` + `PULL_BASE_SHA`, then we do. If not, then we simply add a value of "canary" to indicate that the cluster was built from source via our standard E2E tooling ( traversing through `scripts/ci-e2e.sh`).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1189

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ x ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
