### PR TITLE
test: validate VMSS accelerated networking during E2E

### DIFF
--- a/test/e2e/azure_accelnet.go
+++ b/test/e2e/azure_accelnet.go
@@ -35,6 +35,20 @@ type AzureAcceleratedNetworkingSpecInput struct {
 	ClusterName string
 }
 
+// KnownAcceleratedNetworkingSupportedVMSKUs is a manually curated dictionary that maps VM SKUS to accelerated networking capabilities
+// NOTE: add SKUs being tested to this lookup table.
+var KnownAcceleratedNetworkingSupportedVMSKUs = map[compute.VirtualMachineSizeTypes]bool{
+	compute.VirtualMachineSizeTypesStandardB2ms:   false,
+	compute.VirtualMachineSizeTypesStandardD2V2:   true,
+	compute.VirtualMachineSizeTypesStandardD2V3:   false,
+	compute.VirtualMachineSizeTypesStandardD2sV3:  false,
+	compute.VirtualMachineSizeTypesStandardD4V2:   true,
+	compute.VirtualMachineSizeTypesStandardD4V3:   true,
+	compute.VirtualMachineSizeTypesStandardD8sV3:  true,
+	compute.VirtualMachineSizeTypesStandardNC6sV3: false,
+	compute.VirtualMachineSizeTypesStandardNV6:    false,
+}
+
 // AzureAcceleratedNetworkingSpec implements a test that verifies Azure VMs in a workload
 // cluster provisioned by CAPZ have accelerated networking enabled if they're capable of it.
 func AzureAcceleratedNetworkingSpec(ctx context.Context, inputGetter func() AzureAcceleratedNetworkingSpecInput) {
@@ -54,22 +68,14 @@ func AzureAcceleratedNetworkingSpec(ctx context.Context, inputGetter func() Azur
 	Expect(err).NotTo(HaveOccurred())
 	vmsClient := compute.NewVirtualMachinesClient(subscriptionID)
 	vmsClient.Authorizer = authorizer
+	vmssClient := compute.NewVirtualMachineScaleSetsClient(subscriptionID)
+	vmssClient.Authorizer = authorizer
+	vmssVMsClient := compute.NewVirtualMachineScaleSetVMsClient(subscriptionID)
+	vmssVMsClient.Authorizer = authorizer
 	nicsClient := network.NewInterfacesClient(subscriptionID)
 	nicsClient.Authorizer = authorizer
 
 	By("verifying EnableAcceleratedNetworking for the primary NIC of each VM")
-	// NOTE: add SKUs being tested to this lookup table.
-	acceleratedNetworking := map[compute.VirtualMachineSizeTypes]bool{
-		compute.VirtualMachineSizeTypesStandardB2ms:   false,
-		compute.VirtualMachineSizeTypesStandardD2V2:   true,
-		compute.VirtualMachineSizeTypesStandardD2V3:   false,
-		compute.VirtualMachineSizeTypesStandardD2sV3:  false,
-		compute.VirtualMachineSizeTypesStandardD4V2:   true,
-		compute.VirtualMachineSizeTypesStandardD4V3:   true,
-		compute.VirtualMachineSizeTypesStandardD8sV3:  true,
-		compute.VirtualMachineSizeTypesStandardNC6sV3: false,
-		compute.VirtualMachineSizeTypesStandardNV6:    false,
-	}
 	rgName := input.ClusterName
 	page, err := vmsClient.List(ctx, rgName)
 	Expect(err).NotTo(HaveOccurred())
@@ -79,10 +85,8 @@ func AzureAcceleratedNetworkingSpec(ctx context.Context, inputGetter func() Azur
 			sku := vm.HardwareProfile.VMSize
 			for _, nic := range *vm.NetworkProfile.NetworkInterfaces {
 				if nic.Primary != nil && *nic.Primary {
-					// verify that accelerated networking is enabled if the SKU is capable
-					nicInfo, err := nicsClient.Get(ctx, rgName, filepath.Base(*nic.ID), "")
+					capable, found, nicInfo, err := validateAcceleratedNetworkingCapabilityMatch(ctx, nicsClient, rgName, *nic.ID, sku)
 					Expect(err).NotTo(HaveOccurred())
-					capable, found := acceleratedNetworking[sku]
 					if !found {
 						fmt.Fprintf(GinkgoWriter, "SKU %s was not found, please add to the acceleratedNetworking lookup table.\n", sku)
 					} else {
@@ -95,4 +99,40 @@ func AzureAcceleratedNetworkingSpec(ctx context.Context, inputGetter func() Azur
 		err = page.NextWithContext(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}
+	p, err := vmssClient.List(ctx, rgName)
+	Expect(err).NotTo(HaveOccurred())
+	for p.NotDone() {
+		for _, vmss := range p.Values() {
+			itr, err := vmssVMsClient.ListComplete(ctx, rgName, *vmss.Name, "", "", "")
+			var instances []compute.VirtualMachineScaleSetVM
+			for ; itr.NotDone(); err = itr.NextWithContext(ctx) {
+				Expect(err).NotTo(HaveOccurred())
+				vm := itr.Value()
+				sku := vm.HardwareProfile.VMSize
+				for _, nic := range *vm.NetworkProfile.NetworkInterfaces {
+					if nic.Primary != nil && *nic.Primary {
+						capable, found, nicInfo, err := validateAcceleratedNetworkingCapabilityMatch(ctx, nicsClient, rgName, *nic.ID, sku)
+						Expect(err).NotTo(HaveOccurred())
+						if !found {
+							fmt.Fprintf(GinkgoWriter, "SKU %s was not found, please add to the acceleratedNetworking lookup table.\n", sku)
+						} else {
+							Expect(capable).To(Equal(*nicInfo.EnableAcceleratedNetworking))
+						}
+					}
+				}
+				instances = append(instances, vm)
+			}
+		}
+	}
+}
+
+// validateAcceleratedNetworkingCapabilityMatch is a simple, common func to ensure that a NIC resource has the accelerated networking capability that we expect
+// because the NIC client is a common reference for both VM and VMSS resources, we can re-use this business logic in both above flows
+func validateAcceleratedNetworkingCapabilityMatch(ctx context.Context, nicsClient network.InterfacesClient, rgName, nicID string, sku compute.VirtualMachineSizeTypes) (bool, bool, network.Interface, error) {
+	nicInfo, err := nicsClient.Get(ctx, rgName, filepath.Base(nicID), "")
+	if err != nil {
+		return false, false, network.Interface{}, err
+	}
+	capable, found := KnownAcceleratedNetworkingSupportedVMSKUs[sku]
+	return capable, found, nicInfo, nil
 }

--- a/test/e2e/azure_accelnet.go
+++ b/test/e2e/azure_accelnet.go
@@ -99,6 +99,7 @@ func AzureAcceleratedNetworkingSpec(ctx context.Context, inputGetter func() Azur
 		err = page.NextWithContext(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}
+	By("verifying EnableAcceleratedNetworking for the primary NIC of each VMSS instance")
 	p, err := vmssClient.List(ctx, rgName)
 	Expect(err).NotTo(HaveOccurred())
 	for p.NotDone() {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

This PR adds VMSS accelerated networking E2E coverage, mimic'ing the VM coverage. This is hacky, but I'm just following the existing pattern (apologies for any offense if I'm saying the existing implementation is hacky!)

Because this adds coverage where there is none, perhaps a functional, if hacky, solution is fine for now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1015

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ x ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
