### PR TITLE
set BUILD_PROVENANCE when running conformance tests on ci

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -87,6 +87,11 @@ export AZURE_SSH_PUBLIC_KEY_B64=$(cat "${AZURE_SSH_PUBLIC_KEY_FILE}" | base64 | 
 # timestamp is in RFC-3339 format to match kubetest
 export TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 export JOB_NAME="${JOB_NAME:-"cluster-api-provider-azure-e2e"}"
+if [ -n "${REPO_OWNER}" ] && [ -n "${REPO_NAME}" ] && [ -n "${PULL_BASE_SHA}" ]; then
+    export BUILD_PROVENANCE="${REPO_OWNER}/${REPO_NAME}:${PULL_BASE_SHA}"
+else
+    export BUILD_PROVENANCE="canary"
+fi
 
 cleanup() {
     ${REPO_ROOT}/hack/log/redact.sh || true


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
- Setting BUILD_PROVENANCE when running conformance tests on ci since the `periodic-cluster-api-provider-azure-conformance-v1alpha4` job was failing with the following error:
```
Unexpected error:
[1]       <*yamlprocessor.errMissingVariables | 0xc0003ade30>: {
[1]           Missing: ["BUILD_PROVENANCE"],
[1]       }
[1]       value for variables [BUILD_PROVENANCE] is not set. Please set the value using os environment variables or the clusterctl config file
[1]   occurred
``` 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
