### PR TITLE
Fix unbound variable issues in test scripts

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -87,8 +87,8 @@ export AZURE_SSH_PUBLIC_KEY_B64=$(cat "${AZURE_SSH_PUBLIC_KEY_FILE}" | base64 | 
 # timestamp is in RFC-3339 format to match kubetest
 export TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 export JOB_NAME="${JOB_NAME:-"cluster-api-provider-azure-e2e"}"
-if [ -n "${REPO_OWNER}" ] && [ -n "${REPO_NAME}" ] && [ -n "${PULL_BASE_SHA}" ]; then
-    export BUILD_PROVENANCE="${REPO_OWNER}/${REPO_NAME}:${PULL_BASE_SHA}"
+if [ -n "${REPO_OWNER:-}" ] && [ -n "${REPO_NAME:-}" ] && [ -n "${PULL_BASE_SHA:-}" ]; then
+    export BUILD_PROVENANCE="${REPO_OWNER:-}/${REPO_NAME:-}:${PULL_BASE_SHA:-}"
 else
     export BUILD_PROVENANCE="canary"
 fi

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -88,8 +88,8 @@ export AZURE_SSH_PUBLIC_KEY_B64=$(cat "${AZURE_SSH_PUBLIC_KEY_FILE}" | base64 | 
 # timestamp is in RFC-3339 format to match kubetest
 export TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 export JOB_NAME="${JOB_NAME:-"cluster-api-provider-azure-e2e"}"
-if [ -n "${REPO_OWNER}" ] && [ -n "${REPO_NAME}" ] && [ -n "${PULL_BASE_SHA}" ]; then
-    export BUILD_PROVENANCE="${REPO_OWNER}/${REPO_NAME}:${PULL_BASE_SHA}"
+if [ -n "${REPO_OWNER:-}" ] && [ -n "${REPO_NAME:-}" ] && [ -n "${PULL_BASE_SHA:-}" ]; then
+    export BUILD_PROVENANCE="${REPO_OWNER:-}/${REPO_NAME:-}:${PULL_BASE_SHA:-}"
 else
     export BUILD_PROVENANCE="canary"
 fi


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capz-periodic-capi-e2e-main has been failing consistently since #1239 merged with error `./scripts/ci-e2e.sh: line 92: REPO_OWNER: unbound variable`. Adds a default empty value to all the added vars to make sure no unbound variable issues occur.

Side note: it looks like periodic jobs in prow do not have `REPO_OWNER` set.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
