### PR TITLE
Set identity settings in cloud config file for worker nodes as well

### DIFF
--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -148,7 +148,7 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl
 		azureMachinePool.Namespace,
 		azureMachinePool.Name,
 		owner,
-		infrav1.VMIdentityNone,
+		azureMachinePool.Spec.Identity,
 		"",
 	)
 

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -197,6 +197,9 @@ func systemAssignedIdentityCloudProviderConfig(d azure.ClusterScoper) (*CloudPro
 	controlPlaneConfig.AadClientID = ""
 	controlPlaneConfig.AadClientSecret = ""
 	controlPlaneConfig.UseManagedIdentityExtension = true
+	workerConfig.AadClientID = ""
+	workerConfig.AadClientSecret = ""
+	workerConfig.UseManagedIdentityExtension = true
 	return controlPlaneConfig, workerConfig
 }
 
@@ -206,6 +209,10 @@ func userAssignedIdentityCloudProviderConfig(d azure.ClusterScoper, identityID s
 	controlPlaneConfig.AadClientSecret = ""
 	controlPlaneConfig.UseManagedIdentityExtension = true
 	controlPlaneConfig.UserAssignedIdentityID = identityID
+	workerConfig.AadClientID = ""
+	workerConfig.AadClientSecret = ""
+	workerConfig.UseManagedIdentityExtension = true
+	workerConfig.UserAssignedIdentityID = identityID
 	return controlPlaneConfig, workerConfig
 }
 
@@ -232,6 +239,8 @@ func newCloudProviderConfig(d azure.ClusterScoper) (controlPlaneConfig *CloudPro
 		},
 		&CloudProviderConfig{
 			Cloud:                        d.CloudEnvironment(),
+			AadClientID:                  d.ClientID(),
+			AadClientSecret:              d.ClientSecret(),
 			TenantID:                     d.TenantID(),
 			SubscriptionID:               d.SubscriptionID(),
 			ResourceGroup:                d.ResourceGroup(),

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -357,6 +357,8 @@ const (
     "cloud": "AzurePublicCloud",
     "tenantId": "fooTenant",
     "subscriptionId": "baz",
+    "aadClientId": "fooClient",
+    "aadClientSecret": "fooSecret",
     "resourceGroup": "bar",
     "securityGroupName": "foo-node-nsg",
     "securityGroupResourceGroup": "bar",
@@ -405,7 +407,7 @@ const (
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
     "maximumLoadBalancerRuleCount": 250,
-    "useManagedIdentityExtension": false,
+    "useManagedIdentityExtension": true,
     "useInstanceMetadata": true
 }`
 
@@ -443,8 +445,9 @@ const (
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
     "maximumLoadBalancerRuleCount": 250,
-    "useManagedIdentityExtension": false,
-    "useInstanceMetadata": true
+    "useManagedIdentityExtension": true,
+    "useInstanceMetadata": true,
+    "userAssignedIdentityId": "foobar"
 }`
 	spCustomVnetControlPlaneCloudConfig = `{
     "cloud": "AzurePublicCloud",
@@ -470,6 +473,8 @@ const (
     "cloud": "AzurePublicCloud",
     "tenantId": "fooTenant",
     "subscriptionId": "baz",
+    "aadClientId": "fooClient",
+    "aadClientSecret": "fooSecret",
     "resourceGroup": "bar",
     "securityGroupName": "foo-node-nsg",
     "securityGroupResourceGroup": "custom-vnet-resource-group",


### PR DESCRIPTION
 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

I tried to enable managed identity (system assigned) for workers.
In my machine template I set the `identity: SystemAssigned` field:

```apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
kind: AzureMachineTemplate
...
spec:
  template:
    spec:
      identity: SystemAssigned
...
```

But the machine deployment's azure.json still has `useManagedIdentityExtension` set to `false`:

```
$ kubectl get secret  m4z6d-md-0-azure-json -o yaml| yq -r '.data["control-plane-azure.json"]' | base64 -d
{
    ...
    "useManagedIdentityExtension": true,
    ...
}

$ kubectl get secret  m4z6d-md-0-azure-json -o yaml| yq -r '.data["worker-node-azure.json"]' | base64 -d
{
    ...
    "useManagedIdentityExtension": false,
    ...
}
```

After discussion with Cecile [on slack](https://kubernetes.slack.com/archives/CEX9HENG7/p1616150706059800), it emerged that this was intended behaviour because managed identity on worker nodes is not used by k8s components.

Nevertheless, there might be cases where applications running as pods in the cluster use the same cloud config file for their purposes. One notable mention to this is `external-dns`.
In that case, it would be helpful to have the right authentication settings in the cloud config file.

This PR makes the controllers respect the `identity` field in `AzureMachineTemplate` and `AzureMachinePool` CRs when generating the azure cloud config file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:



**Special notes for your reviewer**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
The `Identity` field is now considered when generating the azure cloud config file for both control plane and worker nodes.
```
