### PR TITLE
Change CI bucket for conformance tests to the non-bazel build

### DIFF
--- a/templates/test/cluster-template-prow-ci-version.yaml
+++ b/templates/test/cluster-template-prow-ci-version.yaml
@@ -137,9 +137,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
@@ -324,9 +324,9 @@ spec:
                 DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
               done
             else
-              CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+              CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
               if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-                CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+                CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
               fi
               for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
                 echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
@@ -503,9 +503,9 @@ spec:
             DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
           done
         else
-          CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+          CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
           if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
           fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"

--- a/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/cluster-template-prow-machine-pool-ci-version.yaml
@@ -137,9 +137,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
@@ -317,9 +317,9 @@ spec:
             DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
           done
         else
-          CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+          CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
           if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
           fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"

--- a/templates/test/prow-ci-version/patches/ci-artifacts-script.yaml
+++ b/templates/test/prow-ci-version/patches/ci-artifacts-script.yaml
@@ -58,9 +58,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
@@ -150,9 +150,9 @@ spec:
                   DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
                 done
               else
-                CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+                CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
                 if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-                  CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+                  CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
                 fi
                 for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
                   echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
@@ -240,9 +240,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"

--- a/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -58,9 +58,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
@@ -148,9 +148,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION-bazel/bin/linux/amd64"
+            CI_URL="gs://kubernetes-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION-bazel/bin/linux/amd64"
+              CI_URL="gs://kubernetes-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: This PR changes the conformance test CI bucket because bazel build is removed recently kubernetes/kubernetes#99561

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1253 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
