### PR TITLE
Revert "re-enable ILB test for VMSS"

### DIFF
--- a/test/e2e/azure_lb.go
+++ b/test/e2e/azure_lb.go
@@ -47,6 +47,7 @@ type AzureLBSpecInput struct {
 	SkipCleanup           bool
 	IPv6                  bool
 	Windows               bool
+	IsVMSS                bool
 }
 
 // AzureLBSpec implements a test that verifies Azure internal and external load balancers can
@@ -113,7 +114,9 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 
 	// TODO: fix and enable this. Internal LBs + IPv6 is currently in preview.
 	// https://docs.microsoft.com/en-us/azure/virtual-network/ipv6-dual-stack-standard-internal-load-balancer-powershell
-	if !input.IPv6 {
+	//
+	// TODO: fix and enable this for VMSS after NRP / CRP sync bug is resolved
+	if !input.IPv6 && !input.IsVMSS {
 		By("creating an internal Load Balancer service")
 
 		ilbService := webDeployment.GetService(ports, deploymentBuilder.InternalLoadbalancer)
@@ -176,7 +179,10 @@ func AzureLBSpec(ctx context.Context, inputGetter func() AzureLBSpecInput) {
 		Clientset: clientset,
 	}
 	WaitForJobComplete(ctx, elbJobInput, e2eConfig.GetIntervals(specName, "wait-job")...)
-	
+
+	// TODO: determine root issue of failures of addressing the ELB from prow and fix
+	// see https://kubernetes.slack.com/archives/CEX9HENG7/p1610547551019900
+
 	if !input.IPv6 {
 		By("connecting directly to the external LB service")
 		url := fmt.Sprintf("http://%s", elbIP)

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -301,6 +301,7 @@ var _ = Describe("Workload cluster creation", func() {
 						Namespace:             namespace,
 						ClusterName:           clusterName,
 						SkipCleanup:           skipCleanup,
+						IsVMSS:                true,
 					}
 				})
 			})
@@ -533,6 +534,7 @@ var _ = Describe("Workload cluster creation", func() {
 						Namespace:             namespace,
 						ClusterName:           clusterName,
 						SkipCleanup:           skipCleanup,
+						IsVMSS:                true,
 					}
 				})
 			})
@@ -545,6 +547,7 @@ var _ = Describe("Workload cluster creation", func() {
 						ClusterName:           clusterName,
 						SkipCleanup:           skipCleanup,
 						Windows:               true,
+						IsVMSS:                true,
 					}
 				})
 			})


### PR DESCRIPTION
Reverts kubernetes-sigs/cluster-api-provider-azure#1177



 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind other

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
- Revert "re-enable ILB test for VMSS" since the windows-e2e job is failing consistently since its merged

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
