### PR TITLE
Increase E2E wait-service timeout

### DIFF
--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -112,5 +112,5 @@ intervals:
   default/wait-machine-remediation: ["30m", "10s"]
   default/wait-deployment: ["5m", "10s"]
   default/wait-job: ["5m", "10s"]
-  default/wait-service: ["3m", "10s"]
+  default/wait-service: ["5m", "10s"]
   default/wait-machine-pool-nodes: ["20m", "10s"]

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -129,6 +129,7 @@ type WaitForJobCompleteInput struct {
 func WaitForJobComplete(ctx context.Context, input WaitForJobCompleteInput, intervals ...interface{}) {
 	namespace, name := input.Job.GetNamespace(), input.Job.GetName()
 	Byf("waiting for job %s/%s to be complete", namespace, name)
+	Logf("waiting for job %s/%s to be complete", namespace, name)
 	Eventually(func() bool {
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		if err := input.Getter.Get(ctx, key, input.Job); err == nil {
@@ -140,6 +141,7 @@ func WaitForJobComplete(ctx context.Context, input WaitForJobCompleteInput, inte
 		}
 		return false
 	}, intervals...).Should(BeTrue(), func() string { return DescribeFailedJob(ctx, input) })
+	Logf("job %s/%s is complete", namespace, name)
 }
 
 // DescribeFailedJob returns a string with information to help debug a failed job.
@@ -178,6 +180,7 @@ type WaitForServiceAvailableInput struct {
 func WaitForServiceAvailable(ctx context.Context, input WaitForServiceAvailableInput, intervals ...interface{}) {
 	namespace, name := input.Service.GetNamespace(), input.Service.GetName()
 	Byf("waiting for service %s/%s to be available", namespace, name)
+	Logf("waiting for service %s/%s to be available", namespace, name)
 	Eventually(func() bool {
 		key := client.ObjectKey{Namespace: namespace, Name: name}
 		if err := input.Getter.Get(ctx, key, input.Service); err == nil {
@@ -193,6 +196,7 @@ func WaitForServiceAvailable(ctx context.Context, input WaitForServiceAvailableI
 		}
 		return false
 	}, intervals...).Should(BeTrue(), func() string { return DescribeFailedService(ctx, input) })
+	Logf("service %s/%s is available", namespace, name)
 }
 
 // DescribeFailedService returns a string with information to help debug a failed service.

--- a/test/e2e/log.go
+++ b/test/e2e/log.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+)
+
+// This code was inspired from kubernetes/kubernetes, specifically https://github.com/oomichi/kubernetes/blob/master/test/e2e/framework/log.go
+
+func nowStamp() string {
+	return time.Now().Format(time.StampMilli)
+}
+
+func log(level string, format string, args ...interface{}) {
+	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
+}
+
+// Logf prints info logs with a timestamp and formatting.
+func Logf(format string, args ...interface{}) {
+	log("INFO", format, args...)
+}
+
+// Log prints info logs with a timestamp.
+func Log(message string) {
+	log("INFO", message)
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind failing-test

**What this PR does / why we need it**: increase the timeout for wait-for-service to mitigate recent windows + vmss ELB e2e failures. Also add a bunch of logs with timestamps to facilitate debugging e2e LB failures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1221  

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
