### PR TITLE
ci: add `$(KUBECTL)` as a dependency of `make kind-create`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ generate-go: $(CONTROLLER_GEN) $(MOCKGEN) $(CONVERSION_GEN) ## Runs Go related g
 	$(CONVERSION_GEN) \
 		--input-dirs=./$(EXP_DIR)/api/v1alpha3 \
 		--output-file-base=zz_generated.conversion \
-		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt $(OUTPUT_BASE)	
+		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt $(OUTPUT_BASE)
 	go generate ./...
 
 .PHONY: generate-manifests
@@ -467,7 +467,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST)
 	kubectl create configmap flannel-windows-addon --from-file=templates/addons/windows/
 	kubectl apply -f templates/addons/calico-resource-set.yaml
 	kubectl apply -f templates/addons/flannel-resource-set.yaml
-	
+
 	# Wait for CAPZ deployments
 	kubectl wait --for=condition=Available --timeout=5m -n capz-system deployment -l cluster.x-k8s.io/provider=infrastructure-azure
 
@@ -531,7 +531,7 @@ delete-workload-cluster: ## Deletes the example workload Kubernetes cluster
 ## --------------------------------------
 
 .PHONY: kind-create
-kind-create: ## create capz kind cluster if needed
+kind-create: $(KUBECTL) ## create capz kind cluster if needed
 	./scripts/kind-with-registry.sh
 
 .PHONY: tilt-up


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

/kind failing-test

Fixes test failure in https://testgrid.k8s.io/provider-azure-master-signal#capz-azure-disk-machinepool

```log
./scripts/kind-with-registry.sh: line 80: ./scripts/../hack/tools/bin/kubectl: No such file or directory
make[2]: *** [Makefile:535: kind-create] Error 127
make[2]: Leaving directory '/home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure'
make[1]: *** [Makefile:443: create-management-cluster] Error 2
make[1]: Leaving directory '/home/prow/go/src/sigs.k8s.io/cluster-api-provider-azure'
make: *** [Makefile:518: create-cluster] Error 2
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
