### PR TITLE
[backport] Set identity settings in cloud config file for worker nodes as well

### DIFF
--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -148,7 +148,7 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.Res
 		azureMachinePool.Namespace,
 		azureMachinePool.Name,
 		owner,
-		infrav1.VMIdentityNone,
+		azureMachinePool.Spec.Identity,
 		"",
 	)
 

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -198,6 +198,9 @@ func systemAssignedIdentityCloudProviderConfig(d azure.ClusterScoper) (*CloudPro
 	controlPlaneConfig.AadClientID = ""
 	controlPlaneConfig.AadClientSecret = ""
 	controlPlaneConfig.UseManagedIdentityExtension = true
+	workerConfig.AadClientID = ""
+	workerConfig.AadClientSecret = ""
+	workerConfig.UseManagedIdentityExtension = true
 	return controlPlaneConfig, workerConfig
 }
 
@@ -207,6 +210,10 @@ func userAssignedIdentityCloudProviderConfig(d azure.ClusterScoper, identityID s
 	controlPlaneConfig.AadClientSecret = ""
 	controlPlaneConfig.UseManagedIdentityExtension = true
 	controlPlaneConfig.UserAssignedIdentityID = identityID
+	workerConfig.AadClientID = ""
+	workerConfig.AadClientSecret = ""
+	workerConfig.UseManagedIdentityExtension = true
+	workerConfig.UserAssignedIdentityID = identityID
 	return controlPlaneConfig, workerConfig
 }
 
@@ -233,6 +240,8 @@ func newCloudProviderConfig(d azure.ClusterScoper) (controlPlaneConfig *CloudPro
 		},
 		&CloudProviderConfig{
 			Cloud:                        d.CloudEnvironment(),
+			AadClientID:                  d.ClientID(),
+			AadClientSecret:              d.ClientSecret(),
 			TenantID:                     d.TenantID(),
 			SubscriptionID:               d.SubscriptionID(),
 			ResourceGroup:                d.ResourceGroup(),

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -353,6 +353,8 @@ const (
     "cloud": "AzurePublicCloud",
     "tenantId": "fooTenant",
     "subscriptionId": "baz",
+    "aadClientId": "fooClient",
+    "aadClientSecret": "fooSecret",
     "resourceGroup": "bar",
     "securityGroupName": "foo-node-nsg",
     "securityGroupResourceGroup": "bar",
@@ -401,7 +403,7 @@ const (
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
     "maximumLoadBalancerRuleCount": 250,
-    "useManagedIdentityExtension": false,
+    "useManagedIdentityExtension": true,
     "useInstanceMetadata": true
 }`
 
@@ -439,8 +441,9 @@ const (
     "routeTableName": "foo-node-routetable",
     "loadBalancerSku": "Standard",
     "maximumLoadBalancerRuleCount": 250,
-    "useManagedIdentityExtension": false,
-    "useInstanceMetadata": true
+    "useManagedIdentityExtension": true,
+    "useInstanceMetadata": true,
+    "userAssignedIdentityId": "foobar"
 }`
 	spCustomVnetControlPlaneCloudConfig = `{
     "cloud": "AzurePublicCloud",
@@ -466,6 +469,8 @@ const (
     "cloud": "AzurePublicCloud",
     "tenantId": "fooTenant",
     "subscriptionId": "baz",
+    "aadClientId": "fooClient",
+    "aadClientSecret": "fooSecret",
     "resourceGroup": "bar",
     "securityGroupName": "foo-node-nsg",
     "securityGroupResourceGroup": "custom-vnet-resource-group",


### PR DESCRIPTION
This is a backport of [this PR](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1251) to release-0.4

/kind bug

**What this PR does / why we need it**:

Please check original PR https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1251

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
The `Identity` field is now considered when generating the azure cloud config file for both control plane and worker nodes.
```
