### PR TITLE
⚠️  Change Subnets type to map[string]SubnetSpec

### DIFF
--- a/api/v1alpha3/azurecluster_conversion.go
+++ b/api/v1alpha3/azurecluster_conversion.go
@@ -122,11 +122,12 @@ func Convert_v1alpha3_NetworkSpec_To_v1alpha4_NetworkSpec(in *NetworkSpec, out *
 	}
 
 	out.Subnets = make(infrav1alpha4.Subnets, len(in.Subnets))
-	for i := range in.Subnets {
-		out.Subnets[i] = infrav1alpha4.SubnetSpec{}
-		if err := Convert_v1alpha3_SubnetSpec_To_v1alpha4_SubnetSpec(&in.Subnets[i], &out.Subnets[i], s); err != nil {
+	for i, sn := range in.Subnets {
+		dst := infrav1alpha4.SubnetSpec{}
+		if err := Convert_v1alpha3_SubnetSpec_To_v1alpha4_SubnetSpec(&in.Subnets[i], &dst, s); err != nil {
 			return err
 		}
+		out.Subnets[sn.Name] = dst
 	}
 
 	if err := autoConvert_v1alpha3_LoadBalancerSpec_To_v1alpha4_LoadBalancerSpec(&in.APIServerLB, &out.APIServerLB, s); err != nil {
@@ -142,11 +143,15 @@ func Convert_v1alpha4_NetworkSpec_To_v1alpha3_NetworkSpec(in *infrav1alpha4.Netw
 	}
 
 	out.Subnets = make(Subnets, len(in.Subnets))
-	for i := range in.Subnets {
+	i := 0
+	for k := range in.Subnets {
 		out.Subnets[i] = SubnetSpec{}
-		if err := Convert_v1alpha4_SubnetSpec_To_v1alpha3_SubnetSpec(&in.Subnets[i], &out.Subnets[i], s); err != nil {
+		src := in.Subnets[k]
+		if err := Convert_v1alpha4_SubnetSpec_To_v1alpha3_SubnetSpec(&src, &out.Subnets[i], s); err != nil {
 			return err
 		}
+		out.Subnets[i].Name = k
+		i++
 	}
 
 	if err := autoConvert_v1alpha4_LoadBalancerSpec_To_v1alpha3_LoadBalancerSpec(&in.APIServerLB, &out.APIServerLB, s); err != nil {

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -1291,17 +1291,7 @@ func autoConvert_v1alpha3_NetworkSpec_To_v1alpha4_NetworkSpec(in *NetworkSpec, o
 	if err := Convert_v1alpha3_VnetSpec_To_v1alpha4_VnetSpec(&in.Vnet, &out.Vnet, s); err != nil {
 		return err
 	}
-	if in.Subnets != nil {
-		in, out := &in.Subnets, &out.Subnets
-		*out = make(v1alpha4.Subnets, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha3_SubnetSpec_To_v1alpha4_SubnetSpec(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Subnets = nil
-	}
+	// WARNING: in.Subnets requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3.Subnets vs sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4.Subnets)
 	if err := Convert_v1alpha3_LoadBalancerSpec_To_v1alpha4_LoadBalancerSpec(&in.APIServerLB, &out.APIServerLB, s); err != nil {
 		return err
 	}
@@ -1312,17 +1302,7 @@ func autoConvert_v1alpha4_NetworkSpec_To_v1alpha3_NetworkSpec(in *v1alpha4.Netwo
 	if err := Convert_v1alpha4_VnetSpec_To_v1alpha3_VnetSpec(&in.Vnet, &out.Vnet, s); err != nil {
 		return err
 	}
-	if in.Subnets != nil {
-		in, out := &in.Subnets, &out.Subnets
-		*out = make(Subnets, len(*in))
-		for i := range *in {
-			if err := Convert_v1alpha4_SubnetSpec_To_v1alpha3_SubnetSpec(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Subnets = nil
-	}
+	// WARNING: in.Subnets requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4.Subnets vs sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3.Subnets)
 	if err := Convert_v1alpha4_LoadBalancerSpec_To_v1alpha3_LoadBalancerSpec(&in.APIServerLB, &out.APIServerLB, s); err != nil {
 		return err
 	}
@@ -1484,7 +1464,7 @@ func Convert_v1alpha4_SpotVMOptions_To_v1alpha3_SpotVMOptions(in *v1alpha4.SpotV
 func autoConvert_v1alpha3_SubnetSpec_To_v1alpha4_SubnetSpec(in *SubnetSpec, out *v1alpha4.SubnetSpec, s conversion.Scope) error {
 	out.Role = v1alpha4.SubnetRole(in.Role)
 	out.ID = in.ID
-	out.Name = in.Name
+	// WARNING: in.Name requires manual conversion: does not exist in peer-type
 	// WARNING: in.CidrBlock requires manual conversion: does not exist in peer-type
 	out.CIDRBlocks = *(*[]string)(unsafe.Pointer(&in.CIDRBlocks))
 	// WARNING: in.InternalLBIPAddress requires manual conversion: does not exist in peer-type
@@ -1500,7 +1480,6 @@ func autoConvert_v1alpha3_SubnetSpec_To_v1alpha4_SubnetSpec(in *SubnetSpec, out 
 func autoConvert_v1alpha4_SubnetSpec_To_v1alpha3_SubnetSpec(in *v1alpha4.SubnetSpec, out *SubnetSpec, s conversion.Scope) error {
 	out.Role = SubnetRole(in.Role)
 	out.ID = in.ID
-	out.Name = in.Name
 	out.CIDRBlocks = *(*[]string)(unsafe.Pointer(&in.CIDRBlocks))
 	if err := Convert_v1alpha4_SecurityGroup_To_v1alpha3_SecurityGroup(&in.SecurityGroup, &out.SecurityGroup, s); err != nil {
 		return err

--- a/api/v1alpha4/azurecluster_default_test.go
+++ b/api/v1alpha4/azurecluster_default_test.go
@@ -101,15 +101,13 @@ func TestVnetDefaults(t *testing.T) {
 							CIDRBlocks:    []string{DefaultVnetCIDR},
 						},
 						Subnets: Subnets{
-							{
+							"control-plane-subnet": {
 								Role:          SubnetControlPlane,
-								Name:          "control-plane-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
-							{
+							"node-subnet": {
 								Role:          SubnetNode,
-								Name:          "node-subnet",
 								SecurityGroup: SecurityGroup{},
 								RouteTable:    RouteTable{},
 							},
@@ -259,16 +257,14 @@ func TestSubnetDefaults(t *testing.T) {
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
-							{
+							"cluster-test-controlplane-subnet": {
 								Role:          SubnetControlPlane,
-								Name:          "cluster-test-controlplane-subnet",
 								CIDRBlocks:    []string{DefaultControlPlaneSubnetCIDR},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
 							},
-							{
+							"cluster-test-node-subnet": {
 								Role:          SubnetNode,
-								Name:          "cluster-test-node-subnet",
 								CIDRBlocks:    []string{DefaultNodeSubnetCIDR},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
@@ -287,14 +283,12 @@ func TestSubnetDefaults(t *testing.T) {
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
-							{
+							"my-controlplane-subnet": {
 								Role:       SubnetControlPlane,
-								Name:       "my-controlplane-subnet",
 								CIDRBlocks: []string{"10.0.0.16/24"},
 							},
-							{
+							"my-node-subnet": {
 								Role:       SubnetNode,
-								Name:       "my-node-subnet",
 								CIDRBlocks: []string{"10.1.0.16/24"},
 							},
 						},
@@ -308,16 +302,14 @@ func TestSubnetDefaults(t *testing.T) {
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
-							{
+							"my-controlplane-subnet": {
 								Role:          SubnetControlPlane,
-								Name:          "my-controlplane-subnet",
 								CIDRBlocks:    []string{"10.0.0.16/24"},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
 							},
-							{
+							"my-node-subnet": {
 								Role:          SubnetNode,
-								Name:          "my-node-subnet",
 								CIDRBlocks:    []string{"10.1.0.16/24"},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
@@ -336,13 +328,11 @@ func TestSubnetDefaults(t *testing.T) {
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
-							{
+							"cluster-test-controlplane-subnet": {
 								Role: SubnetControlPlane,
-								Name: "cluster-test-controlplane-subnet",
 							},
-							{
+							"cluster-test-node-subnet": {
 								Role: SubnetNode,
-								Name: "cluster-test-node-subnet",
 							},
 						},
 					},
@@ -355,16 +345,14 @@ func TestSubnetDefaults(t *testing.T) {
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
-							{
+							"cluster-test-controlplane-subnet": {
 								Role:          SubnetControlPlane,
-								Name:          "cluster-test-controlplane-subnet",
 								CIDRBlocks:    []string{DefaultControlPlaneSubnetCIDR},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
 							},
-							{
+							"cluster-test-node-subnet": {
 								Role:          SubnetNode,
-								Name:          "cluster-test-node-subnet",
 								CIDRBlocks:    []string{DefaultNodeSubnetCIDR},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
@@ -383,16 +371,14 @@ func TestSubnetDefaults(t *testing.T) {
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
-							{
+							"cluster-test-controlplane-subnet": {
 								Role: SubnetControlPlane,
-								Name: "cluster-test-controlplane-subnet",
 								RouteTable: RouteTable{
 									Name: "control-plane-custom-route-table",
 								},
 							},
-							{
+							"cluster-test-node-subnet": {
 								Role: SubnetNode,
-								Name: "cluster-test-node-subnet",
 							},
 						},
 					},
@@ -405,16 +391,14 @@ func TestSubnetDefaults(t *testing.T) {
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
-							{
+							"cluster-test-controlplane-subnet": {
 								Role:          SubnetControlPlane,
-								Name:          "cluster-test-controlplane-subnet",
 								CIDRBlocks:    []string{DefaultControlPlaneSubnetCIDR},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{Name: "control-plane-custom-route-table"},
 							},
-							{
+							"cluster-test-node-subnet": {
 								Role:          SubnetNode,
-								Name:          "cluster-test-node-subnet",
 								CIDRBlocks:    []string{DefaultNodeSubnetCIDR},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
@@ -433,9 +417,8 @@ func TestSubnetDefaults(t *testing.T) {
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
-							{
+							"my-node-subnet": {
 								Role: SubnetNode,
-								Name: "my-node-subnet",
 							},
 						},
 					},
@@ -448,16 +431,14 @@ func TestSubnetDefaults(t *testing.T) {
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
-							{
+							"my-node-subnet": {
 								Role:          SubnetNode,
-								Name:          "my-node-subnet",
 								CIDRBlocks:    []string{DefaultNodeSubnetCIDR},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
 							},
-							{
+							"cluster-test-controlplane-subnet": {
 								Role:          SubnetControlPlane,
-								Name:          "cluster-test-controlplane-subnet",
 								CIDRBlocks:    []string{DefaultControlPlaneSubnetCIDR},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
@@ -479,13 +460,11 @@ func TestSubnetDefaults(t *testing.T) {
 							CIDRBlocks: []string{"2001:be00::1/56"},
 						},
 						Subnets: Subnets{
-							{
-								Name:       "cluster-test-controlplane-subnet",
+							"cluster-test-controlplane-subnet": {
 								Role:       "control-plane",
 								CIDRBlocks: []string{"2001:beef::1/64"},
 							},
-							{
-								Name:       "cluster-test-node-subnet",
+							"cluster-test-node-subnet": {
 								Role:       "node",
 								CIDRBlocks: []string{"2001:beea::1/64"},
 							},
@@ -503,16 +482,14 @@ func TestSubnetDefaults(t *testing.T) {
 							CIDRBlocks: []string{"2001:be00::1/56"},
 						},
 						Subnets: Subnets{
-							{
+							"cluster-test-controlplane-subnet": {
 								Role:          SubnetControlPlane,
-								Name:          "cluster-test-controlplane-subnet",
 								CIDRBlocks:    []string{"2001:beef::1/64"},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
 								RouteTable:    RouteTable{},
 							},
-							{
+							"cluster-test-node-subnet": {
 								Role:          SubnetNode,
-								Name:          "cluster-test-node-subnet",
 								CIDRBlocks:    []string{"2001:beea::1/64"},
 								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
 								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},

--- a/api/v1alpha4/azurecluster_webhook_test.go
+++ b/api/v1alpha4/azurecluster_webhook_test.go
@@ -50,7 +50,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 			name: "azurecluster with pre-existing vnet - lack control plane subnet",
 			cluster: func() *AzureCluster {
 				cluster := createValidCluster()
-				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[1:]
+				delete(cluster.Spec.NetworkSpec.Subnets, "control-plane-subnet")
 				return cluster
 			}(),
 			wantErr: true,
@@ -59,7 +59,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 			name: "azurecluster with pre-existing vnet - lack node subnet",
 			cluster: func() *AzureCluster {
 				cluster := createValidCluster()
-				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[:1]
+				delete(cluster.Spec.NetworkSpec.Subnets, "node-subnet")
 				return cluster
 			}(),
 			wantErr: true,
@@ -77,8 +77,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 			name: "azurecluster with pre-existing vnet - invalid subnet name",
 			cluster: func() *AzureCluster {
 				cluster := createValidCluster()
-				cluster.Spec.NetworkSpec.Subnets = append(cluster.Spec.NetworkSpec.Subnets,
-					SubnetSpec{Name: "invalid-subnet-name###", Role: "random-role"})
+				cluster.Spec.NetworkSpec.Subnets["invalid-subnet-name###"] = SubnetSpec{Role: "random-role"}
 				return cluster
 			}(),
 			wantErr: true,
@@ -125,7 +124,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 			name: "azurecluster with pre-existing vnet - lack control plane subnet",
 			cluster: func() *AzureCluster {
 				cluster := createValidCluster()
-				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[1:]
+				delete(cluster.Spec.NetworkSpec.Subnets, "control-plane-subnet")
 				return cluster
 			}(),
 			wantErr: true,
@@ -134,7 +133,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 			name: "azurecluster with pre-existing vnet - lack node subnet",
 			cluster: func() *AzureCluster {
 				cluster := createValidCluster()
-				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[:1]
+				delete(cluster.Spec.NetworkSpec.Subnets, "node-subnet")
 				return cluster
 			}(),
 			wantErr: true,
@@ -152,8 +151,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 			name: "azurecluster with pre-existing vnet - invalid subnet name",
 			cluster: func() *AzureCluster {
 				cluster := createValidCluster()
-				cluster.Spec.NetworkSpec.Subnets = append(cluster.Spec.NetworkSpec.Subnets,
-					SubnetSpec{Name: "invalid-name###", Role: "random-role"})
+				cluster.Spec.NetworkSpec.Subnets["invalid-subnet-name###"] = SubnetSpec{Role: "random-role"}
 				return cluster
 			}(),
 			wantErr: true,

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -86,8 +86,8 @@ func (v *VnetSpec) IsManaged(clusterName string) bool {
 	return v.ID == "" || v.Tags.HasOwned(clusterName)
 }
 
-// Subnets is a slice of Subnet.
-type Subnets []SubnetSpec
+// Subnets is a map of subnets, where the key is the name of the subnet.
+type Subnets map[string]SubnetSpec
 
 // SecurityGroupRole defines the unique role of a security group.
 type SecurityGroupRole string
@@ -415,9 +415,6 @@ type SubnetSpec struct {
 	// +optional
 	ID string `json:"id,omitempty"`
 
-	// Name defines a name for the subnet resource.
-	Name string `json:"name"`
-
 	// CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.
 	// +optional
 	CIDRBlocks []string `json:"cidrBlocks,omitempty"`
@@ -432,41 +429,23 @@ type SubnetSpec struct {
 }
 
 // GetControlPlaneSubnet returns the cluster control plane subnet.
-func (n *NetworkSpec) GetControlPlaneSubnet() (SubnetSpec, error) {
-	for _, sn := range n.Subnets {
+func (n *NetworkSpec) GetControlPlaneSubnet() (string, SubnetSpec, error) {
+	for name, sn := range n.Subnets {
 		if sn.Role == SubnetControlPlane {
-			return sn, nil
+			return name, sn, nil
 		}
 	}
-	return SubnetSpec{}, errors.Errorf("no subnet found with role %s", SubnetControlPlane)
-}
-
-// UpdateControlPlaneSubnet updates the cluster control plane subnet.
-func (n *NetworkSpec) UpdateControlPlaneSubnet(subnet SubnetSpec) {
-	for i, sn := range n.Subnets {
-		if sn.Role == SubnetControlPlane {
-			n.Subnets[i] = subnet
-		}
-	}
+	return "", SubnetSpec{}, errors.Errorf("no subnet found with role %s", SubnetControlPlane)
 }
 
 // GetNodeSubnet returns the cluster node subnet.
-func (n *NetworkSpec) GetNodeSubnet() (SubnetSpec, error) {
-	for _, sn := range n.Subnets {
+func (n *NetworkSpec) GetNodeSubnet() (string, SubnetSpec, error) {
+	for name, sn := range n.Subnets {
 		if sn.Role == SubnetNode {
-			return sn, nil
+			return name, sn, nil
 		}
 	}
-	return SubnetSpec{}, errors.Errorf("no subnet found with role %s", SubnetNode)
-}
-
-// UpdateNodeSubnet updates the cluster node subnet.
-func (n *NetworkSpec) UpdateNodeSubnet(subnet SubnetSpec) {
-	for i, sn := range n.Subnets {
-		if sn.Role == SubnetNode {
-			n.Subnets[i] = subnet
-		}
-	}
+	return "", SubnetSpec{}, errors.Errorf("no subnet found with role %s", SubnetNode)
 }
 
 // SecurityProfile specifies the Security profile settings for a

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -804,8 +804,8 @@ func (in *NetworkSpec) DeepCopyInto(out *NetworkSpec) {
 	if in.Subnets != nil {
 		in, out := &in.Subnets, &out.Subnets
 		*out = make(Subnets, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 	in.APIServerLB.DeepCopyInto(&out.APIServerLB)
@@ -968,8 +968,8 @@ func (in Subnets) DeepCopyInto(out *Subnets) {
 	{
 		in := &in
 		*out = make(Subnets, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 }

--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -62,8 +62,10 @@ type Authorizer interface {
 type NetworkDescriber interface {
 	Vnet() *infrav1.VnetSpec
 	IsVnetManaged() bool
-	NodeSubnet() infrav1.SubnetSpec
-	ControlPlaneSubnet() infrav1.SubnetSpec
+	NodeSubnet() (string, infrav1.SubnetSpec)
+	ControlPlaneSubnet() (string, infrav1.SubnetSpec)
+	Subnet(string) infrav1.SubnetSpec
+	SetSubnet(string, infrav1.SubnetSpec)
 	IsIPv6Enabled() bool
 	NodeRouteTable() infrav1.RouteTable
 	ControlPlaneRouteTable() infrav1.RouteTable

--- a/azure/mocks/service_mock.go
+++ b/azure/mocks/service_mock.go
@@ -398,11 +398,12 @@ func (mr *MockNetworkDescriberMockRecorder) ControlPlaneRouteTable() *gomock.Cal
 }
 
 // ControlPlaneSubnet mocks base method.
-func (m *MockNetworkDescriber) ControlPlaneSubnet() v1alpha4.SubnetSpec {
+func (m *MockNetworkDescriber) ControlPlaneSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControlPlaneSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // ControlPlaneSubnet indicates an expected call of ControlPlaneSubnet.
@@ -468,11 +469,12 @@ func (mr *MockNetworkDescriberMockRecorder) NodeRouteTable() *gomock.Call {
 }
 
 // NodeSubnet mocks base method.
-func (m *MockNetworkDescriber) NodeSubnet() v1alpha4.SubnetSpec {
+func (m *MockNetworkDescriber) NodeSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NodeSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // NodeSubnet indicates an expected call of NodeSubnet.
@@ -507,6 +509,32 @@ func (m *MockNetworkDescriber) OutboundPoolName(arg0 string) string {
 func (mr *MockNetworkDescriberMockRecorder) OutboundPoolName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OutboundPoolName", reflect.TypeOf((*MockNetworkDescriber)(nil).OutboundPoolName), arg0)
+}
+
+// SetSubnet mocks base method.
+func (m *MockNetworkDescriber) SetSubnet(arg0 string, arg1 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0, arg1)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockNetworkDescriberMockRecorder) SetSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockNetworkDescriber)(nil).SetSubnet), arg0, arg1)
+}
+
+// Subnet mocks base method.
+func (m *MockNetworkDescriber) Subnet(arg0 string) v1alpha4.SubnetSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subnet", arg0)
+	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
+	return ret0
+}
+
+// Subnet indicates an expected call of Subnet.
+func (mr *MockNetworkDescriberMockRecorder) Subnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockNetworkDescriber)(nil).Subnet), arg0)
 }
 
 // Vnet mocks base method.
@@ -906,11 +934,12 @@ func (mr *MockClusterScoperMockRecorder) ControlPlaneRouteTable() *gomock.Call {
 }
 
 // ControlPlaneSubnet mocks base method.
-func (m *MockClusterScoper) ControlPlaneSubnet() v1alpha4.SubnetSpec {
+func (m *MockClusterScoper) ControlPlaneSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControlPlaneSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // ControlPlaneSubnet indicates an expected call of ControlPlaneSubnet.
@@ -1004,11 +1033,12 @@ func (mr *MockClusterScoperMockRecorder) NodeRouteTable() *gomock.Call {
 }
 
 // NodeSubnet mocks base method.
-func (m *MockClusterScoper) NodeSubnet() v1alpha4.SubnetSpec {
+func (m *MockClusterScoper) NodeSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NodeSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // NodeSubnet indicates an expected call of NodeSubnet.
@@ -1057,6 +1087,32 @@ func (m *MockClusterScoper) ResourceGroup() string {
 func (mr *MockClusterScoperMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockClusterScoper)(nil).ResourceGroup))
+}
+
+// SetSubnet mocks base method.
+func (m *MockClusterScoper) SetSubnet(arg0 string, arg1 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0, arg1)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockClusterScoperMockRecorder) SetSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockClusterScoper)(nil).SetSubnet), arg0, arg1)
+}
+
+// Subnet mocks base method.
+func (m *MockClusterScoper) Subnet(arg0 string) v1alpha4.SubnetSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subnet", arg0)
+	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
+	return ret0
+}
+
+// Subnet indicates an expected call of Subnet.
+func (mr *MockClusterScoperMockRecorder) Subnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockClusterScoper)(nil).Subnet), arg0)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -60,8 +60,7 @@ func TestGettingIngressRules(t *testing.T) {
 			SubscriptionID: "123",
 			NetworkSpec: infrav1.NetworkSpec{
 				Subnets: infrav1.Subnets{
-					{
-						Name: "node",
+					"node": {
 						Role: infrav1.SubnetNode,
 					},
 				},
@@ -85,7 +84,7 @@ func TestGettingIngressRules(t *testing.T) {
 
 	clusterScope.SetControlPlaneIngressRules()
 
-	subnet, err := clusterScope.AzureCluster.Spec.NetworkSpec.GetControlPlaneSubnet()
+	_, subnet, err := clusterScope.AzureCluster.Spec.NetworkSpec.GetControlPlaneSubnet()
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(subnet.SecurityGroup.IngressRules)).To(Equal(2))
 }

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -151,7 +151,7 @@ func (m *MachineScope) NICSpecs() []azure.NICSpec {
 		MachineName:             m.Name(),
 		VNetName:                m.Vnet().Name,
 		VNetResourceGroup:       m.Vnet().ResourceGroup,
-		SubnetName:              m.Subnet().Name,
+		SubnetName:              m.SubnetName(),
 		VMSize:                  m.AzureMachine.Spec.VMSize,
 		AcceleratedNetworking:   m.AzureMachine.Spec.AcceleratedNetworking,
 		IPv6Enabled:             m.IsIPv6Enabled(),
@@ -175,7 +175,7 @@ func (m *MachineScope) NICSpecs() []azure.NICSpec {
 			MachineName:           m.Name(),
 			VNetName:              m.Vnet().Name,
 			VNetResourceGroup:     m.Vnet().ResourceGroup,
-			SubnetName:            m.Subnet().Name,
+			SubnetName:            m.SubnetName(),
 			PublicIPName:          azure.GenerateNodePublicIPName(m.Name()),
 			VMSize:                m.AzureMachine.Spec.VMSize,
 			AcceleratedNetworking: m.AzureMachine.Spec.AcceleratedNetworking,
@@ -211,7 +211,7 @@ func (m *MachineScope) DiskSpecs() []azure.DiskSpec {
 func (m *MachineScope) BastionSpecs() []azure.BastionSpec {
 	spec := azure.BastionSpec{
 		Name:         azure.GenerateOSDiskName(m.Name()),
-		SubnetName:   m.Subnet().Name,
+		SubnetName:   m.SubnetName(),
 		PublicIPName: azure.GenerateNodePublicIPName(azure.GenerateNICName(m.Name())),
 		VNetName:     m.Vnet().Name,
 	}
@@ -251,12 +251,15 @@ func (m *MachineScope) VMExtensionSpecs() []azure.VMExtensionSpec {
 	return []azure.VMExtensionSpec{}
 }
 
-// Subnet returns the machine's subnet based on its role
-func (m *MachineScope) Subnet() infrav1.SubnetSpec {
+// SubnetName returns the machine's subnet name based on its role.
+func (m *MachineScope) SubnetName() string {
+	var name string
 	if m.IsControlPlane() {
-		return m.ControlPlaneSubnet()
+		name, _ = m.ControlPlaneSubnet()
+	} else {
+		name, _ = m.NodeSubnet()
 	}
-	return m.NodeSubnet()
+	return name
 }
 
 // AvailabilityZone returns the AzureMachine Availability Zone.

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -114,7 +114,7 @@ func (m *MachinePoolScope) ScaleSetSpec() azure.ScaleSetSpec {
 		SSHKeyData:              m.AzureMachinePool.Spec.Template.SSHPublicKey,
 		OSDisk:                  m.AzureMachinePool.Spec.Template.OSDisk,
 		DataDisks:               m.AzureMachinePool.Spec.Template.DataDisks,
-		SubnetName:              m.NodeSubnet().Name,
+		SubnetName:              m.SubnetName(),
 		VNetName:                m.Vnet().Name,
 		VNetResourceGroup:       m.Vnet().ResourceGroup,
 		PublicLBName:            m.OutboundLBName(infrav1.Node),
@@ -135,6 +135,12 @@ func (m *MachinePoolScope) Name() string {
 		return "win-" + m.AzureMachinePool.Name[len(m.AzureMachinePool.Name)-5:]
 	}
 	return m.AzureMachinePool.Name
+}
+
+// SubnetName returns the AzureMachinePool's subnet name based on its role.
+func (m *MachinePoolScope) SubnetName() string {
+	name, _ := m.NodeSubnet()
+	return name
 }
 
 // ProviderID returns the AzureMachinePool ID by parsing Spec.ProviderID.

--- a/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -222,11 +222,12 @@ func (mr *MockBastionScopeMockRecorder) ControlPlaneRouteTable() *gomock.Call {
 }
 
 // ControlPlaneSubnet mocks base method.
-func (m *MockBastionScope) ControlPlaneSubnet() v1alpha4.SubnetSpec {
+func (m *MockBastionScope) ControlPlaneSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControlPlaneSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // ControlPlaneSubnet indicates an expected call of ControlPlaneSubnet.
@@ -368,11 +369,12 @@ func (mr *MockBastionScopeMockRecorder) NodeRouteTable() *gomock.Call {
 }
 
 // NodeSubnet mocks base method.
-func (m *MockBastionScope) NodeSubnet() v1alpha4.SubnetSpec {
+func (m *MockBastionScope) NodeSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NodeSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // NodeSubnet indicates an expected call of NodeSubnet.
@@ -421,6 +423,32 @@ func (m *MockBastionScope) ResourceGroup() string {
 func (mr *MockBastionScopeMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockBastionScope)(nil).ResourceGroup))
+}
+
+// SetSubnet mocks base method.
+func (m *MockBastionScope) SetSubnet(arg0 string, arg1 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0, arg1)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockBastionScopeMockRecorder) SetSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockBastionScope)(nil).SetSubnet), arg0, arg1)
+}
+
+// Subnet mocks base method.
+func (m *MockBastionScope) Subnet(arg0 string) v1alpha4.SubnetSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subnet", arg0)
+	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
+	return ret0
+}
+
+// Subnet indicates an expected call of Subnet.
+func (mr *MockBastionScopeMockRecorder) Subnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockBastionScope)(nil).Subnet), arg0)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -208,11 +208,12 @@ func (mr *MockLBScopeMockRecorder) ControlPlaneRouteTable() *gomock.Call {
 }
 
 // ControlPlaneSubnet mocks base method.
-func (m *MockLBScope) ControlPlaneSubnet() v1alpha4.SubnetSpec {
+func (m *MockLBScope) ControlPlaneSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControlPlaneSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // ControlPlaneSubnet indicates an expected call of ControlPlaneSubnet.
@@ -368,11 +369,12 @@ func (mr *MockLBScopeMockRecorder) NodeRouteTable() *gomock.Call {
 }
 
 // NodeSubnet mocks base method.
-func (m *MockLBScope) NodeSubnet() v1alpha4.SubnetSpec {
+func (m *MockLBScope) NodeSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NodeSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // NodeSubnet indicates an expected call of NodeSubnet.
@@ -421,6 +423,32 @@ func (m *MockLBScope) ResourceGroup() string {
 func (mr *MockLBScopeMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockLBScope)(nil).ResourceGroup))
+}
+
+// SetSubnet mocks base method.
+func (m *MockLBScope) SetSubnet(arg0 string, arg1 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0, arg1)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockLBScopeMockRecorder) SetSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockLBScope)(nil).SetSubnet), arg0, arg1)
+}
+
+// Subnet mocks base method.
+func (m *MockLBScope) Subnet(arg0 string) v1alpha4.SubnetSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subnet", arg0)
+	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
+	return ret0
+}
+
+// Subnet indicates an expected call of Subnet.
+func (mr *MockLBScopeMockRecorder) Subnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockLBScope)(nil).Subnet), arg0)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/services/routetables/mock_routetables/routetables_mock.go
+++ b/azure/services/routetables/mock_routetables/routetables_mock.go
@@ -208,11 +208,12 @@ func (mr *MockRouteTableScopeMockRecorder) ControlPlaneRouteTable() *gomock.Call
 }
 
 // ControlPlaneSubnet mocks base method.
-func (m *MockRouteTableScope) ControlPlaneSubnet() v1alpha4.SubnetSpec {
+func (m *MockRouteTableScope) ControlPlaneSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControlPlaneSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // ControlPlaneSubnet indicates an expected call of ControlPlaneSubnet.
@@ -354,11 +355,12 @@ func (mr *MockRouteTableScopeMockRecorder) NodeRouteTable() *gomock.Call {
 }
 
 // NodeSubnet mocks base method.
-func (m *MockRouteTableScope) NodeSubnet() v1alpha4.SubnetSpec {
+func (m *MockRouteTableScope) NodeSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NodeSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // NodeSubnet indicates an expected call of NodeSubnet.
@@ -421,6 +423,32 @@ func (m *MockRouteTableScope) RouteTableSpecs() []azure.RouteTableSpec {
 func (mr *MockRouteTableScopeMockRecorder) RouteTableSpecs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteTableSpecs", reflect.TypeOf((*MockRouteTableScope)(nil).RouteTableSpecs))
+}
+
+// SetSubnet mocks base method.
+func (m *MockRouteTableScope) SetSubnet(arg0 string, arg1 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0, arg1)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockRouteTableScopeMockRecorder) SetSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockRouteTableScope)(nil).SetSubnet), arg0, arg1)
+}
+
+// Subnet mocks base method.
+func (m *MockRouteTableScope) Subnet(arg0 string) v1alpha4.SubnetSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subnet", arg0)
+	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
+	return ret0
+}
+
+// Subnet indicates an expected call of Subnet.
+func (mr *MockRouteTableScopeMockRecorder) Subnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockRouteTableScope)(nil).Subnet), arg0)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/services/routetables/routetables.go
+++ b/azure/services/routetables/routetables.go
@@ -72,7 +72,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			// currently don't support specifying your own routes via spec
 			routeTableSpec.Subnet.RouteTable.Name = to.String(existingRouteTable.Name)
 			routeTableSpec.Subnet.RouteTable.ID = to.String(existingRouteTable.ID)
-
+			s.Scope.SetSubnet(routeTableSpec.SubnetName, routeTableSpec.Subnet)
 			continue
 		}
 

--- a/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
+++ b/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
@@ -208,11 +208,12 @@ func (mr *MockNSGScopeMockRecorder) ControlPlaneRouteTable() *gomock.Call {
 }
 
 // ControlPlaneSubnet mocks base method.
-func (m *MockNSGScope) ControlPlaneSubnet() v1alpha4.SubnetSpec {
+func (m *MockNSGScope) ControlPlaneSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControlPlaneSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // ControlPlaneSubnet indicates an expected call of ControlPlaneSubnet.
@@ -368,11 +369,12 @@ func (mr *MockNSGScopeMockRecorder) NodeRouteTable() *gomock.Call {
 }
 
 // NodeSubnet mocks base method.
-func (m *MockNSGScope) NodeSubnet() v1alpha4.SubnetSpec {
+func (m *MockNSGScope) NodeSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NodeSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // NodeSubnet indicates an expected call of NodeSubnet.
@@ -421,6 +423,32 @@ func (m *MockNSGScope) ResourceGroup() string {
 func (mr *MockNSGScopeMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockNSGScope)(nil).ResourceGroup))
+}
+
+// SetSubnet mocks base method.
+func (m *MockNSGScope) SetSubnet(arg0 string, arg1 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0, arg1)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockNSGScopeMockRecorder) SetSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockNSGScope)(nil).SetSubnet), arg0, arg1)
+}
+
+// Subnet mocks base method.
+func (m *MockNSGScope) Subnet(arg0 string) v1alpha4.SubnetSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subnet", arg0)
+	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
+	return ret0
+}
+
+// Subnet indicates an expected call of Subnet.
+func (mr *MockNSGScopeMockRecorder) Subnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockNSGScope)(nil).Subnet), arg0)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/services/subnets/mock_subnets/subnets_mock.go
+++ b/azure/services/subnets/mock_subnets/subnets_mock.go
@@ -208,11 +208,12 @@ func (mr *MockSubnetScopeMockRecorder) ControlPlaneRouteTable() *gomock.Call {
 }
 
 // ControlPlaneSubnet mocks base method.
-func (m *MockSubnetScope) ControlPlaneSubnet() v1alpha4.SubnetSpec {
+func (m *MockSubnetScope) ControlPlaneSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControlPlaneSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // ControlPlaneSubnet indicates an expected call of ControlPlaneSubnet.
@@ -354,11 +355,12 @@ func (mr *MockSubnetScopeMockRecorder) NodeRouteTable() *gomock.Call {
 }
 
 // NodeSubnet mocks base method.
-func (m *MockSubnetScope) NodeSubnet() v1alpha4.SubnetSpec {
+func (m *MockSubnetScope) NodeSubnet() (string, v1alpha4.SubnetSpec) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NodeSubnet")
-	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(v1alpha4.SubnetSpec)
+	return ret0, ret1
 }
 
 // NodeSubnet indicates an expected call of NodeSubnet.
@@ -407,6 +409,32 @@ func (m *MockSubnetScope) ResourceGroup() string {
 func (mr *MockSubnetScopeMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockSubnetScope)(nil).ResourceGroup))
+}
+
+// SetSubnet mocks base method.
+func (m *MockSubnetScope) SetSubnet(arg0 string, arg1 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0, arg1)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockSubnetScopeMockRecorder) SetSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockSubnetScope)(nil).SetSubnet), arg0, arg1)
+}
+
+// Subnet mocks base method.
+func (m *MockSubnetScope) Subnet(arg0 string) v1alpha4.SubnetSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subnet", arg0)
+	ret0, _ := ret[0].(v1alpha4.SubnetSpec)
+	return ret0
+}
+
+// Subnet indicates an expected call of Subnet.
+func (mr *MockSubnetScopeMockRecorder) Subnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockSubnetScope)(nil).Subnet), arg0)
 }
 
 // SubnetSpecs mocks base method.

--- a/azure/services/subnets/subnets_test.go
+++ b/azure/services/subnets/subnets_test.go
@@ -209,14 +209,6 @@ func TestReconcileSubnets(t *testing.T) {
 					},
 				})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "my-vnet"})
-				s.NodeSubnet().AnyTimes().Return(infrav1.SubnetSpec{
-					Name: "my-subnet",
-					Role: infrav1.SubnetNode,
-				})
-				s.ControlPlaneSubnet().AnyTimes().Return(infrav1.SubnetSpec{
-					Name: "my-subnet-1",
-					Role: infrav1.SubnetControlPlane,
-				})
 				s.ClusterName().AnyTimes().Return("fake-cluster")
 				s.SubscriptionID().AnyTimes().Return("123")
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -236,6 +228,27 @@ func TestReconcileSubnets(t *testing.T) {
 							},
 						},
 					}, nil)
+				s.Subnet("my-subnet").Return(infrav1.SubnetSpec{
+					CIDRBlocks: []string{"10.0.0.0/16"},
+					RouteTable: infrav1.RouteTable{
+						Name: "my-subnet_route_table",
+					},
+					SecurityGroup: infrav1.SecurityGroup{
+						Name: "my-sg",
+					},
+					Role: infrav1.SubnetNode,
+				})
+				s.SetSubnet("my-subnet", infrav1.SubnetSpec{
+					ID:         "subnet-id",
+					CIDRBlocks: []string{"10.0.0.0/16"},
+					RouteTable: infrav1.RouteTable{
+						Name: "my-subnet_route_table",
+					},
+					SecurityGroup: infrav1.SecurityGroup{
+						Name: "my-sg",
+					},
+					Role: infrav1.SubnetNode,
+				})
 				m.Get(gomockinternal.AContext(), "", "my-vnet", "my-subnet-1").
 					Return(network.Subnet{
 						ID:   to.StringPtr("subnet-id-1"),
@@ -252,6 +265,27 @@ func TestReconcileSubnets(t *testing.T) {
 							},
 						},
 					}, nil)
+				s.Subnet("my-subnet-1").Return(infrav1.SubnetSpec{
+					CIDRBlocks: []string{"10.2.0.0/16"},
+					RouteTable: infrav1.RouteTable{
+						Name: "my-subnet_route_table",
+					},
+					SecurityGroup: infrav1.SecurityGroup{
+						Name: "my-sg-1",
+					},
+					Role: infrav1.SubnetControlPlane,
+				})
+				s.SetSubnet("my-subnet-1", infrav1.SubnetSpec{
+					ID:         "subnet-id-1",
+					CIDRBlocks: []string{"10.2.0.0/16"},
+					RouteTable: infrav1.RouteTable{
+						Name: "my-subnet_route_table",
+					},
+					SecurityGroup: infrav1.SecurityGroup{
+						Name: "my-sg-1",
+					},
+					Role: infrav1.SubnetControlPlane,
+				})
 			},
 		},
 		{
@@ -278,14 +312,6 @@ func TestReconcileSubnets(t *testing.T) {
 					},
 				})
 				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "my-vnet"})
-				s.NodeSubnet().AnyTimes().Return(infrav1.SubnetSpec{
-					Name: "my-subnet",
-					Role: infrav1.SubnetNode,
-				})
-				s.ControlPlaneSubnet().AnyTimes().Return(infrav1.SubnetSpec{
-					Name: "my-subnet-1",
-					Role: infrav1.SubnetControlPlane,
-				})
 				s.ClusterName().AnyTimes().Return("fake-cluster")
 				s.IsIPv6Enabled().AnyTimes().Return(true)
 				s.SubscriptionID().AnyTimes().Return("123")
@@ -309,6 +335,27 @@ func TestReconcileSubnets(t *testing.T) {
 							},
 						},
 					}, nil)
+				s.Subnet("my-ipv6-subnet").Return(infrav1.SubnetSpec{
+					CIDRBlocks: []string{"10.0.0.0/16", "2001:1234:5678:9abd::/64"},
+					RouteTable: infrav1.RouteTable{
+						Name: "my-subnet_route_table",
+					},
+					SecurityGroup: infrav1.SecurityGroup{
+						Name: "my-sg",
+					},
+					Role: infrav1.SubnetNode,
+				})
+				s.SetSubnet("my-ipv6-subnet", infrav1.SubnetSpec{
+					ID:         "subnet-id",
+					CIDRBlocks: []string{"10.0.0.0/16", "2001:1234:5678:9abd::/64"},
+					RouteTable: infrav1.RouteTable{
+						Name: "my-subnet_route_table",
+					},
+					SecurityGroup: infrav1.SecurityGroup{
+						Name: "my-sg",
+					},
+					Role: infrav1.SubnetNode,
+				})
 				m.Get(gomockinternal.AContext(), "", "my-vnet", "my-ipv6-subnet-cp").
 					Return(network.Subnet{
 						ID:   to.StringPtr("subnet-id-1"),
@@ -328,6 +375,27 @@ func TestReconcileSubnets(t *testing.T) {
 							},
 						},
 					}, nil)
+				s.Subnet("my-ipv6-subnet-cp").Return(infrav1.SubnetSpec{
+					CIDRBlocks: []string{"10.2.0.0/16", "2001:1234:5678:9abc::/64"},
+					RouteTable: infrav1.RouteTable{
+						Name: "my-subnet_route_table",
+					},
+					SecurityGroup: infrav1.SecurityGroup{
+						Name: "my-sg-1",
+					},
+					Role: infrav1.SubnetControlPlane,
+				})
+				s.SetSubnet("my-ipv6-subnet-cp", infrav1.SubnetSpec{
+					ID:         "subnet-id-1",
+					CIDRBlocks: []string{"10.2.0.0/16", "2001:1234:5678:9abc::/64"},
+					RouteTable: infrav1.RouteTable{
+						Name: "my-subnet_route_table",
+					},
+					SecurityGroup: infrav1.SecurityGroup{
+						Name: "my-sg-1",
+					},
+					Role: infrav1.SubnetControlPlane,
+				})
 			},
 		},
 	}

--- a/azure/types.go
+++ b/azure/types.go
@@ -64,13 +64,11 @@ type LBSpec struct {
 	APIServerPort     int32
 }
 
-// RouteTableRole defines the unique role of a route table.
-type RouteTableRole string
-
 // RouteTableSpec defines the specification for a Route Table.
 type RouteTableSpec struct {
-	Name   string
-	Subnet infrav1.SubnetSpec
+	Name       string
+	SubnetName string
+	Subnet     infrav1.SubnetSpec
 }
 
 // InboundNatSpec defines the specification for an inbound NAT rule.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -452,8 +452,7 @@ spec:
                         type: string
                     type: object
                   subnets:
-                    description: Subnets is the configuration for the control-plane subnet and the node subnet.
-                    items:
+                    additionalProperties:
                       description: SubnetSpec configures an Azure subnet.
                       properties:
                         cidrBlocks:
@@ -463,9 +462,6 @@ spec:
                           type: array
                         id:
                           description: ID defines a unique identifier to reference this resource.
-                          type: string
-                        name:
-                          description: Name defines a name for the subnet resource.
                           type: string
                         role:
                           description: Role defines the subnet role (eg. Node, ControlPlane)
@@ -525,10 +521,9 @@ spec:
                               description: Tags defines a map of tags.
                               type: object
                           type: object
-                      required:
-                      - name
                       type: object
-                    type: array
+                    description: Subnets is the configuration for the control-plane subnet and the node subnet.
+                    type: object
                   vnet:
                     description: Vnet is the configuration for the Azure virtual network.
                     properties:

--- a/controllers/azurejson_machine_controller_test.go
+++ b/controllers/azurejson_machine_controller_test.go
@@ -119,8 +119,7 @@ func TestAzureJSONMachineReconciler(t *testing.T) {
 			SubscriptionID: "123",
 			NetworkSpec: infrav1.NetworkSpec{
 				Subnets: infrav1.Subnets{
-					{
-						Name: "node",
+					"node": {
 						Role: infrav1.SubnetNode,
 					},
 				},

--- a/controllers/azurejson_machinepool_controller_test.go
+++ b/controllers/azurejson_machinepool_controller_test.go
@@ -70,8 +70,7 @@ func TestAzureJSONPoolReconciler(t *testing.T) {
 			SubscriptionID: "123",
 			NetworkSpec: infrav1.NetworkSpec{
 				Subnets: infrav1.Subnets{
-					{
-						Name: "node",
+					"node": {
 						Role: infrav1.SubnetNode,
 					},
 				},

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -217,6 +217,7 @@ func userAssignedIdentityCloudProviderConfig(d azure.ClusterScoper, identityID s
 }
 
 func newCloudProviderConfig(d azure.ClusterScoper) (controlPlaneConfig *CloudProviderConfig, workerConfig *CloudProviderConfig) {
+	nodeSubnetName, nodeSubnet := d.NodeSubnet()
 	return &CloudProviderConfig{
 			Cloud:                        d.CloudEnvironment(),
 			AadClientID:                  d.ClientID(),
@@ -224,13 +225,13 @@ func newCloudProviderConfig(d azure.ClusterScoper) (controlPlaneConfig *CloudPro
 			TenantID:                     d.TenantID(),
 			SubscriptionID:               d.SubscriptionID(),
 			ResourceGroup:                d.ResourceGroup(),
-			SecurityGroupName:            d.NodeSubnet().SecurityGroup.Name,
+			SecurityGroupName:            nodeSubnet.SecurityGroup.Name,
 			SecurityGroupResourceGroup:   d.Vnet().ResourceGroup,
 			Location:                     d.Location(),
 			VMType:                       "vmss",
 			VnetName:                     d.Vnet().Name,
 			VnetResourceGroup:            d.Vnet().ResourceGroup,
-			SubnetName:                   d.NodeSubnet().Name,
+			SubnetName:                   nodeSubnetName,
 			RouteTableName:               d.NodeRouteTable().Name,
 			LoadBalancerSku:              "Standard",
 			MaximumLoadBalancerRuleCount: 250,
@@ -244,13 +245,13 @@ func newCloudProviderConfig(d azure.ClusterScoper) (controlPlaneConfig *CloudPro
 			TenantID:                     d.TenantID(),
 			SubscriptionID:               d.SubscriptionID(),
 			ResourceGroup:                d.ResourceGroup(),
-			SecurityGroupName:            d.NodeSubnet().SecurityGroup.Name,
+			SecurityGroupName:            nodeSubnet.SecurityGroup.Name,
 			SecurityGroupResourceGroup:   d.Vnet().ResourceGroup,
 			Location:                     d.Location(),
 			VMType:                       "vmss",
 			VnetName:                     d.Vnet().Name,
 			VnetResourceGroup:            d.Vnet().ResourceGroup,
-			SubnetName:                   d.NodeSubnet().Name,
+			SubnetName:                   nodeSubnetName,
 			RouteTableName:               d.NodeRouteTable().Name,
 			LoadBalancerSku:              "Standard",
 			MaximumLoadBalancerRuleCount: 250,

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -316,12 +316,10 @@ func newAzureClusterWithCustomVnet(name, location string) *infrav1.AzureCluster 
 					ResourceGroup: "custom-vnet-resource-group",
 				},
 				Subnets: infrav1.Subnets{
-					infrav1.SubnetSpec{
-						Name: "foo-controlplane-subnet",
+					"foo-controlplane-subnet": infrav1.SubnetSpec{
 						Role: infrav1.SubnetControlPlane,
 					},
-					infrav1.SubnetSpec{
-						Name: "foo-node-subnet",
+					"foo-node-subnet": infrav1.SubnetSpec{
 						Role: infrav1.SubnetNode,
 					},
 				},

--- a/docs/book/src/topics/api-server-endpoint.md
+++ b/docs/book/src/topics/api-server-endpoint.md
@@ -57,11 +57,11 @@ spec:
       cidrBlocks: 
         - 172.16.0.0/16
     subnets:
-      - name: my-subnet-cp
+      my-subnet-cp:
         role: control-plane
         cidrBlocks: 
           - 172.16.0.0/24
-      - name: my-subnet-node
+      my-subnet-node:
         role: node
         cidrBlocks: 
           - 172.16.2.0/24

--- a/docs/book/src/topics/custom-vnet.md
+++ b/docs/book/src/topics/custom-vnet.md
@@ -17,9 +17,9 @@ spec:
       resourceGroup: custom-vnet
       name: my-vnet
     subnets:
-      - name: control-plane-subnet
+      control-plane-subnet:
         role: control-plane
-      - name: node-subnet
+      node-subnet:
         role: node
   resourceGroup: cluster-byo-vnet
   ```
@@ -48,11 +48,11 @@ spec:
       cidrBlocks: 
         - 10.0.0.0/16
     subnets:
-      - name: my-subnet-cp
+      my-subnet-cp:
         role: control-plane
         cidrBlocks: 
           - 10.0.1.0/24
-      - name: my-subnet-node
+      my-subnet-node:
         role: node
         cidrBlocks: 
           - 10.0.2.0/24
@@ -85,7 +85,7 @@ spec:
       cidrBlocks: 
         - 10.0.0.0/16
     subnets:
-      - name: my-subnet-cp
+      my-subnet-cp:
         role: control-plane
         cidrBlocks: 
           - 10.0.1.0/24
@@ -116,7 +116,7 @@ spec:
               destinationPorts: "50000"
               source: "*"
               sourcePorts: "*"
-      - name: my-subnet-node
+      my-subnet-node:
         role: node
         cidrBlocks: 
           - 10.0.2.0/24

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -31,16 +31,16 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     subnets:
-    - cidrBlocks:
-      - 10.0.0.0/16
-      - 2001:1234:5678:9abc::/64
-      name: control-plane-subnet
-      role: control-plane
-    - cidrBlocks:
-      - 10.1.0.0/16
-      - 2001:1234:5678:9abd::/64
-      name: node-subnet
-      role: node
+      control-plane-subnet:
+        cidrBlocks:
+        - 10.0.0.0/16
+        - 2001:1234:5678:9abc::/64
+        role: control-plane
+      node-subnet:
+        cidrBlocks:
+        - 10.1.0.0/16
+        - 2001:1234:5678:9abd::/64
+        role: node
     vnet:
       cidrBlocks:
       - 10.0.0.0/8

--- a/templates/flavors/ipv6/patches/ipv6.yaml
+++ b/templates/flavors/ipv6/patches/ipv6.yaml
@@ -25,12 +25,12 @@ spec:
         - "10.0.0.0/8"
         - "2001:1234:5678:9a00::/56"
     subnets:
-      - name: control-plane-subnet
+      control-plane-subnet:
         role: control-plane
         cidrBlocks:
           - "10.0.0.0/16"
           - "2001:1234:5678:9abc::/64"
-      - name: node-subnet
+      node-subnet:
         role: node
         cidrBlocks:
           - "10.1.0.0/16"

--- a/templates/test/cluster-template-prow-ipv6.yaml
+++ b/templates/test/cluster-template-prow-ipv6.yaml
@@ -35,16 +35,16 @@ spec:
   location: ${AZURE_LOCATION}
   networkSpec:
     subnets:
-    - cidrBlocks:
-      - 10.0.0.0/16
-      - 2001:1234:5678:9abc::/64
-      name: control-plane-subnet
-      role: control-plane
-    - cidrBlocks:
-      - 10.1.0.0/16
-      - 2001:1234:5678:9abd::/64
-      name: node-subnet
-      role: node
+      control-plane-subnet:
+        cidrBlocks:
+        - 10.0.0.0/16
+        - 2001:1234:5678:9abc::/64
+        role: control-plane
+      node-subnet:
+        cidrBlocks:
+        - 10.1.0.0/16
+        - 2001:1234:5678:9abd::/64
+        role: node
     vnet:
       cidrBlocks:
       - 10.0.0.0/8

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Workload cluster creation", func() {
 		specName      = "create-workload-cluster"
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
-		result       *clusterctl.ApplyClusterTemplateAndWaitResult
+		result        *clusterctl.ApplyClusterTemplateAndWaitResult
 		clusterName   string
 		specTimes     = map[string]time.Time{}
 	)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind api-change

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Change `Subnets` type from `[]SubnetSpec` to `map[string]SubnetSpec`.
- Allows for easier retrieving of subnets, instead of having to loop through the map and comparing names
- Enforces the uniqueness of name requirement implicitly
- Makes #664 possible by not relying on "NodeSubnet()" and "ControlPlaneSubnet()" anymore in services

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes partially #618 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Changed Subnets type to map[string]SubnetSpec
Action required: AzureCluster.Spec.NetworkSpec.Subnets should now be of type map[string]SubnetSpec. See https://capz.sigs.k8s.io/topics/custom-vnet.html for examples. Existing clusters will be automatically converted to use the new type.
```
