### PR TITLE
feat: add custom private dns zone name in networkSpec

### DIFF
--- a/api/v1alpha3/azurecluster_conversion.go
+++ b/api/v1alpha3/azurecluster_conversion.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha3
 
 import (
-	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	unsafe "unsafe"
+
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
 	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
@@ -46,12 +47,13 @@ func (src *AzureCluster) ConvertTo(dstRaw conversion.Hub) error { // nolint
 			dst.Annotations = nil
 		}
 	}
-
 	// Manually restore data.
 	restored := &infrav1alpha4.AzureCluster{}
 	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
 		return err
 	}
+
+	dst.Spec.NetworkSpec.PrivateDNSZoneName = restored.Spec.NetworkSpec.PrivateDNSZoneName
 
 	dst.Spec.NetworkSpec.APIServerLB.FrontendIPsCount = restored.Spec.NetworkSpec.APIServerLB.FrontendIPsCount
 	dst.Spec.NetworkSpec.NodeOutboundLB = restored.Spec.NetworkSpec.NodeOutboundLB
@@ -72,6 +74,10 @@ func (dst *AzureCluster) ConvertFrom(srcRaw conversion.Hub) error { // nolint
 			dst.Annotations = make(map[string]string)
 		}
 		dst.Annotations[azureEnvironmentAnnotation] = src.Spec.AzureEnvironment
+	}
+	// Preserve Hub data on down-conversion.
+	if err := utilconversion.MarshalData(src, dst); err != nil {
+		return err
 	}
 
 	// Preserve Hub data on down-conversion.

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -1323,6 +1323,7 @@ func autoConvert_v1alpha4_NetworkSpec_To_v1alpha3_NetworkSpec(in *v1alpha4.Netwo
 		return err
 	}
 	// WARNING: in.NodeOutboundLB requires manual conversion: does not exist in peer-type
+	// WARNING: in.PrivateDNSZoneName requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha4/azurecluster_webhook.go
+++ b/api/v1alpha4/azurecluster_webhook.go
@@ -91,6 +91,13 @@ func (c *AzureCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
+	if !reflect.DeepEqual(c.Spec.NetworkSpec.PrivateDNSZoneName, old.Spec.NetworkSpec.PrivateDNSZoneName) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "NetworkSpec", "PrivateDNSZoneName"),
+				c.Spec.NetworkSpec.PrivateDNSZoneName, "field is immutable"),
+		)
+	}
+
 	if len(allErrs) == 0 {
 		return c.validateCluster(old)
 	}

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -62,6 +62,10 @@ type NetworkSpec struct {
 	// NodeOutboundLB is the configuration for the node outbound load balancer.
 	// +optional
 	NodeOutboundLB *LoadBalancerSpec `json:"nodeOutboundLB,omitempty"`
+
+	// PrivateDNSZoneName defines the zone name for the Azure Private DNS.
+	// +optional
+	PrivateDNSZoneName string `json:"privateDNSZoneName,omitempty"`
 }
 
 // VnetSpec configures an Azure virtual network.

--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -70,6 +70,7 @@ type NetworkDescriber interface {
 	APIServerLBName() string
 	APIServerLBPoolName(string) string
 	IsAPIServerPrivate() bool
+	GetPrivateDNSZoneName() string
 	OutboundLBName(string) string
 	OutboundPoolName(string) string
 }

--- a/azure/mocks/service_mock.go
+++ b/azure/mocks/service_mock.go
@@ -411,6 +411,20 @@ func (mr *MockNetworkDescriberMockRecorder) ControlPlaneSubnet() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlPlaneSubnet", reflect.TypeOf((*MockNetworkDescriber)(nil).ControlPlaneSubnet))
 }
 
+// GetPrivateDNSZoneName mocks base method.
+func (m *MockNetworkDescriber) GetPrivateDNSZoneName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrivateDNSZoneName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetPrivateDNSZoneName indicates an expected call of GetPrivateDNSZoneName.
+func (mr *MockNetworkDescriberMockRecorder) GetPrivateDNSZoneName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateDNSZoneName", reflect.TypeOf((*MockNetworkDescriber)(nil).GetPrivateDNSZoneName))
+}
+
 // IsAPIServerPrivate mocks base method.
 func (m *MockNetworkDescriber) IsAPIServerPrivate() bool {
 	m.ctrl.T.Helper()
@@ -917,6 +931,20 @@ func (m *MockClusterScoper) ControlPlaneSubnet() v1alpha4.SubnetSpec {
 func (mr *MockClusterScoperMockRecorder) ControlPlaneSubnet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlPlaneSubnet", reflect.TypeOf((*MockClusterScoper)(nil).ControlPlaneSubnet))
+}
+
+// GetPrivateDNSZoneName mocks base method.
+func (m *MockClusterScoper) GetPrivateDNSZoneName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrivateDNSZoneName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetPrivateDNSZoneName indicates an expected call of GetPrivateDNSZoneName.
+func (mr *MockClusterScoperMockRecorder) GetPrivateDNSZoneName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateDNSZoneName", reflect.TypeOf((*MockClusterScoper)(nil).GetPrivateDNSZoneName))
 }
 
 // HashKey mocks base method.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -270,7 +270,7 @@ func (s *ClusterScope) PrivateDNSSpec() *azure.PrivateDNSSpec {
 	var spec *azure.PrivateDNSSpec
 	if s.IsAPIServerPrivate() {
 		spec = &azure.PrivateDNSSpec{
-			ZoneName:          azure.GeneratePrivateDNSZoneName(s.ClusterName()),
+			ZoneName:          s.GetPrivateDNSZoneName(),
 			VNetName:          s.Vnet().Name,
 			VNetResourceGroup: s.Vnet().ResourceGroup,
 			LinkName:          azure.GenerateVNetLinkName(s.Vnet().Name),
@@ -362,6 +362,14 @@ func (s *ClusterScope) APIServerPublicIP() *infrav1.PublicIPSpec {
 // APIServerPrivateIP returns the API Server private IP.
 func (s *ClusterScope) APIServerPrivateIP() string {
 	return s.APIServerLB().FrontendIPs[0].PrivateIPAddress
+}
+
+// GetPrivateDNSZoneName returns the Private DNS Zone from the spec or generate it from cluster name.
+func (s *ClusterScope) GetPrivateDNSZoneName() string {
+	if len(s.AzureCluster.Spec.NetworkSpec.PrivateDNSZoneName) > 0 {
+		return s.AzureCluster.Spec.NetworkSpec.PrivateDNSZoneName
+	}
+	return azure.GeneratePrivateDNSZoneName(s.ClusterName())
 }
 
 // APIServerLBPoolName returns the API Server LB backend pool name.

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -240,3 +240,9 @@ func (s *ManagedControlPlaneScope) OutboundLBName(_ string) string {
 func (s *ManagedControlPlaneScope) OutboundPoolName(_ string) string {
 	return "aksOutboundBackendPool" // hard-coded in aks
 }
+
+// GetPrivateDNSZoneName returns the Private DNS Zone from the spec or generate it from cluster name.
+// Currently always empty as managed control planes do not currently implement private clusters.
+func (s *ManagedControlPlaneScope) GetPrivateDNSZoneName() string {
+	return ""
+}

--- a/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -266,6 +266,20 @@ func (mr *MockBastionScopeMockRecorder) Error(err, msg interface{}, keysAndValue
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockBastionScope)(nil).Error), varargs...)
 }
 
+// GetPrivateDNSZoneName mocks base method.
+func (m *MockBastionScope) GetPrivateDNSZoneName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrivateDNSZoneName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetPrivateDNSZoneName indicates an expected call of GetPrivateDNSZoneName.
+func (mr *MockBastionScopeMockRecorder) GetPrivateDNSZoneName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateDNSZoneName", reflect.TypeOf((*MockBastionScope)(nil).GetPrivateDNSZoneName))
+}
+
 // HashKey mocks base method.
 func (m *MockBastionScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -252,6 +252,20 @@ func (mr *MockLBScopeMockRecorder) Error(err, msg interface{}, keysAndValues ...
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockLBScope)(nil).Error), varargs...)
 }
 
+// GetPrivateDNSZoneName mocks base method.
+func (m *MockLBScope) GetPrivateDNSZoneName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrivateDNSZoneName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetPrivateDNSZoneName indicates an expected call of GetPrivateDNSZoneName.
+func (mr *MockLBScopeMockRecorder) GetPrivateDNSZoneName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateDNSZoneName", reflect.TypeOf((*MockLBScope)(nil).GetPrivateDNSZoneName))
+}
+
 // HashKey mocks base method.
 func (m *MockLBScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/routetables/mock_routetables/routetables_mock.go
+++ b/azure/services/routetables/mock_routetables/routetables_mock.go
@@ -252,6 +252,20 @@ func (mr *MockRouteTableScopeMockRecorder) Error(err, msg interface{}, keysAndVa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockRouteTableScope)(nil).Error), varargs...)
 }
 
+// GetPrivateDNSZoneName mocks base method.
+func (m *MockRouteTableScope) GetPrivateDNSZoneName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrivateDNSZoneName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetPrivateDNSZoneName indicates an expected call of GetPrivateDNSZoneName.
+func (mr *MockRouteTableScopeMockRecorder) GetPrivateDNSZoneName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateDNSZoneName", reflect.TypeOf((*MockRouteTableScope)(nil).GetPrivateDNSZoneName))
+}
+
 // HashKey mocks base method.
 func (m *MockRouteTableScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
+++ b/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
@@ -252,6 +252,20 @@ func (mr *MockNSGScopeMockRecorder) Error(err, msg interface{}, keysAndValues ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockNSGScope)(nil).Error), varargs...)
 }
 
+// GetPrivateDNSZoneName mocks base method.
+func (m *MockNSGScope) GetPrivateDNSZoneName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrivateDNSZoneName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetPrivateDNSZoneName indicates an expected call of GetPrivateDNSZoneName.
+func (mr *MockNSGScopeMockRecorder) GetPrivateDNSZoneName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateDNSZoneName", reflect.TypeOf((*MockNSGScope)(nil).GetPrivateDNSZoneName))
+}
+
 // HashKey mocks base method.
 func (m *MockNSGScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/subnets/mock_subnets/subnets_mock.go
+++ b/azure/services/subnets/mock_subnets/subnets_mock.go
@@ -252,6 +252,20 @@ func (mr *MockSubnetScopeMockRecorder) Error(err, msg interface{}, keysAndValues
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockSubnetScope)(nil).Error), varargs...)
 }
 
+// GetPrivateDNSZoneName mocks base method.
+func (m *MockSubnetScope) GetPrivateDNSZoneName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrivateDNSZoneName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetPrivateDNSZoneName indicates an expected call of GetPrivateDNSZoneName.
+func (mr *MockSubnetScopeMockRecorder) GetPrivateDNSZoneName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateDNSZoneName", reflect.TypeOf((*MockSubnetScope)(nil).GetPrivateDNSZoneName))
+}
+
 // HashKey mocks base method.
 func (m *MockSubnetScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -494,6 +494,9 @@ spec:
                         description: LBType defines an Azure load balancer Type.
                         type: string
                     type: object
+                  privateDNSZoneName:
+                    description: PrivateDNSZoneName defines the zone name for the Azure Private DNS.
+                    type: string
                   subnets:
                     description: Subnets is the configuration for the control-plane subnet and the node subnet.
                     items:

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -21,4 +21,5 @@
     - [Node Ooutbound Load Balancer](./topics/node-outbound-lb.md)
     - [Spot Virtual Machines](./topics/spot-vms.md)
     - [Virtual Networks](./topics/custom-vnet.md)
+    - [Custom Private DNS Zone Name](./topics/custom-dns.md)
     - [Windows](./topics/windows.md)

--- a/docs/book/src/topics/custom-dns.md
+++ b/docs/book/src/topics/custom-dns.md
@@ -1,0 +1,37 @@
+# Custom Private DNS Zone Name
+
+It is possible to set the DNS zone name to a custom value by setting `PrivateDNSZoneName` in the `NetworkSpec`. By default the DNS zone name is `${CLUSTER_NAME}.capz.io`.
+
+*This feature is enabled only if the `apiServerLB.type` is `Internal`*
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: AzureCluster
+metadata:
+  name: cluster-example
+  namespace: default
+spec:
+  location: southcentralus
+  networkSpec:
+    privateDNSZoneName: "kubernetes.myzone.com"
+    vnet:
+      name: my-vnet
+      cidrBlocks:
+        - 10.0.0.0/16
+    subnets:
+      - name: my-subnet-cp
+        role: control-plane
+        cidrBlocks:
+          - 10.0.1.0/24
+      - name: my-subnet-node
+        role: node
+        cidrBlocks:
+          - 10.0.2.0/24
+    apiServerLB:
+      type: Internal
+      frontendIPs:
+        - name: lb-private-ip-frontend
+          privateIP: 172.16.0.100
+  resourceGroup: cluster-example
+
+```

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
+github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
/kind feature
 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
* Allows users to customize Private DNS Zone name in the AzureCluster NetworkSpec
* If not specified the PrivateDNSZoneName  will still be generated by : azure.GeneratePrivateDNSZoneName()

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes partially #1159 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a customizable PrivateDNSZoneName to AzureCluster NetworkSpec
```
