### PR TITLE
Update Windows ssh configuration

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -21,19 +21,20 @@
     - [Tilt for dev in both CAPZ and CAPI](#tilt-for-dev-in-both-capz-and-capi)
     - [Deploying a workload cluster](#deploying-a-workload-cluster)
     - [Viewing Telemetry](#viewing-telemetry)
-  - [Instrumenting Telemetry](#instrumenting-telemetry)
-    - [Distributed Tracing](#distributed-tracing)
-    - [Metrics](#metrics)
   - [Manual Testing](#manual-testing)
     - [Creating a dev cluster](#creating-a-dev-cluster)
       - [Building and pushing dev images](#building-and-pushing-dev-images)
       - [Customizing the cluster deployment](#customizing-the-cluster-deployment)
       - [Creating the cluster](#creating-the-cluster)
+  - [Instrumenting Telemetry](#instrumenting-telemetry)
+    - [Distributed Tracing](#distributed-tracing)
+    - [Metrics](#metrics)
   - [Submitting PRs and testing](#submitting-prs-and-testing)
     - [Executing unit tests](#executing-unit-tests)
   - [Automated Testing](#automated-testing)
     - [Mocks](#mocks)
     - [E2E Testing](#e2e-testing)
+    - [Running custom test suites on CAPZ clusters](#running-custom-test-suites-on-capz-clusters)
     - [Conformance Testing](#conformance-testing)
 
 <!-- /TOC -->
@@ -292,7 +293,10 @@ SSH_KEY_FILE=.sshkey
 rm -f "${SSH_KEY_FILE}" 2>/dev/null
 ssh-keygen -t rsa -b 2048 -f "${SSH_KEY_FILE}" -N '' 1>/dev/null
 echo "Machine SSH key generated in ${SSH_KEY_FILE}"
+# For Linux the ssh key needs to be b64 encoded because we use the azure api to set it
+# Windows doesn't support setting ssh keys so we use cloudbase-int to set which doesn't require base64 
 export AZURE_SSH_PUBLIC_KEY_B64=$(cat "${SSH_KEY_FILE}.pub" | base64 | tr -d '\r\n')
+export AZURE_SSH_PUBLIC_KEY=$(cat "${SSH_KEY_FILE}.pub" | tr -d '\r\n')
 ```
 
 ⚠️ Please note the generated templates include default values and therefore require the use of `clusterctl` to create the cluster

--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -252,15 +252,6 @@ spec:
       New-HnsNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "Ethernet 2" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })
     path: C:/create-external-network.ps1
     permissions: "0744"
-  - content: |
-      [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("${AZURE_SSH_PUBLIC_KEY_B64:=''}")) | Add-Content C:/ProgramData/ssh/administrators_authorized_keys
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /remove "NT AUTHORITY\Authenticated Users"
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /inheritance:r
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /grant SYSTEM:F
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /grant BUILTIN\Administrators:F
-      restart-service sshd
-    path: C:/configure-ssh.ps1
-    permissions: "0744"
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
@@ -270,4 +261,8 @@ spec:
       name: '{{ ds.meta_data["local_hostname"] }}'
   preKubeadmCommands:
   - powershell c:/create-external-network.ps1
-  - powershell c:/configure-ssh.ps1
+  users:
+  - groups: Administrators
+    name: capi
+    sshAuthorizedKeys:
+    - ${AZURE_SSH_PUBLIC_KEY:=""}

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -260,15 +260,6 @@ spec:
           New-HnsNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "Ethernet 2" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })
         path: C:/create-external-network.ps1
         permissions: "0744"
-      - content: |
-          [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("${AZURE_SSH_PUBLIC_KEY_B64:=''}")) | Add-Content C:/ProgramData/ssh/administrators_authorized_keys
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /remove "NT AUTHORITY\Authenticated Users"
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /inheritance:r
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /grant SYSTEM:F
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /grant BUILTIN\Administrators:F
-          restart-service sshd
-        path: C:/configure-ssh.ps1
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
@@ -278,4 +269,8 @@ spec:
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
       - powershell c:/create-external-network.ps1
-      - powershell c:/configure-ssh.ps1
+      users:
+      - groups: Administrators
+        name: capi
+        sshAuthorizedKeys:
+        - ${AZURE_SSH_PUBLIC_KEY:=""}

--- a/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
+++ b/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
@@ -40,9 +40,13 @@ kind: KubeadmConfig
 metadata:
   name: "${CLUSTER_NAME}-mp-win"
 spec:
+  users:
+  - name: capi
+    groups: Administrators
+    sshAuthorizedKeys:
+    - ${AZURE_SSH_PUBLIC_KEY:=""}
   preKubeadmCommands:
     - powershell c:/create-external-network.ps1
-    - powershell c:/configure-ssh.ps1
   joinConfiguration:
     nodeRegistration:
       name: '{{ ds.meta_data["local_hostname"] }}'
@@ -66,12 +70,3 @@ spec:
       # https://github.com/kubernetes-sigs/sig-windows-tools/issues/103#issuecomment-709426828
       ipmo C:\k\debug\hns.psm1;
       New-HnsNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "Ethernet 2" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })
-  - path: C:/configure-ssh.ps1
-    permissions: "0744"
-    content: |
-      [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("${AZURE_SSH_PUBLIC_KEY_B64:=''}")) | Add-Content C:/ProgramData/ssh/administrators_authorized_keys
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /remove "NT AUTHORITY\Authenticated Users"
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /inheritance:r
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /grant SYSTEM:F
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /grant BUILTIN\Administrators:F
-      restart-service sshd

--- a/templates/flavors/windows/machine-deployment-windows.yaml
+++ b/templates/flavors/windows/machine-deployment-windows.yaml
@@ -44,9 +44,13 @@ metadata:
 spec:
   template:
     spec:
+      users:
+      - name: capi
+        groups: Administrators
+        sshAuthorizedKeys:
+        - ${AZURE_SSH_PUBLIC_KEY:=""}
       preKubeadmCommands:
         - powershell c:/create-external-network.ps1
-        - powershell c:/configure-ssh.ps1
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -70,12 +74,3 @@ spec:
           # https://github.com/kubernetes-sigs/sig-windows-tools/issues/103#issuecomment-709426828
           ipmo C:\k\debug\hns.psm1;
           New-HnsNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "Ethernet 2" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })
-      - path: C:/configure-ssh.ps1
-        permissions: "0744"
-        content: |
-          [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("${AZURE_SSH_PUBLIC_KEY_B64:=''}")) | Add-Content C:/ProgramData/ssh/administrators_authorized_keys
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /remove "NT AUTHORITY\Authenticated Users"
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /inheritance:r
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /grant SYSTEM:F
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /grant BUILTIN\Administrators:F
-          restart-service sshd

--- a/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
@@ -257,15 +257,6 @@ spec:
       New-HnsNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "Ethernet 2" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })
     path: C:/create-external-network.ps1
     permissions: "0744"
-  - content: |
-      [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("${AZURE_SSH_PUBLIC_KEY_B64:=''}")) | Add-Content C:/ProgramData/ssh/administrators_authorized_keys
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /remove "NT AUTHORITY\Authenticated Users"
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /inheritance:r
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /grant SYSTEM:F
-      icacls C:/ProgramData/ssh/administrators_authorized_keys /grant BUILTIN\Administrators:F
-      restart-service sshd
-    path: C:/configure-ssh.ps1
-    permissions: "0744"
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
@@ -275,7 +266,11 @@ spec:
       name: '{{ ds.meta_data["local_hostname"] }}'
   preKubeadmCommands:
   - powershell c:/create-external-network.ps1
-  - powershell c:/configure-ssh.ps1
+  users:
+  - groups: Administrators
+    name: capi
+    sshAuthorizedKeys:
+    - ${AZURE_SSH_PUBLIC_KEY:=""}
 ---
 apiVersion: v1
 data: ${CNI_RESOURCES_WINDOWS}

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -265,15 +265,6 @@ spec:
           New-HnsNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "Ethernet 2" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })
         path: C:/create-external-network.ps1
         permissions: "0744"
-      - content: |
-          [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("${AZURE_SSH_PUBLIC_KEY_B64:=''}")) | Add-Content C:/ProgramData/ssh/administrators_authorized_keys
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /remove "NT AUTHORITY\Authenticated Users"
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /inheritance:r
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /grant SYSTEM:F
-          icacls C:/ProgramData/ssh/administrators_authorized_keys /grant BUILTIN\Administrators:F
-          restart-service sshd
-        path: C:/configure-ssh.ps1
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
@@ -283,7 +274,11 @@ spec:
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
       - powershell c:/create-external-network.ps1
-      - powershell c:/configure-ssh.ps1
+      users:
+      - groups: Administrators
+        name: capi
+        sshAuthorizedKeys:
+        - ${AZURE_SSH_PUBLIC_KEY:=""}
 ---
 apiVersion: v1
 data: ${CNI_RESOURCES_WINDOWS}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Image builder added support ssh configuration to the image which breaks the way we were configuring ssh.  This copies the ssh public key to the correct location and aligns the Windows ssh approach with other providers.

https://github.com/kubernetes-sigs/image-builder/blob/4b1de420ab2af76bac6580218b565e037904f5f9/images/capi/ansible/windows/roles/systemprep/tasks/main.yml#L94-L95

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix ssh for newer image builder images on windows
```
