### PR TITLE
ensure no latest Azure SDK API versions are allowed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,11 +258,15 @@ $(KUBECTL): ## Build kubectl
 ## --------------------------------------
 
 .PHONY: lint
-lint: $(GOLANGCI_LINT) ## Lint codebase
+lint: $(GOLANGCI_LINT) lint-latest ## Lint codebase
 	$(GOLANGCI_LINT) run -v
 
 lint-full: $(GOLANGCI_LINT) ## Run slower linters to detect possible issues
 	$(GOLANGCI_LINT) run -v --fast=false
+
+.PHONY: lint-latest
+lint-latest:
+	./hack/lint-latest.sh
 
 ## --------------------------------------
 ## Generate

--- a/hack/lint-latest.sh
+++ b/hack/lint-latest.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+
+root=$(dirname "${BASH_SOURCE[0]}")
+abs_root=$(cd "${root}/.." || exit 2; pwd)
+found=$(find "${abs_root}" -type f -name '*.go' -print0 | xargs -0 grep -Ei 'github.com/Azure/azure-sdk-for-go/.+/latest/.+')
+if [[ -n ${found} ]]; then
+  echo "Found usages of the 'latest' floating Azure API version. Only specific versions of the Azure APIs are allowed. Replace the following occurrences of latest with a specific date version described here: https://github.com/Azure/azure-sdk-for-go#versioning."
+  echo "${found}"
+  exit 1
+fi


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

It's very easy for a reviewer to miss Azure SDK "latest" import paths. This lint script will ensure none are committed.

Why do we not want a "latest" import path? The "latest" import paths are floating imports. This means the types in the latest import path are aliases which point to types in the newest stable Azure API version (latest --> 2020-12-01). By importing these paths, the version of the API used will change without making changes to the import path. This is advantageous for folks who would always like to stay on latest, and don't want to deal with updating import paths with each SDK Go module upgrade. However, in Cluster API Provider Azure it is beneficial to make a conscious choice which API versions we chose to depend upon to ensure compatibility across Azure clouds (public, sovereign, government, etc.).


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
