### PR TITLE
Update OOT cloud-provider version and enable LB test

### DIFF
--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -375,7 +375,7 @@ data:
           effect: NoSchedule
       containers:
         - name: cloud-controller-manager
-          image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.7.2}
+          image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.7.4}
           imagePullPolicy: IfNotPresent
           command: ["cloud-controller-manager"]
           args:
@@ -503,7 +503,7 @@ data:
               effect: NoSchedule
           containers:
             - name: cloud-node-manager
-              image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.2}
+              image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4}
               imagePullPolicy: IfNotPresent
               command:
                 - cloud-node-manager

--- a/templates/flavors/external-cloud-provider/cloud-controller-manager.yaml
+++ b/templates/flavors/external-cloud-provider/cloud-controller-manager.yaml
@@ -148,7 +148,7 @@ spec:
       effect: NoSchedule
   containers:
     - name: cloud-controller-manager
-      image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.7.2}
+      image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.7.4}
       imagePullPolicy: IfNotPresent
       command: ["cloud-controller-manager"]
       args:

--- a/templates/flavors/external-cloud-provider/cloud-node-manager.yaml
+++ b/templates/flavors/external-cloud-provider/cloud-node-manager.yaml
@@ -66,7 +66,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cloud-node-manager
-          image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.2}
+          image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4}
           imagePullPolicy: IfNotPresent
           command:
             - cloud-node-manager

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -380,7 +380,7 @@ data:
           effect: NoSchedule
       containers:
         - name: cloud-controller-manager
-          image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.7.2}
+          image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.7.4}
           imagePullPolicy: IfNotPresent
           command: ["cloud-controller-manager"]
           args:
@@ -508,7 +508,7 @@ data:
               effect: NoSchedule
           containers:
             - name: cloud-node-manager
-              image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.2}
+              image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4}
               imagePullPolicy: IfNotPresent
               command:
                 - cloud-node-manager

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -361,7 +361,7 @@ var _ = Describe("Workload cluster creation", func() {
 	// ci-e2e.sh and Prow CI skip this test by default.
 	// To include this test, set `GINKGO_SKIP=""`.
 	Context("Creating a cluster that uses the external cloud provider", func() {
-		It("with a 3 control plane nodes and 2 worker nodes", func() {
+		It("with a 1 control plane nodes and 2 worker nodes", func() {
 			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 				ClusterProxy: bootstrapClusterProxy,
 				ConfigCluster: clusterctl.ConfigClusterInput{
@@ -373,7 +373,7 @@ var _ = Describe("Workload cluster creation", func() {
 					Namespace:                namespace.Name,
 					ClusterName:              clusterName,
 					KubernetesVersion:        e2eConfig.GetVariable(capi_e2e.KubernetesVersion),
-					ControlPlaneMachineCount: pointer.Int64Ptr(3),
+					ControlPlaneMachineCount: pointer.Int64Ptr(1),
 					WorkerMachineCount:       pointer.Int64Ptr(2),
 				},
 				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
@@ -381,18 +381,16 @@ var _ = Describe("Workload cluster creation", func() {
 				WaitForMachinePools:          e2eConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 			}, result)
 
-			// TODO: fix and enable
-			//Context("Creating an accessible load balancer", func() {
-			//	AzureLBSpec(ctx, func() AzureLBSpecInput {
-			//		return AzureLBSpecInput{
-			//			BootstrapClusterProxy: bootstrapClusterProxy,
-			//			Namespace:             namespace,
-			//			ClusterName:           clusterName,
-			//			SkipCleanup:           skipCleanup,
-			//			IsVMSS:                false,
-			//		}
-			//	})
-			//})
+			Context("Creating an accessible load balancer", func() {
+				AzureLBSpec(ctx, func() AzureLBSpecInput {
+					return AzureLBSpecInput{
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+						SkipCleanup:           skipCleanup,
+					}
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Updates cloud-controller-manager and cloud-node-manager default versions to v0.7.4 in the templates and enable the LB test for the external cloud provider spec. [v0.7.3](https://kubernetes-sigs.github.io/cloud-provider-azure/blog/2021/04/19/v0.7.3/) fixes a bug in the cache for VMs when using "vmss" vmType.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update OOT cloud-provider version and enable LB test
```
