### PR TITLE
Increase deloyment timeout in e2e to accommodate Windows deployments

### DIFF
--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -110,7 +110,7 @@ intervals:
   default/wait-delete-cluster: ["30m", "10s"]
   default/wait-machine-upgrade: ["60m", "10s"]
   default/wait-machine-remediation: ["30m", "10s"]
-  default/wait-deployment: ["8m", "10s"]
+  default/wait-deployment: ["15m", "10s"]
   default/wait-job: ["5m", "10s"]
   default/wait-service: ["5m", "10s"]
   default/wait-machine-pool-nodes: ["20m", "10s"]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**  
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test

/kind other
-->

**What this PR does / why we need it**:
The windows pod sometimes takes longer to come online.  Logs indicate it pulling was still in progress.

- https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/1119/pull-cluster-api-provider-azure-e2e-windows/1384286383429914624

- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1294#issuecomment-814966423


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

We could have a separate timeout for Windows, but added more complexity to implement.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
