### PR TITLE
fix: remove calico installation step in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,17 +490,6 @@ create-workload-cluster: $(ENVSUBST)
 	kubectl get secrets $(CLUSTER_NAME)-kubeconfig -o json | jq -r .data.value | base64 --decode > ./kubeconfig
 	timeout --foreground 600 bash -c "while ! kubectl --kubeconfig=./kubeconfig get nodes | grep master; do sleep 1; done"
 
-	@if [[ "${CLUSTER_TEMPLATE}" == *prow* ]]; then \
-		if [[ "${CLUSTER_TEMPLATE}" == *ipv6* ]]; then \
-			kubectl --kubeconfig=./kubeconfig apply -f templates/addons/calico-ipv6.yaml; \
-		elif [[ "${CLUSTER_TEMPLATE}" == *windows* ]]; then \
-			echo "windows being applied" \
-			kubectl --kubeconfig=./kubeconfig apply -f templates/addons/windows; \
-		else \
-			kubectl --kubeconfig=./kubeconfig apply -f templates/addons/calico.yaml; \
-		fi \
-	fi
-
 	@echo 'run "kubectl --kubeconfig=./kubeconfig ..." to work with the new target cluster'
 
 .PHONY: create-aks-cluster


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

Follow-up PR for https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1287. Looks like we are now installing calico twice on the workload cluster, causing the following flake in https://testgrid.k8s.io/provider-azure-master-signal#capz-azure-disk:

```log
Warning: resource serviceaccounts/calico-kube-controllers is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
serviceaccount/calico-kube-controllers configured
Error from server (AlreadyExists): error when creating "templates/addons/calico.yaml": deployments.apps "calico-kube-controllers" already exists
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
