### PR TITLE
Fix issue for Windows Flannel deployments when packet size is over 1400 MTU

### DIFF
--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -87,6 +87,18 @@ spec:
         overwrite: false
         tableType: gpt
     files:
+    - content: |
+        network:
+          version: 2
+          ethernets:
+            eth0:
+              mtu: 1400
+              match:
+                macaddress: MACADDRESS
+              set-name: eth0
+      owner: root:root
+      path: /etc/netplan/60-eth0.yaml
+      permissions: "0644"
     - contentFrom:
         secret:
           key: control-plane-azure.json
@@ -109,6 +121,10 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
+    postKubeadmCommands:
+    - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+    - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+    - netplan apply
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
@@ -182,12 +198,28 @@ spec:
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"
+  - content: |
+      network:
+        version: 2
+        ethernets:
+          eth0:
+            mtu: 1400
+            match:
+              macaddress: MACADDRESS
+            set-name: eth0
+    owner: root:root
+    path: /etc/netplan/60-eth0.yaml
+    permissions: "0644"
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-config: /etc/kubernetes/azure.json
         cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
+  postKubeadmCommands:
+  - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+  - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+  - netplan apply
   useExperimentalRetryJoin: true
 ---
 apiVersion: exp.cluster.x-k8s.io/v1alpha4

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -87,6 +87,18 @@ spec:
         overwrite: false
         tableType: gpt
     files:
+    - content: |
+        network:
+          version: 2
+          ethernets:
+            eth0:
+              mtu: 1400
+              match:
+                macaddress: MACADDRESS
+              set-name: eth0
+      owner: root:root
+      path: /etc/netplan/60-eth0.yaml
+      permissions: "0644"
     - contentFrom:
         secret:
           key: control-plane-azure.json
@@ -109,6 +121,10 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
+    postKubeadmCommands:
+    - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+    - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+    - netplan apply
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
@@ -186,12 +202,28 @@ spec:
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"
+      - content: |
+          network:
+            version: 2
+            ethernets:
+              eth0:
+                mtu: 1400
+                match:
+                  macaddress: MACADDRESS
+                set-name: eth0
+        owner: root:root
+        path: /etc/netplan/60-eth0.yaml
+        permissions: "0644"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
+      postKubeadmCommands:
+      - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+      - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+      - netplan apply
       useExperimentalRetryJoin: true
 ---
 apiVersion: cluster.x-k8s.io/v1alpha4

--- a/templates/flavors/base-windows/patches/kubeadm-control-plane.yaml
+++ b/templates/flavors/base-windows/patches/kubeadm-control-plane.yaml
@@ -4,8 +4,38 @@ metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   kubeadmConfigSpec:
+    postKubeadmCommands:
+      # Azures vnet MTU is 1400. 
+      # When using Flannel VXLAN to avoid packet fragmentation 
+      # that results dropped packets on Windows we need to match.
+      # Flannel will automatically choose eth0 - 50
+      # a bug in netplan requires matching on macaddress
+      # https://bugs.launchpad.net/netplan/+bug/1807273
+      - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+      - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+      - netplan apply 
     clusterConfiguration:
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "true"
           configure-cloud-routes: "false"
+    files:
+    - path: /etc/netplan/60-eth0.yaml
+      permissions: "0644"
+      owner: root:root
+      content: |
+        network:
+          version: 2
+          ethernets:
+            eth0:
+              mtu: 1400
+              match:
+                macaddress: MACADDRESS
+              set-name: eth0
+    - contentFrom:
+        secret:
+          name: ${CLUSTER_NAME}-control-plane-azure-json
+          key: control-plane-azure.json
+      owner: root:root
+      path: /etc/kubernetes/azure.json
+      permissions: "0644"

--- a/templates/flavors/machinepool-windows/machine-pool-deployment.yaml
+++ b/templates/flavors/machinepool-windows/machine-pool-deployment.yaml
@@ -40,6 +40,14 @@ kind: KubeadmConfig
 metadata:
   name: "${CLUSTER_NAME}-mp-0"
 spec:
+  postKubeadmCommands:
+    # Azures vnet MTU is 1400. 
+    # When using Flannel VXLAN to avoid packet fragmentation 
+    # that results dropped packets on Windows we need to match.
+    # Flannel will automatically choose eth0 - 50
+    - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+    - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+    - netplan apply 
   useExperimentalRetryJoin: true
   joinConfiguration:
     nodeRegistration:
@@ -55,3 +63,15 @@ spec:
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"
+  - path: /etc/netplan/60-eth0.yaml
+    permissions: "0644"
+    owner: root:root
+    content: |
+      network:
+        version: 2
+        ethernets:
+          eth0:
+            mtu: 1400
+            match:
+              macaddress: MACADDRESS
+            set-name: eth0

--- a/templates/flavors/windows/machine-deployment.yaml
+++ b/templates/flavors/windows/machine-deployment.yaml
@@ -44,6 +44,14 @@ metadata:
 spec:
   template:
     spec:
+      postKubeadmCommands:
+        # Azures vnet MTU is 1400. 
+        # When using Flannel VXLAN to avoid packet fragmentation 
+        # that results dropped packets on Windows we need to match.
+        # Flannel will automatically choose eth0 - 50
+        - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+        - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+        - netplan apply 
       useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
@@ -59,3 +67,16 @@ spec:
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"
+      - path: /etc/netplan/60-eth0.yaml
+        permissions: "0644"
+        owner: root:root
+        content: |
+          network:
+            version: 2
+            ethernets:
+              eth0:
+                mtu: 1400
+                match:
+                  macaddress: MACADDRESS
+                set-name: eth0
+      

--- a/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
@@ -92,6 +92,18 @@ spec:
         overwrite: false
         tableType: gpt
     files:
+    - content: |
+        network:
+          version: 2
+          ethernets:
+            eth0:
+              mtu: 1400
+              match:
+                macaddress: MACADDRESS
+              set-name: eth0
+      owner: root:root
+      path: /etc/netplan/60-eth0.yaml
+      permissions: "0644"
     - contentFrom:
         secret:
           key: control-plane-azure.json
@@ -114,6 +126,10 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
+    postKubeadmCommands:
+    - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+    - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+    - netplan apply
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
@@ -187,12 +203,28 @@ spec:
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"
+  - content: |
+      network:
+        version: 2
+        ethernets:
+          eth0:
+            mtu: 1400
+            match:
+              macaddress: MACADDRESS
+            set-name: eth0
+    owner: root:root
+    path: /etc/netplan/60-eth0.yaml
+    permissions: "0644"
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-config: /etc/kubernetes/azure.json
         cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
+  postKubeadmCommands:
+  - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+  - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+  - netplan apply
   useExperimentalRetryJoin: true
 ---
 apiVersion: exp.cluster.x-k8s.io/v1alpha4

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -92,6 +92,18 @@ spec:
         overwrite: false
         tableType: gpt
     files:
+    - content: |
+        network:
+          version: 2
+          ethernets:
+            eth0:
+              mtu: 1400
+              match:
+                macaddress: MACADDRESS
+              set-name: eth0
+      owner: root:root
+      path: /etc/netplan/60-eth0.yaml
+      permissions: "0644"
     - contentFrom:
         secret:
           key: control-plane-azure.json
@@ -114,6 +126,10 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
+    postKubeadmCommands:
+    - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+    - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+    - netplan apply
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
@@ -191,12 +207,28 @@ spec:
         owner: root:root
         path: /etc/kubernetes/azure.json
         permissions: "0644"
+      - content: |
+          network:
+            version: 2
+            ethernets:
+              eth0:
+                mtu: 1400
+                match:
+                  macaddress: MACADDRESS
+                set-name: eth0
+        owner: root:root
+        path: /etc/netplan/60-eth0.yaml
+        permissions: "0644"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
+      postKubeadmCommands:
+      - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
+      - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
+      - netplan apply
       useExperimentalRetryJoin: true
 ---
 apiVersion: cluster.x-k8s.io/v1alpha4


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test
/kind bug

<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation

/kind flake
/kind other
-->

**What this PR does / why we need it**:

Flannel is being used as the default CNI.  An important note for Flannel vxlan deployments is that the MTU for the linux nodes must be set to 1400.  
This is because [Azure's VNET MTU is 1400](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-tcpip-performance-tuning#azure-and-vm-mtu) which can cause fragmentation on packets sent from the Linux node to Windows node resulting in dropped packets. 
To mitigate this we set the Linux eth0 port match 1400 and Flannel will automatically pick this up and [subtract 50](https://github.com/flannel-io/flannel/issues/1011) for the flannel network created.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Found issues during testing of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1119

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [X] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use MTU of 1400 on linux nodes when including Windows deployments using vxlan
```
