### PR TITLE
fix: node resource group name is option/defaulted

### DIFF
--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -254,7 +254,6 @@ spec:
             required:
             - defaultPoolRef
             - location
-            - nodeResourceGroupName
             - resourceGroupName
             - sshPublicKey
             - version

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -223,7 +223,7 @@ spec:
                 description: SSHPublicKey is a string literal containing an ssh public key base64 encoded.
                 type: string
               subscriptionID:
-                description: SubscriotionID is the GUID of the Azure subscription to hold this cluster.
+                description: SubscriptionID is the GUID of the Azure subscription to hold this cluster.
                 type: string
               version:
                 description: Version defines the desired Kubernetes version.

--- a/exp/api/v1alpha4/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1alpha4/azuremanagedcontrolplane_types.go
@@ -36,12 +36,13 @@ type AzureManagedControlPlaneSpec struct {
 	// NodeResourceGroupName is the name of the resource group
 	// containining cluster IaaS resources. Will be populated to default
 	// in webhook.
-	NodeResourceGroupName string `json:"nodeResourceGroupName"`
+	// +optional
+	NodeResourceGroupName string `json:"nodeResourceGroupName,omitempty"`
 
 	// VirtualNetwork describes the vnet for the AKS cluster. Will be created if it does not exist.
 	VirtualNetwork ManagedControlPlaneVirtualNetwork `json:"virtualNetwork,omitempty"`
 
-	// SubscriotionID is the GUID of the Azure subscription to hold this cluster.
+	// SubscriptionID is the GUID of the Azure subscription to hold this cluster.
 	SubscriptionID string `json:"subscriptionID,omitempty"`
 
 	// Location is a string matching one of the canonical Azure region names. Examples: "westus2", "eastus".


### PR DESCRIPTION

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

fixes #1148

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Node resource group is optional on AzureManagedControlPlane. It defaults to `"MC_${RESOURCE_GROUP}_${CLUSTER_NAME}_${location}"`
```
