### PR TITLE
[backport-release-0.4] fix imagePullPolicy of nmi image

### DIFF
--- a/config/aadpodidentity/aad-pod-identity-deployment.yaml
+++ b/config/aadpodidentity/aad-pod-identity-deployment.yaml
@@ -103,7 +103,7 @@ spec:
       containers:
       - name: nmi
         image: "mcr.microsoft.com/oss/azure/aad-pod-identity/nmi:v1.6.3"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args:
           - "--node=$(NODE_NAME)"
           - "--forceNamespaced"          


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Change the nmi imagePullPolicy from Always to IfNotPresent

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change the nmi imagePullPolicy from Always to IfNotPresent
```
