### PR TITLE
🐛 Make cloud config secret key backward compatible

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -188,6 +188,8 @@ func GetCloudProviderSecret(d azure.ClusterScoper, namespace, name string, owner
 	secret.Data = map[string][]byte{
 		"control-plane-azure.json": controlPlaneData,
 		"worker-node-azure.json":   workerNodeData,
+		// added for backwards compatibility
+		"azure.json": controlPlaneData,
 	}
 
 	return secret, nil

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -157,6 +157,9 @@ func TestGetCloudProviderConfig(t *testing.T) {
 			if diff := cmp.Diff(tc.expectedWorkerNodeConfig, string(cloudConfig.Data["worker-node-azure.json"])); diff != "" {
 				t.Errorf(diff)
 			}
+			if diff := cmp.Diff(tc.expectedControlPlaneConfig, string(cloudConfig.Data["azure.json"])); diff != "" {
+				t.Errorf(diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

Copies `control-plane-azure.json` to `azure.json` for backwards compatibility.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1357

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Make azure.json secret key backward compatible
```
