### PR TITLE
 do not conversion-gen v1alpha3.OSDisk due to warning message non-determinism

### DIFF
--- a/api/v1alpha3/azuremachine_conversion.go
+++ b/api/v1alpha3/azuremachine_conversion.go
@@ -18,7 +18,7 @@ package v1alpha3
 
 import (
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
-	v1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
@@ -112,11 +112,12 @@ func Convert_v1alpha4_AzureMachineStatus_To_v1alpha3_AzureMachineStatus(in *v1al
 
 // Convert_v1alpha3_OSDisk_To_v1alpha4_OSDisk converts this OSDisk to the Hub version (v1alpha4).
 func Convert_v1alpha3_OSDisk_To_v1alpha4_OSDisk(in *OSDisk, out *v1alpha4.OSDisk, s apiconversion.Scope) error { // nolint
-	if err := autoConvert_v1alpha3_OSDisk_To_v1alpha4_OSDisk(in, out, s); err != nil {
-		return err
-	}
-
+	out.OSType = in.OSType
+	out.DiskSizeGB = in.DiskSizeGB
+	out.DiffDiskSettings = (*v1alpha4.DiffDiskSettings)(in.DiffDiskSettings)
+	out.CachingType = in.CachingType
 	out.ManagedDisk = &v1alpha4.ManagedDiskParameters{}
+
 	if err := Convert_v1alpha3_ManagedDisk_To_v1alpha4_ManagedDiskParameters(&in.ManagedDisk, out.ManagedDisk, s); err != nil {
 		return err
 	}
@@ -126,9 +127,10 @@ func Convert_v1alpha3_OSDisk_To_v1alpha4_OSDisk(in *OSDisk, out *v1alpha4.OSDisk
 
 // Convert_v1alpha4_OSDisk_To_v1alpha3_OSDisk converts from the Hub version (v1alpha4) of the AzureMachineStatus to this version.
 func Convert_v1alpha4_OSDisk_To_v1alpha3_OSDisk(in *v1alpha4.OSDisk, out *OSDisk, s apiconversion.Scope) error { // nolint
-	if err := autoConvert_v1alpha4_OSDisk_To_v1alpha3_OSDisk(in, out, s); err != nil {
-		return err
-	}
+	out.OSType = in.OSType
+	out.DiskSizeGB = in.DiskSizeGB
+	out.DiffDiskSettings = (*DiffDiskSettings)(in.DiffDiskSettings)
+	out.CachingType = in.CachingType
 
 	if in.ManagedDisk != nil {
 		out.ManagedDisk = ManagedDisk{}

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -358,6 +358,11 @@ const (
 )
 
 // OSDisk defines the operating system disk for a VM.
+//
+// WARNING: this requires any updates to ManagedDisk to be manually converted. This is due to the odd issue with
+// conversion-gen where the warning message generated uses a relative directory import rather than the fully
+// qualified import when generating outside of the GOPATH.
+// +k8s:conversion-gen=false
 type OSDisk struct {
 	OSType           string            `json:"osType"`
 	DiskSizeGB       int32             `json:"diskSizeGB"`

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -1296,24 +1296,6 @@ func autoConvert_v1alpha4_NetworkSpec_To_v1alpha3_NetworkSpec(in *v1alpha4.Netwo
 	return nil
 }
 
-func autoConvert_v1alpha3_OSDisk_To_v1alpha4_OSDisk(in *OSDisk, out *v1alpha4.OSDisk, s conversion.Scope) error {
-	out.OSType = in.OSType
-	out.DiskSizeGB = in.DiskSizeGB
-	// WARNING: in.ManagedDisk requires manual conversion: inconvertible types (sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3.ManagedDisk vs *sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4.ManagedDiskParameters)
-	out.DiffDiskSettings = (*v1alpha4.DiffDiskSettings)(unsafe.Pointer(in.DiffDiskSettings))
-	out.CachingType = in.CachingType
-	return nil
-}
-
-func autoConvert_v1alpha4_OSDisk_To_v1alpha3_OSDisk(in *v1alpha4.OSDisk, out *OSDisk, s conversion.Scope) error {
-	out.OSType = in.OSType
-	out.DiskSizeGB = in.DiskSizeGB
-	// WARNING: in.ManagedDisk requires manual conversion: inconvertible types (*sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4.ManagedDiskParameters vs sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3.ManagedDisk)
-	out.DiffDiskSettings = (*DiffDiskSettings)(unsafe.Pointer(in.DiffDiskSettings))
-	out.CachingType = in.CachingType
-	return nil
-}
-
 func autoConvert_v1alpha3_PublicIPSpec_To_v1alpha4_PublicIPSpec(in *PublicIPSpec, out *v1alpha4.PublicIPSpec, s conversion.Scope) error {
 	out.Name = in.Name
 	out.DNSName = in.DNSName

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -361,6 +361,10 @@ const (
 )
 
 // OSDisk defines the operating system disk for a VM.
+//
+// WARNING: this requires any updates to ManagedDisk to be manually converted. This is due to the odd issue with
+// conversion-gen where the warning message generated uses a relative directory import rather than the fully
+// qualified import when generating outside of the GOPATH.
 type OSDisk struct {
 	OSType     string `json:"osType"`
 	DiskSizeGB int32  `json:"diskSizeGB"`


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

When conversion-gen runs outside of the GOPATH, it will generate some resources with `./api/v1alpha3.TypeName` rather than the full import path of the resource `sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3.TypeName`. This seems to work fine when running conversion-gen in the GOPATH.

#1300 and #1332 are running into this issue. It seems to have started with #1321, ~~but I don't see any evidence that the issue should be caused by anything in that change set.~~

~~I do not see a clear cause for why this is happening, and after a messing around with each of the flags for conversion-gen, I've thrown up my hands and just used sed to manipulate the conversion-gen output. I'm not super proud, but it will fix the problem until we find a better solution.~~

Due to OSDisk and DataDisk needing `*ManageDisk` and `ManagedDisk` conversions which would require the same conversion func name with two different signatures, conversion-gen warns that manual conversion is needed, which #1321 properly handled. This PR tells conversion-gen not to generate conversions for OSDisk and handles the conversion in the custom converter func for OSDisk, which eliminates the warning message with the relative path.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
manually convert `OSDisk.ManagedDisk` to eliminate a non-deterministic warning from conversion-gen due to generating code outside of the GOPATH.
```
