### PR TITLE
[backport] Update CCM and CNM templates to v0.7.4

### DIFF
--- a/templates/addons/cloud-controller-manager.yaml
+++ b/templates/addons/cloud-controller-manager.yaml
@@ -151,7 +151,7 @@ spec:
   serviceAccountName: cloud-controller-manager
   containers:
     - name: cloud-controller-manager
-      image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.5.0
+      image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v0.7.4
       imagePullPolicy: IfNotPresent
       command: ["cloud-controller-manager"]
       args:

--- a/templates/addons/cloud-node-manager.yaml
+++ b/templates/addons/cloud-node-manager.yaml
@@ -66,7 +66,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cloud-node-manager
-          image: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.5.0
+          image: mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v0.7.4
           imagePullPolicy: IfNotPresent
           command:
             - cloud-node-manager


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Updates cloud-controller-manager and cloud-node-manager default versions to v0.7.4 in the templates. v0.7.3 fixes a bug in the cache for VMs when using "vmss" vmType.

Note that #1323 cannot be cleanly cherry-picked as the OOT template has been refactored to use ClusterResourceSets since v0.4.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
solves #857 for out of tree cloud-provider

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update CCM and CNM templates to v0.7.4
```
