### PR TITLE
Trailing comma breaks tilt

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -133,7 +133,7 @@ cat <<EOF > tilt-settings.json
       "AZURE_SUBSCRIPTION_ID_B64": "$(echo "${AZURE_SUBSCRIPTION_ID}" | tr -d '\n' | base64 | tr -d '\n')",
       "AZURE_TENANT_ID_B64": "$(echo "${AZURE_TENANT_ID}" | tr -d '\n' | base64 | tr -d '\n')",
       "AZURE_CLIENT_SECRET_B64": "$(echo "${AZURE_CLIENT_SECRET}" | tr -d '\n' | base64 | tr -d '\n')",
-      "AZURE_CLIENT_ID_B64": "$(echo "${AZURE_CLIENT_ID}" | tr -d '\n' | base64 | tr -d '\n')",
+      "AZURE_CLIENT_ID_B64": "$(echo "${AZURE_CLIENT_ID}" | tr -d '\n' | base64 | tr -d '\n')"
   }
 }
 EOF


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind documentation

**What this PR does / why we need it**:

With the trailing comma tilt complains with an error when trying to start
```
make tilt-up
./scripts/kind-with-registry.sh
cluster already exists, moving on
EXP_CLUSTER_RESOURCE_SET=true EXP_AKS=true EXP_MACHINE_POOL=true tilt up
Tilt started on http://localhost:10350/
v0.20.4, built 2021-05-24

(space) to open the browser
(s) to stream logs (--stream=true)
(t) to open legacy terminal mode (--legacy=true)
(ctrl-c) to exit
Opening browser: http://localhost:10350/
Opening in existing browser session.
Tilt started on http://localhost:10350/
v0.20.4, built 2021-05-24

Initial Build • (Tiltfile)
Beginning Tiltfile execution
ERROR: Traceback (most recent call last):
  /home/jose/dev/src/github.com/kubernetes-sigs/cluster-api-provider-azure/Tiltfile:28:26: in <toplevel>
  <builtin>: in read_json
Error: error parsing JSON from tilt-settings.json: invalid character '}' looking for beginning of object key string
^C
```

I'm using Tilt version
```
v0.20.4, built 2021-05-24
```

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
