### PR TITLE
Update cert_manager tilt extension to fix startup bug

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -149,7 +149,7 @@ def file_extension(filename):
 
 skipped_dirs = ['Godeps', 'third_party', '_gopath', '_output', '.git', 'cluster/env.sh',
                 "vendor", "test/e2e/generated/bindata.go", "hack/boilerplate/test",
-                "pkg/kubectl/generated/bindata.go"]
+                "pkg/kubectl/generated/bindata.go", "tilt_modules"]
 
 # list all the files contain 'DO NOT EDIT', but are not generated
 skipped_ungenerated_files = ['hack/lib/swagger.sh', 'hack/boilerplate/boilerplate.py']

--- a/tilt_modules/cert_manager/README.md
+++ b/tilt_modules/cert_manager/README.md
@@ -12,15 +12,15 @@ load('ext://cert_manager', 'deploy_cert_manager')
 deploy_cert_manager()
 ```
 
-This will deploy cert-manager to you cluster and checks it actually works.
+This will deploy cert-manager to your cluster and check that it actually works.
 
-If working with Kind, its is possible to pass `load_to_kind=True` to `deploy_cert_manager` so
-all the cert-manager images will be pre-pulled to your local environment and then loaded into Kind before installing. 
+If working with Kind, it's possible to pass `load_to_kind=True` to `deploy_cert_manager` so
+all the cert-manager images will be pre-pulled to your local environment and then loaded into Kind before installing.
 This speeds up your workflow if you're repeatedly destroying and recreating your kind cluster, as it doesn't
 have to pull the images over the network each time.
 
 The full list of parameters accepted by `deploy_cert_manager` includes:
 - `registry` from which images should be pulled, defaults to `quay.io/jetstack`
-- `version` of cert-manager to install, defaults to `v1.1.0`
+- `version` of cert-manager to install, defaults to `v1.3.1`
 - `load_to_kind` (see above), defaults to `False`
 - `kind_cluster_name`, defaults to `kind`

--- a/tilt_modules/cert_manager/Tiltfile
+++ b/tilt_modules/cert_manager/Tiltfile
@@ -26,13 +26,13 @@ spec:
 """
 
 # Deploys cert manager to your environment
-def deploy_cert_manager(registry="quay.io/jetstack", version="v1.1.0", load_to_kind=False, kind_cluster_name="kind"):
+def deploy_cert_manager(registry="quay.io/jetstack", version="v1.3.1", load_to_kind=False, kind_cluster_name="kind"):
     silent=True
-
     if version.startswith('v0'):
-        cert_manager_test_resources_versioned = cert_manager_test_resources.format(cert_manager_api_version='v1alpha2')
+      cert_manager_test_resources_versioned = cert_manager_test_resources.format(cert_manager_api_version='v1alpha2')
     else:
-        cert_manager_test_resources_versioned = cert_manager_test_resources.format(cert_manager_api_version='v1')
+      cert_manager_test_resources_versioned = cert_manager_test_resources.format(cert_manager_api_version='v1')
+
     if load_to_kind == True:
         print("Loading images to kind")
         # Prepull all the cert-manager images to your local environment and then load them directly into kind. This speeds up
@@ -44,6 +44,7 @@ def deploy_cert_manager(registry="quay.io/jetstack", version="v1.1.0", load_to_k
             local("kind load docker-image --name {} {}/{}:{}".format(kind_cluster_name, registry, image, version), quiet=silent, echo_off=silent)
 
     # apply the cert-manager manifest
+    # NOTE!
     # Applying the same manifest twice to same cluster kubectl get stuck with older versions of kubernetes/cert-manager.
     # https://github.com/jetstack/cert-manager/issues/3121
     print("Installing cert-manager")
@@ -58,6 +59,7 @@ def deploy_cert_manager(registry="quay.io/jetstack", version="v1.1.0", load_to_k
 
     # 2. create a test certificate
     print("Testing cert-manager")
-    local("cat << EOF | kubectl apply -f - " + cert_manager_test_resources_versioned + "EOF", quiet=silent, echo_off=silent)
+    # The webhook may refuse connections initially (despite the deployment being Available), so try several times.
+    local("for i in 1 2 3 4 5 6; do (kubectl apply -f - <<EOF" + cert_manager_test_resources_versioned + "EOF\n) && break || sleep 15; done", quiet=silent, echo_off=silent)
     local("kubectl wait --for=condition=Ready --timeout=300s -n cert-manager-test certificate/selfsigned-cert ", quiet=silent, echo_off=silent)
-    local("cat << EOF | kubectl delete -f - " + cert_manager_test_resources_versioned + "EOF", quiet=silent, echo_off=silent)
+    local("kubectl delete -f - <<EOF" + cert_manager_test_resources_versioned + "EOF", quiet=silent, echo_off=silent)

--- a/tilt_modules/cert_manager/test/Tiltfile
+++ b/tilt_modules/cert_manager/test/Tiltfile
@@ -1,0 +1,8 @@
+load('../Tiltfile', 'deploy_cert_manager')
+
+is_kind = k8s_context().startswith('kind-')
+deploy_cert_manager(load_to_kind=is_kind)
+
+local_resource(
+  name='verify-cert-manager',
+  cmd='kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager')

--- a/tilt_modules/cert_manager/test/test.sh
+++ b/tilt_modules/cert_manager/test/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+set -ex
+tilt ci
+tilt down --delete-namespaces

--- a/tilt_modules/extensions.json
+++ b/tilt_modules/extensions.json
@@ -3,7 +3,7 @@
     {
       "Name": "cert_manager",
       "ExtensionRegistry": "https://github.com/tilt-dev/tilt-extensions",
-      "TimeFetched": "2020-10-13T13:51:07.717747266-07:00"
+      "TimeFetched": "2021-05-26T11:04:53.552646-06:00"
     }
   ]
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Updates the pinned reference to the [cert_manager](https://github.com/tilt-dev/tilt-extensions/tree/master/cert_manager) tilt extension to include a fix for a startup error (see tilt-dev/tilt-extensions#178).

**Which issue(s) this PR fixes**:

Refs kubernetes-sigs/cluster-api#4559

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
