### PR TITLE
Adds additional tags to aks cluster managed by capz

### DIFF
--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -22,6 +22,7 @@ import (
 	"net"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-02-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -126,6 +127,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			Type: containerservice.SystemAssigned,
 		},
 		Location: &managedClusterSpec.Location,
+		Tags:     *to.StringMapPtr(managedClusterSpec.Tags),
 		ManagedClusterProperties: &containerservice.ManagedClusterProperties{
 			NodeResourceGroup: &managedClusterSpec.NodeResourceGroupName,
 			DNSPrefix:         &managedClusterSpec.Name,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds additional tags to the aks resources when provided in azuremanagedcontrolplane object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # None

**Special notes for your reviewer**: None

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**: None
```release-note
Additional Tags for managed clusters
```
