### PR TITLE
 🐛 fix deletion, speed up creation for aks clusters

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -19,7 +19,7 @@ settings = {
     "capi_version": "nightly_master_20210526",
     "cert_manager_version": "v1.1.0",
     "kubernetes_version": "v1.19.7",
-    "aks_kubernetes_version": "v1.18.8"
+    "aks_kubernetes_version": "v1.20.5"
 }
 
 keys = ["AZURE_SUBSCRIPTION_ID_B64", "AZURE_TENANT_ID_B64", "AZURE_CLIENT_SECRET_B64", "AZURE_CLIENT_ID_B64"]
@@ -96,7 +96,7 @@ def fixup_yaml_empty_arrays(yaml_str):
 
 def validate_auth():
     substitutions = settings.get("kustomize_substitutions", {})
-    missing = [k for k in keys if k not in substitutions]
+    missing = [k for k in keys if k not in substitutions and not os.environ.get(k)]
     if missing:
         fail("missing kustomize_substitutions keys {} in tilt-setting.json".format(missing))
 
@@ -195,7 +195,7 @@ def flavors():
     substitutions = settings.get("kustomize_substitutions", {})
     for key in keys:
         if key[-4:] == "_B64":
-            substitutions[key[:-4]] = base64_decode(substitutions[key])
+            os.environ[key[:-4]] = base64_decode(os.environ[key])
 
     ssh_pub_key_B64 = "AZURE_SSH_PUBLIC_KEY_B64"
     ssh_pub_key_path = "$HOME/.ssh/id_rsa.pub"

--- a/azure/errors.go
+++ b/azure/errors.go
@@ -22,12 +22,22 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 )
 
 // ErrNotOwned is returned when a resource can't be deleted because it isn't owned.
 var ErrNotOwned = errors.New("resource is not managed and cannot be deleted")
+
+const codeResourceGroupNotFound = "ResourceGroupNotFound"
+
+// ResourceGroupNotFound parses the error to check if it's a resource group not found error.
+func ResourceGroupNotFound(err error) bool {
+	derr := autorest.DetailedError{}
+	serr := &azure.ServiceError{}
+	return errors.As(err, &derr) && errors.As(derr.Original, &serr) && serr.Code == codeResourceGroupNotFound
+}
 
 // ResourceNotFound parses the error to check if it's a resource not found error.
 func ResourceNotFound(err error) bool {

--- a/azure/services/managedclusters/client.go
+++ b/azure/services/managedclusters/client.go
@@ -101,6 +101,9 @@ func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, name strin
 
 	future, err := ac.managedclusters.Delete(ctx, resourceGroupName, name)
 	if err != nil {
+		if azure.ResourceGroupNotFound(err) || azure.ResourceNotFound(err) {
+			return nil
+		}
 		return errors.Wrap(err, "failed to begin operation")
 	}
 	if err := future.WaitForCompletionRef(ctx, ac.managedclusters.Client); err != nil {

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -120,9 +120,10 @@ func (s *Service) Delete(ctx context.Context) error {
 
 	s.Scope.V(2).Info("deleting VNet", "VNet", vnetSpec.Name)
 	err := s.Client.Delete(ctx, vnetSpec.ResourceGroup, vnetSpec.Name)
-	if err != nil && azure.ResourceNotFound(err) {
-		// already deleted
-		return nil
+	if err != nil {
+		if azure.ResourceGroupNotFound(err) || azure.ResourceNotFound(err) {
+			return nil
+		}
 	}
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete VNet %s in resource group %s", vnetSpec.Name, vnetSpec.ResourceGroup)

--- a/exp/controllers/azuremangedcontrolplane_reconciler.go
+++ b/exp/controllers/azuremangedcontrolplane_reconciler.go
@@ -147,6 +147,11 @@ func (r *azureManagedControlPlaneReconciler) Delete(ctx context.Context, scope *
 		return errors.Wrapf(err, "failed to delete managed cluster %s", scope.ControlPlane.Name)
 	}
 
+	scope.V(2).Info("Deleting virtual network")
+	if err := r.vnetSvc.Delete(ctx); err != nil {
+		return errors.Wrap(err, "failed to delete virtual network")
+	}
+
 	scope.V(2).Info("Deleting managed cluster resource group")
 	if err := r.groupsSvc.Delete(ctx); err != nil {
 		return errors.Wrap(err, "failed to delete managed cluster resource group")

--- a/exp/controllers/helpers.go
+++ b/exp/controllers/helpers.go
@@ -112,9 +112,9 @@ func AzureManagedClusterToAzureManagedMachinePoolsMapper(ctx context.Context, c 
 			return nil
 		}
 
-		log = log.WithValues("AzureCluster", azCluster.Name, "Namespace", azCluster.Namespace)
+		log = log.WithValues("AzureManagedCluster", azCluster.Name, "Namespace", azCluster.Namespace)
 
-		// Don't handle deleted AzureClusters
+		// Don't handle deleted AzureManagedClusters
 		if !azCluster.ObjectMeta.DeletionTimestamp.IsZero() {
 			log.V(4).Info("AzureManagedCluster has a deletion timestamp, skipping mapping.")
 			return nil
@@ -145,6 +145,59 @@ func AzureManagedClusterToAzureManagedMachinePoolsMapper(ctx context.Context, c 
 	}, nil
 }
 
+// AzureManagedControlPlaneToAzureManagedMachinePoolsMapper creates a mapping handler to transform AzureManagedControlPlanes into
+// AzureManagedMachinePools. The transform requires AzureManagedControlPlane to map to the owning Cluster, then from the
+// Cluster, collect the MachinePools belonging to the cluster, then finally projecting the infrastructure reference
+// to the AzureManagedMachinePools.
+func AzureManagedControlPlaneToAzureManagedMachinePoolsMapper(ctx context.Context, c client.Client, scheme *runtime.Scheme, log logr.Logger) (handler.MapFunc, error) {
+	gvk, err := apiutil.GVKForObject(new(infrav1exp.AzureManagedMachinePool), scheme)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to find GVK for AzureManagedMachinePool")
+	}
+
+	return func(o client.Object) []ctrl.Request {
+		ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultMappingTimeout)
+		defer cancel()
+
+		azControlPlane, ok := o.(*infrav1exp.AzureManagedControlPlane)
+		if !ok {
+			log.Error(errors.Errorf("expected an AzureManagedControlPlane, got %T instead", o.GetObjectKind()), "failed to map AzureManagedControlPlane")
+			return nil
+		}
+
+		log = log.WithValues("AzureManagedControlPlane", azControlPlane.Name, "Namespace", azControlPlane.Namespace)
+
+		// Don't handle deleted AzureManagedControlPlanes
+		if !azControlPlane.ObjectMeta.DeletionTimestamp.IsZero() {
+			log.V(4).Info("AzureManagedControlPlane has a deletion timestamp, skipping mapping.")
+			return nil
+		}
+
+		clusterName, ok := controllers.GetOwnerClusterName(azControlPlane.ObjectMeta)
+		if !ok {
+			log.Info("unable to get the owner cluster")
+			return nil
+		}
+
+		machineList := &clusterv1exp.MachinePoolList{}
+		machineList.SetGroupVersionKind(gvk)
+		// list all of the requested objects within the cluster namespace with the cluster name label
+		if err := c.List(ctx, machineList, client.InNamespace(azControlPlane.Namespace), client.MatchingLabels{clusterv1.ClusterLabelName: clusterName}); err != nil {
+			return nil
+		}
+
+		mapFunc := MachinePoolToInfrastructureMapFunc(gvk, log)
+		var results []ctrl.Request
+		for _, machine := range machineList.Items {
+			m := machine
+			azureMachines := mapFunc(&m)
+			results = append(results, azureMachines...)
+		}
+
+		return results
+	}, nil
+}
+
 // AzureManagedClusterToAzureManagedControlPlaneMapper creates a mapping handler to transform AzureManagedClusters into
 // AzureManagedControlPlane. The transform requires AzureManagedCluster to map to the owning Cluster, then from the
 // Cluster, collect the control plane infrastructure reference.
@@ -159,9 +212,9 @@ func AzureManagedClusterToAzureManagedControlPlaneMapper(ctx context.Context, c 
 			return nil
 		}
 
-		log = log.WithValues("AzureCluster", azCluster.Name, "Namespace", azCluster.Namespace)
+		log = log.WithValues("AzureManagedCluster", azCluster.Name, "Namespace", azCluster.Namespace)
 
-		// Don't handle deleted AzureClusters
+		// Don't handle deleted AzureManagedClusters
 		if !azCluster.ObjectMeta.DeletionTimestamp.IsZero() {
 			log.V(4).Info("AzureManagedCluster has a deletion timestamp, skipping mapping.")
 			return nil
@@ -192,6 +245,139 @@ func AzureManagedClusterToAzureManagedControlPlaneMapper(ctx context.Context, c 
 			},
 		}
 	}, nil
+}
+
+// AzureManagedControlPlaneToAzureManagedClusterMapper creates a mapping handler to transform AzureManagedClusters into
+// AzureManagedControlPlane. The transform requires AzureManagedCluster to map to the owning Cluster, then from the
+// Cluster, collect the control plane infrastructure reference.
+func AzureManagedControlPlaneToAzureManagedClusterMapper(ctx context.Context, c client.Client, log logr.Logger) (handler.MapFunc, error) {
+	return func(o client.Object) []ctrl.Request {
+		ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultMappingTimeout)
+		defer cancel()
+
+		azManagedControlPlane, ok := o.(*infrav1exp.AzureManagedControlPlane)
+		if !ok {
+			log.Error(errors.Errorf("expected an AzureManagedControlPlane, got %T instead", o), "failed to map AzureManagedControlPlane")
+			return nil
+		}
+
+		log = log.WithValues("AzureManagedControlPlane", azManagedControlPlane.Name, "Namespace", azManagedControlPlane.Namespace)
+
+		// Don't handle deleted AzureManagedControlPlanes
+		if !azManagedControlPlane.ObjectMeta.DeletionTimestamp.IsZero() {
+			log.V(4).Info("AzureManagedControlPlane has a deletion timestamp, skipping mapping.")
+			return nil
+		}
+
+		cluster, err := util.GetOwnerCluster(ctx, c, azManagedControlPlane.ObjectMeta)
+		if err != nil {
+			log.Error(err, "failed to get the owning cluster")
+			return nil
+		}
+
+		if cluster == nil {
+			log.Error(err, "cluster has not set owner ref yet")
+			return nil
+		}
+
+		ref := cluster.Spec.InfrastructureRef
+		if ref == nil || ref.Name == "" {
+			return nil
+		}
+
+		return []ctrl.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: ref.Namespace,
+					Name:      ref.Name,
+				},
+			},
+		}
+	}, nil
+}
+
+// MachinePoolToAzureManagedControlPlaneMapFunc returns a handler.MapFunc that watches for
+// MachinePool events and returns reconciliation requests for a control plane object.
+func MachinePoolToAzureManagedControlPlaneMapFunc(ctx context.Context, c client.Client, gvk schema.GroupVersionKind, log logr.Logger) handler.MapFunc {
+	return func(o client.Object) []reconcile.Request {
+		ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultMappingTimeout)
+		defer cancel()
+
+		machinePool, ok := o.(*clusterv1exp.MachinePool)
+		if !ok {
+			log.Info("expected a MachinePool, got wrong type", "type", fmt.Sprintf("%T", o))
+			return nil
+		}
+
+		cluster, err := util.GetClusterByName(ctx, c, machinePool.ObjectMeta.Namespace, machinePool.Spec.ClusterName)
+		if err != nil {
+			log.Error(err, "failed to get the owning cluster")
+			return nil
+		}
+
+		gk := gvk.GroupKind()
+		ref := cluster.Spec.ControlPlaneRef
+		// Return early if the GroupKind doesn't match what we expect.
+		controlPlaneGK := ref.GroupVersionKind().GroupKind()
+		if gk != controlPlaneGK {
+			log.Info("gk does not match", "gk", gk, "controlPlaneGK", controlPlaneGK)
+			return nil
+		}
+
+		controlPlaneKey := client.ObjectKey{
+			Name:      ref.Name,
+			Namespace: ref.Namespace,
+		}
+		controlPlane := &infrav1exp.AzureManagedControlPlane{}
+		if err := c.Get(ctx, controlPlaneKey, controlPlane); err != nil {
+			log.Error(err, "failed to fetch default pool reference")
+			// If we get here, we might want to reconcile but aren't sure.
+			// Do it anyway to be safe. Worst case we reconcile a few extra times with no-ops.
+			return []reconcile.Request{
+				{
+					NamespacedName: client.ObjectKey{
+						Namespace: ref.Namespace,
+						Name:      ref.Name,
+					},
+				},
+			}
+		}
+
+		infraMachinePoolRef := machinePool.Spec.Template.Spec.InfrastructureRef
+
+		gv, err := schema.ParseGroupVersion(infraMachinePoolRef.APIVersion)
+		if err != nil {
+			log.Error(err, "failed to parse group version")
+			// If we get here, we might want to reconcile but aren't sure.
+			// Do it anyway to be safe. Worst case we reconcile a few extra times with no-ops.
+			return []reconcile.Request{
+				{
+					NamespacedName: client.ObjectKey{
+						Namespace: ref.Namespace,
+						Name:      ref.Name,
+					},
+				},
+			}
+		}
+
+		nameMatches := controlPlane.Spec.DefaultPoolRef.Name == infraMachinePoolRef.Name
+		kindMatches := infraMachinePoolRef.Kind == "AzureManagedMachinePool"
+		groupMatches := controlPlaneGK.Group == gv.Group
+
+		if groupMatches && kindMatches && nameMatches {
+			return []reconcile.Request{
+				{
+					NamespacedName: client.ObjectKey{
+						Namespace: ref.Namespace,
+						Name:      ref.Name,
+					},
+				},
+			}
+		}
+
+		// By default, return nothing for a machine pool which is not the default pool for a control plane.
+		return nil
+	}
 }
 
 // MachinePoolToInfrastructureMapFunc returns a handler.MapFunc that watches for

--- a/exp/controllers/helpers_test.go
+++ b/exp/controllers/helpers_test.go
@@ -39,10 +39,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/internal/test/mock_log"
 )
 
+var (
+	cpName      = "my-managed-cp"
+	clusterName = "my-cluster"
+)
+
 func TestAzureClusterToAzureMachinePoolsMapper(t *testing.T) {
 	g := NewWithT(t)
 	scheme := newScheme(g)
-	clusterName := "my-cluster"
 	initObjects := []runtime.Object{
 		newCluster(clusterName),
 		// Create two Machines with an infrastructure ref and one without.
@@ -77,7 +81,6 @@ func TestAzureClusterToAzureMachinePoolsMapper(t *testing.T) {
 func TestAzureManagedClusterToAzureManagedMachinePoolsMapper(t *testing.T) {
 	g := NewWithT(t)
 	scheme := newScheme(g)
-	clusterName := "my-cluster"
 	initObjects := []runtime.Object{
 		newCluster(clusterName),
 		// Create two Machines with an infrastructure ref and one without.
@@ -89,7 +92,7 @@ func TestAzureManagedClusterToAzureManagedMachinePoolsMapper(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 	log := mock_log.NewMockLogger(gomock.NewController(t))
-	log.EXPECT().WithValues("AzureCluster", "my-cluster", "Namespace", "default").Return(log)
+	log.EXPECT().WithValues("AzureManagedCluster", "my-cluster", "Namespace", "default").Return(log)
 	log.EXPECT().Info("gk does not match", "gk", gomock.Any(), "infraGK", gomock.Any())
 	mapper, err := AzureManagedClusterToAzureManagedMachinePoolsMapper(context.Background(), fakeClient, scheme, log)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -129,10 +132,168 @@ func TestAzureManagedClusterToAzureManagedMachinePoolsMapper(t *testing.T) {
 	}))
 }
 
+func TestAzureManagedControlPlaneToAzureManagedMachinePoolsMapper(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newScheme(g)
+	cluster := newCluster("my-cluster")
+	cluster.Spec.ControlPlaneRef = &corev1.ObjectReference{
+		APIVersion: infrav1exp.GroupVersion.String(),
+		Kind:       "AzureManagedControlPlane",
+		Name:       cpName,
+		Namespace:  cluster.Namespace,
+	}
+	initObjects := []runtime.Object{
+		cluster,
+		newAzureManagedControlPlane(cpName),
+		// Create two Machines with an infrastructure ref and one without.
+		newManagedMachinePoolInfraReference(clusterName, "my-mmp-0"),
+		newManagedMachinePoolInfraReference(clusterName, "my-mmp-1"),
+		newManagedMachinePoolInfraReference(clusterName, "my-mmp-2"),
+		newMachinePool(clusterName, "my-machine-2"),
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
+
+	log := mock_log.NewMockLogger(gomock.NewController(t))
+	log.EXPECT().WithValues("AzureManagedControlPlane", cpName, "Namespace", cluster.Namespace).Return(log)
+	log.EXPECT().Info("gk does not match", "gk", gomock.Any(), "infraGK", gomock.Any())
+	mapper, err := AzureManagedControlPlaneToAzureManagedMachinePoolsMapper(context.Background(), fakeClient, scheme, log)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	requests := mapper(&infrav1exp.AzureManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cpName,
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name:       cluster.Name,
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+			},
+		},
+	})
+	g.Expect(requests).To(ConsistOf([]reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      "azuremy-mmp-0",
+				Namespace: "default",
+			},
+		},
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      "azuremy-mmp-1",
+				Namespace: "default",
+			},
+		},
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      "azuremy-mmp-2",
+				Namespace: "default",
+			},
+		},
+	}))
+}
+
+func TestMachinePoolToAzureManagedControlPlaneMapFuncSuccess(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newScheme(g)
+	cluster := newCluster(clusterName)
+	controlPlane := newAzureManagedControlPlane(cpName)
+	cluster.Spec.ControlPlaneRef = &corev1.ObjectReference{
+		APIVersion: infrav1exp.GroupVersion.String(),
+		Kind:       "AzureManagedControlPlane",
+		Name:       cpName,
+		Namespace:  cluster.Namespace,
+	}
+	controlPlane.Spec.DefaultPoolRef.Name = "azuremy-mmp-0"
+	managedMachinePool := newManagedMachinePoolInfraReference(clusterName, "my-mmp-0")
+	managedMachinePool.Spec.ClusterName = clusterName
+	initObjects := []runtime.Object{
+		cluster,
+		controlPlane,
+		managedMachinePool,
+		// Create two Machines with an infrastructure ref and one without.
+		newManagedMachinePoolInfraReference(clusterName, "my-mmp-1"),
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
+
+	log := mock_log.NewMockLogger(gomock.NewController(t))
+	log.EXPECT().WithValues("AzureManagedControlPlane", cpName, "Namespace", cluster.Namespace).Return(log)
+	log.EXPECT().Info("expected a MachinePool, got wrong type", "type", gomock.Any())
+	mapper := MachinePoolToAzureManagedControlPlaneMapFunc(context.Background(), fakeClient, infrav1exp.GroupVersion.WithKind("AzureManagedControlPlane"), log)
+
+	// default pool should trigger
+	requests := mapper(newManagedMachinePoolInfraReference(clusterName, "my-mmp-0"))
+	g.Expect(requests).To(ConsistOf([]reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      "my-managed-cp",
+				Namespace: "default",
+			},
+		},
+	}))
+
+	// any other pool should not trigger
+	requests = mapper(newManagedMachinePoolInfraReference(clusterName, "my-mmp-1"))
+	g.Expect(requests).To(BeNil())
+}
+
+func TestMachinePoolToAzureManagedControlPlaneMapFuncFailure(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newScheme(g)
+	cluster := newCluster(clusterName)
+	controlPlane := newAzureManagedControlPlane(cpName)
+	cluster.Spec.ControlPlaneRef = &corev1.ObjectReference{
+		APIVersion: infrav1exp.GroupVersion.String(),
+		Kind:       "AzureManagedControlPlane",
+		Name:       cpName,
+		Namespace:  cluster.Namespace,
+	}
+	controlPlane.Spec.DefaultPoolRef.Name = "azuremy-mmp-0"
+	managedMachinePool := newManagedMachinePoolInfraReference(clusterName, "my-mmp-0")
+	managedMachinePool.Spec.ClusterName = clusterName
+	initObjects := []runtime.Object{
+		cluster,
+		managedMachinePool,
+		// Create two Machines with an infrastructure ref and one without.
+		newManagedMachinePoolInfraReference(clusterName, "my-mmp-1"),
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
+
+	log := mock_log.NewMockLogger(gomock.NewController(t))
+	log.EXPECT().WithValues("AzureManagedControlPlane", cpName, "Namespace", cluster.Namespace).Return(log)
+	log.EXPECT().Info("expected a MachinePool, got wrong type", "type", gomock.Any())
+	log.EXPECT().Error(gomock.Any(), "failed to fetch default pool reference")
+	log.EXPECT().Error(gomock.Any(), "failed to fetch default pool reference") // twice because we are testing two calls
+
+	mapper := MachinePoolToAzureManagedControlPlaneMapFunc(context.Background(), fakeClient, infrav1exp.GroupVersion.WithKind("AzureManagedControlPlane"), log)
+
+	// default pool should trigger if owned cluster could not be fetched
+	requests := mapper(newManagedMachinePoolInfraReference(clusterName, "my-mmp-0"))
+	g.Expect(requests).To(ConsistOf([]reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      "my-managed-cp",
+				Namespace: "default",
+			},
+		},
+	}))
+
+	// any other pool should also trigger if owned cluster could not be fetched
+	requests = mapper(newManagedMachinePoolInfraReference(clusterName, "my-mmp-1"))
+	g.Expect(requests).To(ConsistOf([]reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      "my-managed-cp",
+				Namespace: "default",
+			},
+		},
+	}))
+}
+
 func TestAzureManagedClusterToAzureManagedControlPlaneMapper(t *testing.T) {
 	g := NewWithT(t)
 	scheme := newScheme(g)
-	cpName := "my-managed-cp"
 	cluster := newCluster("my-cluster")
 	cluster.Spec.ControlPlaneRef = &corev1.ObjectReference{
 		APIVersion: infrav1exp.GroupVersion.String(),
@@ -148,7 +309,7 @@ func TestAzureManagedClusterToAzureManagedControlPlaneMapper(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 	log := mock_log.NewMockLogger(gomock.NewController(t))
-	log.EXPECT().WithValues("AzureCluster", "az-"+cluster.Name, "Namespace", "default")
+	log.EXPECT().WithValues("AzureManagedCluster", "az-"+cluster.Name, "Namespace", "default")
 
 	mapper, err := AzureManagedClusterToAzureManagedControlPlaneMapper(context.Background(), fakeClient, log)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -171,6 +332,73 @@ func TestAzureManagedClusterToAzureManagedControlPlaneMapper(t *testing.T) {
 			NamespacedName: types.NamespacedName{
 				Name:      cpName,
 				Namespace: cluster.Namespace,
+			},
+		},
+	}))
+}
+
+func TestAzureManagedControlPlaneToAzureManagedClusterMapper(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newScheme(g)
+	cluster := newCluster("my-cluster")
+	azManagedCluster := &infrav1exp.AzureManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "az-" + cluster.Name,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name:       cluster.Name,
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+			},
+		},
+	}
+
+	cluster.Spec.ControlPlaneRef = &corev1.ObjectReference{
+		APIVersion: infrav1exp.GroupVersion.String(),
+		Kind:       "AzureManagedControlPlane",
+		Name:       cpName,
+		Namespace:  cluster.Namespace,
+	}
+	cluster.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: infrav1exp.GroupVersion.String(),
+		Kind:       "AzureManagedCluster",
+		Name:       azManagedCluster.Name,
+		Namespace:  azManagedCluster.Namespace,
+	}
+
+	initObjects := []runtime.Object{
+		cluster,
+		newAzureManagedControlPlane(cpName),
+		azManagedCluster,
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
+
+	log := mock_log.NewMockLogger(gomock.NewController(t))
+	log.EXPECT().WithValues("AzureManagedControlPlane", cpName, "Namespace", cluster.Namespace)
+
+	mapper, err := AzureManagedControlPlaneToAzureManagedClusterMapper(context.Background(), fakeClient, log)
+	g.Expect(err).NotTo(HaveOccurred())
+	requests := mapper(&infrav1exp.AzureManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cpName,
+			Namespace: cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name:       cluster.Name,
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+			},
+		},
+	})
+	g.Expect(requests).To(HaveLen(1))
+	g.Expect(requests).To(Equal([]reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      azManagedCluster.Name,
+				Namespace: azManagedCluster.Namespace,
 			},
 		},
 	}))
@@ -392,6 +620,7 @@ func newAzureManagedControlPlane(cpName string) *infrav1exp.AzureManagedControlP
 
 func newManagedMachinePoolInfraReference(clusterName, poolName string) *clusterv1exp.MachinePool {
 	m := newMachinePool(clusterName, poolName)
+	m.Spec.ClusterName = clusterName
 	m.Spec.Template.Spec.InfrastructureRef = corev1.ObjectReference{
 		Kind:       "AzureManagedMachinePool",
 		Namespace:  m.Namespace,

--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -7,7 +7,7 @@
       "go.mod",
       "go.sum",
       "api",
-      "cloud",
+      "azure",
       "controllers",
       "pkg",
       "exp"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
- fixes [circular deletion dependencies](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1395#issuecomment-849982900)
- fixes [CAPZ-managed vnet deletion for BYO resource groups](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1395#issuecomment-850037786).
- Cluster infra ref needs to be ready before CAPI will reconcile the control plane ref. hardcode AzureManagedCluster.Status.Ready to true, since it's meaningless anyway. This speeds up provisioning, since CAPI controllers don't need to wait for AKS to be ready for the field to be true.
- AzureManagedCluster needs to be reconciled from AzureManagedControlPlane events so it can sync its status. We should implement https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1396 and avoid this dance entirely.
- AzureManagedMachinePool doesn't need to watch AzureManagedCluster, since cluster just copies from AzureManagedControlPlane, and it gets the owner cluster from the owning machine pool already.
- If the MachinePool owning the defaultPool of an AzureManagedControlPlane is nil when we try to reconcile, we need to re-reconcile. We can either return an error or watch machinePools and filter them down to the one owning the defaultPool (more accurate, but requires watching and filtering all machinePool events). I implemented the latter.
- Add a `ResourceGroupNotFound` error check during deletion. I accidentally put two CAPZ clusters in one RG. Deleting one deleted the RG, but then the other failed with "ResourceGroupNotFound" which unfortunately does not manifest as 404, because autorest wraps it as a StatusCode: 0.
- Don't fail tilt-up so long as the environment already has Azure credentials defined.
- Bump AKS version default to v1.20.5

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1395

**Special notes for your reviewer**:


**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Fix deletion and speed up provisioning for CAPI clusters using AzureManagedCluster + AzureManagedControlPlane (AKS).
```
