### PR TITLE
Save subnet details back to scope

### DIFF
--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -64,6 +64,7 @@ type NetworkDescriber interface {
 	IsVnetManaged() bool
 	NodeSubnet() infrav1.SubnetSpec
 	ControlPlaneSubnet() infrav1.SubnetSpec
+	SetSubnet(infrav1.SubnetSpec)
 	IsIPv6Enabled() bool
 	NodeRouteTable() infrav1.RouteTable
 	ControlPlaneRouteTable() infrav1.RouteTable

--- a/azure/mocks/service_mock.go
+++ b/azure/mocks/service_mock.go
@@ -523,6 +523,18 @@ func (mr *MockNetworkDescriberMockRecorder) OutboundPoolName(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OutboundPoolName", reflect.TypeOf((*MockNetworkDescriber)(nil).OutboundPoolName), arg0)
 }
 
+// SetSubnet mocks base method.
+func (m *MockNetworkDescriber) SetSubnet(arg0 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockNetworkDescriberMockRecorder) SetSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockNetworkDescriber)(nil).SetSubnet), arg0)
+}
+
 // Vnet mocks base method.
 func (m *MockNetworkDescriber) Vnet() *v1alpha4.VnetSpec {
 	m.ctrl.T.Helper()
@@ -1113,6 +1125,18 @@ func (m *MockClusterScoper) ResourceGroup() string {
 func (mr *MockClusterScoperMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockClusterScoper)(nil).ResourceGroup))
+}
+
+// SetSubnet mocks base method.
+func (m *MockClusterScoper) SetSubnet(arg0 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockClusterScoperMockRecorder) SetSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockClusterScoper)(nil).SetSubnet), arg0)
 }
 
 // SubscriptionID mocks base method.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -322,6 +322,16 @@ func (s *ClusterScope) NodeSubnet() infrav1.SubnetSpec {
 	return subnet
 }
 
+// SetSubnet sets the subnet spec for the subnet with the same role.
+func (s *ClusterScope) SetSubnet(subnetSpec infrav1.SubnetSpec) {
+	for i, sn := range s.AzureCluster.Spec.NetworkSpec.Subnets {
+		if sn.Role == subnetSpec.Role {
+			s.AzureCluster.Spec.NetworkSpec.Subnets[i] = subnetSpec
+			return
+		}
+	}
+}
+
 // ControlPlaneRouteTable returns the cluster controlplane routetable.
 func (s *ClusterScope) ControlPlaneRouteTable() infrav1.RouteTable {
 	subnet, _ := s.AzureCluster.Spec.NetworkSpec.GetControlPlaneSubnet()

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -198,6 +198,12 @@ func (s *ManagedControlPlaneScope) NodeSubnet() infrav1.SubnetSpec {
 	}
 }
 
+// SetSubnet sets the passed subnet spec into the scope.
+// This is not used when using a managed control plane.
+func (s *ManagedControlPlaneScope) SetSubnet(subnetSpec infrav1.SubnetSpec) {
+	// no-op
+}
+
 // ControlPlaneSubnet returns the cluster control plane subnet.
 func (s *ManagedControlPlaneScope) ControlPlaneSubnet() infrav1.SubnetSpec {
 	return infrav1.SubnetSpec{}

--- a/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -451,6 +451,18 @@ func (mr *MockBastionScopeMockRecorder) ResourceGroup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockBastionScope)(nil).ResourceGroup))
 }
 
+// SetSubnet mocks base method.
+func (m *MockBastionScope) SetSubnet(arg0 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockBastionScopeMockRecorder) SetSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockBastionScope)(nil).SetSubnet), arg0)
+}
+
 // SubscriptionID mocks base method.
 func (m *MockBastionScope) SubscriptionID() string {
 	m.ctrl.T.Helper()

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -451,6 +451,18 @@ func (mr *MockLBScopeMockRecorder) ResourceGroup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockLBScope)(nil).ResourceGroup))
 }
 
+// SetSubnet mocks base method.
+func (m *MockLBScope) SetSubnet(arg0 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockLBScopeMockRecorder) SetSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockLBScope)(nil).SetSubnet), arg0)
+}
+
 // SubscriptionID mocks base method.
 func (m *MockLBScope) SubscriptionID() string {
 	m.ctrl.T.Helper()

--- a/azure/services/routetables/mock_routetables/routetables_mock.go
+++ b/azure/services/routetables/mock_routetables/routetables_mock.go
@@ -451,6 +451,18 @@ func (mr *MockRouteTableScopeMockRecorder) RouteTableSpecs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteTableSpecs", reflect.TypeOf((*MockRouteTableScope)(nil).RouteTableSpecs))
 }
 
+// SetSubnet mocks base method.
+func (m *MockRouteTableScope) SetSubnet(arg0 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockRouteTableScopeMockRecorder) SetSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockRouteTableScope)(nil).SetSubnet), arg0)
+}
+
 // SubscriptionID mocks base method.
 func (m *MockRouteTableScope) SubscriptionID() string {
 	m.ctrl.T.Helper()

--- a/azure/services/routetables/routetables.go
+++ b/azure/services/routetables/routetables.go
@@ -72,6 +72,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			// currently don't support specifying your own routes via spec
 			routeTableSpec.Subnet.RouteTable.Name = to.String(existingRouteTable.Name)
 			routeTableSpec.Subnet.RouteTable.ID = to.String(existingRouteTable.ID)
+			s.Scope.SetSubnet(routeTableSpec.Subnet)
 
 			continue
 		}

--- a/azure/services/routetables/routetables_test.go
+++ b/azure/services/routetables/routetables_test.go
@@ -142,6 +142,14 @@ func TestReconcileRouteTables(t *testing.T) {
 					Name: to.StringPtr("my-cp-routetable"),
 					ID:   to.StringPtr("1"),
 				}, nil)
+				s.SetSubnet(infrav1.SubnetSpec{
+					Name: "control-plane-subnet",
+					Role: infrav1.SubnetControlPlane,
+					RouteTable: infrav1.RouteTable{
+						ID:   "1",
+						Name: "my-cp-routetable",
+					},
+				}).Times(1)
 				s.NodeSubnet().AnyTimes().Return(infrav1.SubnetSpec{Name: "node-subnet", Role: infrav1.SubnetNode})
 				s.NodeRouteTable().AnyTimes().Return(infrav1.RouteTable{Name: "my-node-routetable"})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -149,6 +157,14 @@ func TestReconcileRouteTables(t *testing.T) {
 					Name: to.StringPtr("my-node-routetable"),
 					ID:   to.StringPtr("2"),
 				}, nil)
+				s.SetSubnet(infrav1.SubnetSpec{
+					Name: "node-subnet",
+					Role: infrav1.SubnetNode,
+					RouteTable: infrav1.RouteTable{
+						ID:   "2",
+						Name: "my-node-routetable",
+					},
+				}).Times(1)
 			},
 		},
 		{

--- a/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
+++ b/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
@@ -451,6 +451,18 @@ func (mr *MockNSGScopeMockRecorder) ResourceGroup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockNSGScope)(nil).ResourceGroup))
 }
 
+// SetSubnet mocks base method.
+func (m *MockNSGScope) SetSubnet(arg0 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockNSGScopeMockRecorder) SetSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockNSGScope)(nil).SetSubnet), arg0)
+}
+
 // SubscriptionID mocks base method.
 func (m *MockNSGScope) SubscriptionID() string {
 	m.ctrl.T.Helper()

--- a/azure/services/subnets/mock_subnets/subnets_mock.go
+++ b/azure/services/subnets/mock_subnets/subnets_mock.go
@@ -437,6 +437,18 @@ func (mr *MockSubnetScopeMockRecorder) ResourceGroup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockSubnetScope)(nil).ResourceGroup))
 }
 
+// SetSubnet mocks base method.
+func (m *MockSubnetScope) SetSubnet(arg0 v1alpha4.SubnetSpec) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSubnet", arg0)
+}
+
+// SetSubnet indicates an expected call of SetSubnet.
+func (mr *MockSubnetScopeMockRecorder) SetSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockSubnetScope)(nil).SetSubnet), arg0)
+}
+
 // SubnetSpecs mocks base method.
 func (m *MockSubnetScope) SubnetSpecs() []azure.SubnetSpec {
 	m.ctrl.T.Helper()

--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -72,10 +72,10 @@ func (s *Service) Reconcile(ctx context.Context) error {
 				continue
 			}
 
-			subnet.Role = subnetSpec.Role
-			subnet.Name = existingSubnet.Name
-			subnet.CIDRBlocks = existingSubnet.CIDRBlocks
 			subnet.ID = existingSubnet.ID
+			subnet.CIDRBlocks = existingSubnet.CIDRBlocks
+
+			s.Scope.SetSubnet(subnet)
 
 		case !s.Scope.IsVnetManaged():
 			return fmt.Errorf("vnet was provided but subnet %s is missing", subnetSpec.Name)

--- a/azure/services/subnets/subnets_test.go
+++ b/azure/services/subnets/subnets_test.go
@@ -236,6 +236,12 @@ func TestReconcileSubnets(t *testing.T) {
 							},
 						},
 					}, nil)
+				s.SetSubnet(infrav1.SubnetSpec{
+					ID:         "subnet-id",
+					Name:       "my-subnet",
+					Role:       infrav1.SubnetNode,
+					CIDRBlocks: []string{"10.0.0.0/16"},
+				}).Times(1)
 				m.Get(gomockinternal.AContext(), "", "my-vnet", "my-subnet-1").
 					Return(network.Subnet{
 						ID:   to.StringPtr("subnet-id-1"),
@@ -252,6 +258,12 @@ func TestReconcileSubnets(t *testing.T) {
 							},
 						},
 					}, nil)
+				s.SetSubnet(infrav1.SubnetSpec{
+					ID:         "subnet-id-1",
+					Name:       "my-subnet-1",
+					Role:       infrav1.SubnetControlPlane,
+					CIDRBlocks: []string{"10.2.0.0/16"},
+				}).Times(1)
 			},
 		},
 		{
@@ -309,6 +321,12 @@ func TestReconcileSubnets(t *testing.T) {
 							},
 						},
 					}, nil)
+				s.SetSubnet(infrav1.SubnetSpec{
+					ID:         "subnet-id",
+					Name:       "my-subnet",
+					Role:       infrav1.SubnetNode,
+					CIDRBlocks: []string{"10.0.0.0/16", "2001:1234:5678:9abd::/64"},
+				}).Times(1)
 				m.Get(gomockinternal.AContext(), "", "my-vnet", "my-ipv6-subnet-cp").
 					Return(network.Subnet{
 						ID:   to.StringPtr("subnet-id-1"),
@@ -328,6 +346,12 @@ func TestReconcileSubnets(t *testing.T) {
 							},
 						},
 					}, nil)
+				s.SetSubnet(infrav1.SubnetSpec{
+					ID:         "subnet-id-1",
+					Name:       "my-subnet-1",
+					Role:       infrav1.SubnetControlPlane,
+					CIDRBlocks: []string{"10.2.0.0/16", "2001:1234:5678:9abc::/64"},
+				}).Times(1)
 			},
 		},
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind bug

**What this PR does / why we need it**:

When `SubnetSpec` was changed to not be a pointer in #1144 we were not saving the Subnet details in the scope.


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Save subnet details back to scope when reconciling already existing subnets
```
