### PR TITLE
Update Windows VM naming

### DIFF
--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -267,14 +267,12 @@ func (m *MachineScope) AvailabilityZone() string {
 
 // Name returns the AzureMachine name.
 func (m *MachineScope) Name() string {
+	if id := m.GetVMID(); id != "" {
+		return id
+	}
 	// Windows Machine names cannot be longer than 15 chars
 	if m.AzureMachine.Spec.OSDisk.OSType == azure.WindowsOS && len(m.AzureMachine.Name) > 15 {
-		clustername := m.ClusterName()
-		if len(m.ClusterName()) > 9 {
-			clustername = strings.TrimSuffix(clustername[0:9], "-")
-		}
-
-		return clustername + "-" + m.AzureMachine.Name[len(m.AzureMachine.Name)-5:]
+		return strings.TrimSuffix(m.AzureMachine.Name[0:9], "-") + "-" + m.AzureMachine.Name[len(m.AzureMachine.Name)-5:]
 	}
 	return m.AzureMachine.Name
 }
@@ -312,7 +310,7 @@ func (m *MachineScope) ProviderID() string {
 	if err != nil {
 		return ""
 	}
-	return parsed.ID()
+	return parsed.String()
 }
 
 // AvailabilitySet returns the availability set for this machine if available

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -19,24 +19,38 @@ package scope
 import (
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
-	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 func TestMachineScope_Name(t *testing.T) {
-	type fields struct {
-		ClusterScoper azure.ClusterScoper
-		AzureMachine  *infrav1.AzureMachine
-	}
 	tests := []struct {
 		name         string
 		machineScope MachineScope
 		want         string
 		testLength   bool
 	}{
+		{
+			name: "if provider ID exists, use it",
+			machineScope: MachineScope{
+				AzureMachine: &infrav1.AzureMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine-with-a-long-name",
+					},
+					Spec: infrav1.AzureMachineSpec{
+						ProviderID: to.StringPtr("azure://compute/virtual-machines/machine-name"),
+						OSDisk: infrav1.OSDisk{
+							OSType: "Windows",
+						},
+					},
+				},
+			},
+			want: "machine-name",
+		},
 		{
 			name: "linux can be any length",
 			machineScope: MachineScope{
@@ -76,7 +90,7 @@ func TestMachineScope_Name(t *testing.T) {
 					Status: infrav1.AzureMachineStatus{},
 				},
 			},
-			want:       "cluster-23456",
+			want:       "machine-9-23456",
 			testLength: true,
 		},
 		{
@@ -102,7 +116,7 @@ func TestMachineScope_Name(t *testing.T) {
 					Status: infrav1.AzureMachineStatus{},
 				},
 			},
-			want:       "cluster89-23456",
+			want:       "machine-9-23456",
 			testLength: true,
 		},
 	}
@@ -116,6 +130,98 @@ func TestMachineScope_Name(t *testing.T) {
 
 			if tt.testLength && len(got) > 15 {
 				t.Errorf("Length of MachineScope.Name() = %v, want less than %v", len(got), 15)
+			}
+		})
+	}
+}
+
+func TestMachineScope_GetVMID(t *testing.T) {
+	tests := []struct {
+		name         string
+		machineScope MachineScope
+		want         string
+	}{
+		{
+			name: "returns the vm name from provider ID",
+			machineScope: MachineScope{
+				AzureMachine: &infrav1.AzureMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "not-this-name",
+					},
+					Spec: infrav1.AzureMachineSpec{
+						ProviderID: to.StringPtr("azure://compute/virtual-machines/machine-name"),
+					},
+				},
+			},
+			want: "machine-name",
+		},
+		{
+			name: "returns empty if provider ID is invalid",
+			machineScope: MachineScope{
+				AzureMachine: &infrav1.AzureMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine-name",
+					},
+					Spec: infrav1.AzureMachineSpec{
+						ProviderID: to.StringPtr("foo"),
+					},
+				},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := tt.machineScope.GetVMID()
+			if got != tt.want {
+				t.Errorf("MachineScope.GetVMID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMachineScope_ProviderID(t *testing.T) {
+	tests := []struct {
+		name         string
+		machineScope MachineScope
+		want         string
+	}{
+		{
+			name: "returns the entire provider ID",
+			machineScope: MachineScope{
+				AzureMachine: &infrav1.AzureMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "not-this-name",
+					},
+					Spec: infrav1.AzureMachineSpec{
+						ProviderID: to.StringPtr("azure://compute/virtual-machines/machine-name"),
+					},
+				},
+			},
+			want: "azure://compute/virtual-machines/machine-name",
+		},
+		{
+			name: "returns empty if provider ID is invalid",
+			machineScope: MachineScope{
+				AzureMachine: &infrav1.AzureMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine-name",
+					},
+					Spec: infrav1.AzureMachineSpec{
+						ProviderID: to.StringPtr("foo"),
+					},
+				},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := tt.machineScope.ProviderID()
+			if got != tt.want {
+				t.Errorf("MachineScope.ProviderID() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -338,7 +338,7 @@ func collectVMSSBootLog(ctx context.Context, providerID string, outputPath strin
 	resourceId := strings.TrimPrefix(providerID, azure.ProviderIDPrefix)
 	v := strings.Split(resourceId, "/")
 	instanceId := v[len(v)-1]
-	resourceId = strings.TrimSuffix(resourceId, "/virtualMachines/" + instanceId)
+	resourceId = strings.TrimSuffix(resourceId, "/virtualMachines/"+instanceId)
 	resource, err := autorest.ParseResourceID(resourceId)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse resource id")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Renames Windows VMs to use the AzureMachineName as base for the 9 char prefix.

Before:
```
pool1-md-win-k2dqg                 true    Succeeded   win-template   pool1-md-win-5d975686b9-zmbvf          azure:///subscriptions/85d99e6d-f6d6-408f-a9f1-b7a97237d5c4/resourceGroups/win-template/providers/Microsoft.Compute/virtualMachines/win-templ-k2dqg                    Standard_D2s_v3
```
After:
```
pool1-md-win-mh754                 true    Succeeded   win-template   pool1-md-win-5d975686b9-5kjx5          azure:///subscriptions/85d99e6d-f6d6-408f-a9f1-b7a97237d5c4/resourceGroups/win-template/providers/Microsoft.Compute/virtualMachines/pool1-md-mh754                     Standard_D2s_v3
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1313

**Special notes for your reviewer**: this change is backward compatible. Any existing VM will use the providerID field to get the name of the VM. Any new VM will use the new naming scheme.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Windows VM naming to use the AzureMachine name as prefix
```
