### PR TITLE
ci: ability to overwrite CLUSTER_TEMPLATE and CLUSTER_NAME in ci-entrypoint.sh

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -49,6 +49,20 @@ setup() {
     # setup REGISTRY for custom images.
     : "${REGISTRY:?Environment variable empty or not defined.}"
     ${REPO_ROOT}/hack/ensure-acr-login.sh
+    if [[ -z "${CLUSTER_TEMPLATE:-}" ]]; then
+        select_cluster_template
+    fi
+
+    export CLUSTER_NAME="${CLUSTER_NAME:-capz-$(head /dev/urandom | LC_ALL=C tr -dc a-z0-9 | head -c 6 ; echo '')}"
+    export AZURE_RESOURCE_GROUP="${CLUSTER_NAME}"
+    export AZURE_LOCATION="${AZURE_LOCATION:-$(get_random_region)}"
+    # Need a cluster with at least 2 nodes
+    export CONTROL_PLANE_MACHINE_COUNT="${CONTROL_PLANE_MACHINE_COUNT:-1}"
+    export WORKER_MACHINE_COUNT="${WORKER_MACHINE_COUNT:-2}"
+    export EXP_CLUSTER_RESOURCE_SET="true"
+}
+
+select_cluster_template() {
     if [[ "$(capz::util::should_build_kubernetes)" == "true" ]]; then
         source "${REPO_ROOT}/scripts/ci-build-kubernetes.sh"
         export CLUSTER_TEMPLATE="test/dev/cluster-template-custom-builds.yaml"
@@ -76,14 +90,6 @@ setup() {
     if [[ "${EXP_MACHINE_POOL:-}" == "true" ]]; then
         export CLUSTER_TEMPLATE="${CLUSTER_TEMPLATE/prow/prow-machine-pool}"
     fi
-
-    export CLUSTER_NAME="capz-$(head /dev/urandom | LC_ALL=C tr -dc a-z0-9 | head -c 6 ; echo '')"
-    export AZURE_RESOURCE_GROUP="${CLUSTER_NAME}"
-    export AZURE_LOCATION="${AZURE_LOCATION:-$(get_random_region)}"
-    # Need a cluster with at least 2 nodes
-    export CONTROL_PLANE_MACHINE_COUNT="${CONTROL_PLANE_MACHINE_COUNT:-1}"
-    export WORKER_MACHINE_COUNT="${WORKER_MACHINE_COUNT:-2}"
-    export EXP_CLUSTER_RESOURCE_SET="true"
 }
 
 create_cluster() {


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind cleanup

**What this PR does / why we need it**:

Currently, `ci-entrypoint.sh` does not allow user to use a custom cluster template and cluster name. This PR adding the ability to overwrite those two variables for greater customizability when invoking the script. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
