### PR TITLE
Fix tiltfile CAPI release link and update default k8s version in tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -42,7 +42,7 @@ if "default_registry" in settings:
 # deploy CAPI
 def deploy_capi():
     version = settings.get("capi_version")
-    capi_uri = "https://storage.googleapis.com/artifacts.k8s-staging-cluster-api.appspot.com/components/{}/cluster-api-components.yaml".format(version)
+    capi_uri = "https://github.com/kubernetes-sigs/cluster-api/releases/download/{}/cluster-api-components.yaml".format(version)
     cmd = "curl -sSL {} | {} | kubectl apply -f -".format(capi_uri, envsubst_cmd)
     local(cmd, quiet=True)
     if settings.get("extra_args"):

--- a/Tiltfile
+++ b/Tiltfile
@@ -18,7 +18,7 @@ settings = {
     "kind_cluster_name": "capz",
     "capi_version": "v0.4.0-beta.0",
     "cert_manager_version": "v1.1.0",
-    "kubernetes_version": "v1.19.7",
+    "kubernetes_version": "v1.19.11",
     "aks_kubernetes_version": "v1.20.5"
 }
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Fix tiltfile CAPI release link (broken by #1421) and update default k8s version in tilt to 1.19.11.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
