### PR TITLE
Add godot linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - errorlint
     - goconst
     - gocyclo
+    - godot
     - gofmt
     - goimports
     - golint

--- a/api/v1alpha3/azurecluster_types.go
+++ b/api/v1alpha3/azurecluster_types.go
@@ -27,11 +27,11 @@ const (
 	// removing it from the apiserver.
 	ClusterFinalizer = "azurecluster.infrastructure.cluster.x-k8s.io"
 
-	// ClusterLabelNamespace indicates the namespace of the cluster
+	// ClusterLabelNamespace indicates the namespace of the cluster.
 	ClusterLabelNamespace = "azurecluster.infrastructure.cluster.x-k8s.io/cluster-namespace"
 )
 
-// AzureClusterSpec defines the desired state of AzureCluster
+// AzureClusterSpec defines the desired state of AzureCluster.
 type AzureClusterSpec struct {
 	// NetworkSpec encapsulates all things related to Azure network.
 	NetworkSpec NetworkSpec `json:"networkSpec,omitempty"`
@@ -58,7 +58,7 @@ type AzureClusterSpec struct {
 	IdentityRef *corev1.ObjectReference `json:"identityRef,omitempty"`
 }
 
-// AzureClusterStatus defines the observed state of AzureCluster
+// AzureClusterStatus defines the observed state of AzureCluster.
 type AzureClusterStatus struct {
 	// FailureDomains specifies the list of unique failure domains for the location/region of the cluster.
 	// A FailureDomain maps to Availability Zone with an Azure Region (if the region support them). An
@@ -87,7 +87,7 @@ type AzureClusterStatus struct {
 // +kubebuilder:resource:path=azureclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 
-// AzureCluster is the Schema for the azureclusters API
+// AzureCluster is the Schema for the azureclusters API.
 type AzureCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -98,7 +98,7 @@ type AzureCluster struct {
 
 // +kubebuilder:object:root=true
 
-// AzureClusterList contains a list of AzureCluster
+// AzureClusterList contains a list of AzureClusters.
 type AzureClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -110,7 +110,7 @@ func (c *AzureCluster) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureCluster object
+// SetConditions will set the given conditions on an AzureCluster object.
 func (c *AzureCluster) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/api/v1alpha3/azureclusteridentity_types.go
+++ b/api/v1alpha3/azureclusteridentity_types.go
@@ -22,7 +22,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
-// AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity
+// AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.
 type AzureClusterIdentitySpec struct {
 	// UserAssignedMSI or Service Principal
 	Type IdentityType `json:"type"`
@@ -46,7 +46,7 @@ type AzureClusterIdentitySpec struct {
 	AllowedNamespaces []string `json:"allowedNamespaces"`
 }
 
-// AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity
+// AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity.
 type AzureClusterIdentityStatus struct {
 	// Conditions defines current service state of the AzureClusterIdentity.
 	// +optional
@@ -57,7 +57,7 @@ type AzureClusterIdentityStatus struct {
 // +kubebuilder:resource:path=azureclusteridentities,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 
-// AzureClusterIdentity is the Schema for the azureclustersidentities API
+// AzureClusterIdentity is the Schema for the azureclustersidentities API.
 type AzureClusterIdentity struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -68,7 +68,7 @@ type AzureClusterIdentity struct {
 
 // +kubebuilder:object:root=true
 
-// AzureClusterIdentityList contains a list of AzureClusterIdentity
+// AzureClusterIdentityList contains a list of AzureClusterIdentities.
 type AzureClusterIdentityList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -80,12 +80,12 @@ func (c *AzureClusterIdentity) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureClusterIdentity object
+// SetConditions will set the given conditions on an AzureClusterIdentity object.
 func (c *AzureClusterIdentity) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }
 
-// ClusterNamespaceAllowed indicates if the cluster namespace is allowed
+// ClusterNamespaceAllowed indicates if the cluster namespace is allowed.
 func (c *AzureClusterIdentity) ClusterNamespaceAllowed(namespace string) bool {
 	if len(c.Spec.AllowedNamespaces) == 0 {
 		return true

--- a/api/v1alpha3/azuremachine_types.go
+++ b/api/v1alpha3/azuremachine_types.go
@@ -30,7 +30,7 @@ const (
 	MachineFinalizer = "azuremachine.infrastructure.cluster.x-k8s.io"
 )
 
-// AzureMachineSpec defines the desired state of AzureMachine
+// AzureMachineSpec defines the desired state of AzureMachine.
 type AzureMachineSpec struct {
 	// ProviderID is the unique identifier as specified by the cloud provider.
 	// +optional
@@ -107,7 +107,7 @@ type AzureMachineSpec struct {
 	// +optional
 	AcceleratedNetworking *bool `json:"acceleratedNetworking,omitempty"`
 
-	// SpotVMOptions allows the ability to specify the Machine should use a Spot VM
+	// SpotVMOptions allows the ability to specify the Machine should use a Spot VM.
 	// +optional
 	SpotVMOptions *SpotVMOptions `json:"spotVMOptions,omitempty"`
 
@@ -116,14 +116,14 @@ type AzureMachineSpec struct {
 	SecurityProfile *SecurityProfile `json:"securityProfile,omitempty"`
 }
 
-// SpotVMOptions defines the options relevant to running the Machine on Spot VMs
+// SpotVMOptions defines the options relevant to running the Machine on Spot VMs.
 type SpotVMOptions struct {
 	// MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
 	// +optional
 	MaxPrice *resource.Quantity `json:"maxPrice,omitempty"`
 }
 
-// AzureMachineStatus defines the observed state of AzureMachine
+// AzureMachineStatus defines the observed state of AzureMachine.
 type AzureMachineStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -189,7 +189,7 @@ type AzureMachineStatus struct {
 // +kubebuilder:resource:path=azuremachines,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 
-// AzureMachine is the Schema for the azuremachines API
+// AzureMachine is the Schema for the azuremachines API.
 type AzureMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -200,7 +200,7 @@ type AzureMachine struct {
 
 // +kubebuilder:object:root=true
 
-// AzureMachineList contains a list of AzureMachine
+// AzureMachineList contains a list of AzureMachines.
 type AzureMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -212,7 +212,7 @@ func (m *AzureMachine) GetConditions() clusterv1.Conditions {
 	return m.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureMachine object
+// SetConditions will set the given conditions on an AzureMachine object.
 func (m *AzureMachine) SetConditions(conditions clusterv1.Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/api/v1alpha3/azuremachinetemplate_types.go
+++ b/api/v1alpha3/azuremachinetemplate_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate
+// AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate.
 type AzureMachineTemplateSpec struct {
 	Template AzureMachineTemplateResource `json:"template"`
 }
@@ -28,7 +28,7 @@ type AzureMachineTemplateSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=azuremachinetemplates,scope=Namespaced,categories=cluster-api
 
-// AzureMachineTemplate is the Schema for the azuremachinetemplates API
+// AzureMachineTemplate is the Schema for the azuremachinetemplates API.
 type AzureMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -38,7 +38,7 @@ type AzureMachineTemplate struct {
 
 // +kubebuilder:object:root=true
 
-// AzureMachineTemplateList contains a list of AzureMachineTemplate
+// AzureMachineTemplateList contains a list of AzureMachineTemplate.
 type AzureMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -49,7 +49,7 @@ func init() {
 	SchemeBuilder.Register(&AzureMachineTemplate{}, &AzureMachineTemplateList{})
 }
 
-// AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template
+// AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template.
 type AzureMachineTemplateResource struct {
 	// Spec is the specification of the desired behavior of the machine.
 	Spec AzureMachineSpec `json:"spec"`

--- a/api/v1alpha3/conditions_consts.go
+++ b/api/v1alpha3/conditions_consts.go
@@ -18,19 +18,19 @@ package v1alpha3
 
 import clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
-// AzureCluster Conditions and Reasons
+// AzureCluster Conditions and Reasons.
 const (
-	// NetworkInfrastructureReadyCondition reports of current status of cluster infrastructure
+	// NetworkInfrastructureReadyCondition reports of current status of cluster infrastructure.
 	NetworkInfrastructureReadyCondition = "NetworkInfrastructureReady"
-	// LoadBalancerProvisioningReason API Server endpoint for the loadbalancer
+	// LoadBalancerProvisioningReason API Server endpoint for the loadbalancer.
 	LoadBalancerProvisioningReason = "LoadBalancerProvisioning"
 	// LoadBalancerProvisioningFailedReason used for failure during provisioning of loadbalancer.
 	LoadBalancerProvisioningFailedReason = "LoadBalancerProvisioningFailed"
-	// NamespaceNotAllowedByIdentity used to indicate cluster in a namespace not allowed by identity
+	// NamespaceNotAllowedByIdentity used to indicate cluster in a namespace not allowed by identity.
 	NamespaceNotAllowedByIdentity = "NamespaceNotAllowedByIdentity"
 )
 
-// AzureMachine Conditions and Reasons
+// AzureMachine Conditions and Reasons.
 const (
 	// VMRunningCondition reports on current status of the Azure VM.
 	VMRunningCondition clusterv1.ConditionType = "VMRunning"

--- a/api/v1alpha3/groupversion_info.go
+++ b/api/v1alpha3/groupversion_info.go
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1alpha3"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/api/v1alpha3/tags.go
+++ b/api/v1alpha3/tags.go
@@ -47,7 +47,7 @@ func (t Tags) HasAzureCloudProviderOwned(cluster string) bool {
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
 }
 
-// GetRole returns the Cluster API role for the tagged resource
+// GetRole returns the Cluster API role for the tagged resource.
 func (t Tags) GetRole() string {
 	return t[NameAzureClusterAPIRole]
 }
@@ -74,13 +74,13 @@ func (t Tags) Merge(other Tags) {
 	}
 }
 
-// AddSpecVersionHashTag adds a spec version hash to the Azure resource tags to determine if state has changed quickly
+// AddSpecVersionHashTag adds a spec version hash to the Azure resource tags to determine if state has changed quickly.
 func (t Tags) AddSpecVersionHashTag(hash string) Tags {
 	t[SpecVersionHashTagKey()] = hash
 	return t
 }
 
-// ResourceLifecycle configures the lifecycle of a resource
+// ResourceLifecycle configures the lifecycle of a resource.
 type ResourceLifecycle string
 
 const (
@@ -99,36 +99,36 @@ const (
 	// to be permissive about state changes.
 	// logically independent clusters running in the same AZ.
 	// The tag key = NameKubernetesAzureCloudProviderPrefix + clusterID
-	// The tag value is an ownership value
+	// The tag value is an ownership value.
 	NameKubernetesAzureCloudProviderPrefix = "kubernetes.io_cluster_"
 
 	// NameAzureProviderPrefix is the tag prefix we use to differentiate
 	// cluster-api-provider-azure owned components from other tooling that
-	// uses NameKubernetesClusterPrefix
+	// uses NameKubernetesClusterPrefix.
 	NameAzureProviderPrefix = "sigs.k8s.io_cluster-api-provider-azure_"
 
 	// NameAzureProviderOwned is the tag name we use to differentiate
 	// cluster-api-provider-azure owned components from other tooling that
-	// uses NameKubernetesClusterPrefix
+	// uses NameKubernetesClusterPrefix.
 	NameAzureProviderOwned = NameAzureProviderPrefix + "cluster_"
 
 	// NameAzureClusterAPIRole is the tag name we use to mark roles for resources
 	// dedicated to this cluster api provider implementation.
 	NameAzureClusterAPIRole = NameAzureProviderPrefix + "role"
 
-	// APIServerRole describes the value for the apiserver role
+	// APIServerRole describes the value for the apiserver role.
 	APIServerRole = "apiserver"
 
-	// NodeOutboundRole describes the value for the node outbound LB role
+	// NodeOutboundRole describes the value for the node outbound LB role.
 	NodeOutboundRole = "nodeOutbound"
 
-	// ControlPlaneOutboundRole describes the value for the control plane outbound LB role
+	// ControlPlaneOutboundRole describes the value for the control plane outbound LB role.
 	ControlPlaneOutboundRole = "controlPlaneOutbound"
 
-	// BastionRole describes the value for the bastion role
+	// BastionRole describes the value for the bastion role.
 	BastionRole = "bastion"
 
-	// CommonRole describes the value for the common role
+	// CommonRole describes the value for the common role.
 	CommonRole = "common"
 
 	// VMTagsLastAppliedAnnotation is the key for the machine object annotation
@@ -138,7 +138,7 @@ const (
 	VMTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-vm"
 )
 
-// SpecVersionHashTagKey is the key for the spec version hash used to enable quick spec difference comparison
+// SpecVersionHashTagKey is the key for the spec version hash used to enable quick spec difference comparison.
 func SpecVersionHashTagKey() string {
 	return fmt.Sprintf("%s%s", NameAzureProviderPrefix, "spec-version-hash")
 }

--- a/api/v1alpha3/types.go
+++ b/api/v1alpha3/types.go
@@ -21,26 +21,26 @@ import (
 )
 
 const (
-	// ControlPlane machine label
+	// ControlPlane machine label.
 	ControlPlane string = "control-plane"
-	// Node machine label
+	// Node machine label.
 	Node string = "node"
 )
 
-// Future contains the data needed for an Azure long running operation to continue across reconcile loops
+// Future contains the data needed for an Azure long-running operation to continue across reconcile loops.
 type Future struct {
-	// Type describes the type of future, update, create, delete, etc
+	// Type describes the type of future, update, create, delete, etc.
 	Type string `json:"type"`
 
-	// ResourceGroup is the Azure resource group for the resource
+	// ResourceGroup is the Azure resource group for the resource.
 	// +optional
 	ResourceGroup string `json:"resourceGroup,omitempty"`
 
-	// Name is the name of the Azure resource
+	// Name is the name of the Azure resource.
 	// +optional
 	Name string `json:"name,omitempty"`
 
-	// FutureData is the base64 url encoded json Azure AutoRest Future
+	// FutureData is the base64 url encoded json Azure AutoRest Future.
 	FutureData string `json:"futureData,omitempty"`
 }
 
@@ -97,10 +97,10 @@ type Subnets []SubnetSpec
 type SecurityGroupRole string
 
 const (
-	// SecurityGroupNode defines a Kubernetes workload node role
+	// SecurityGroupNode defines a Kubernetes workload node role.
 	SecurityGroupNode = SecurityGroupRole(Node)
 
-	// SecurityGroupControlPlane defines a Kubernetes control plane node role
+	// SecurityGroupControlPlane defines a Kubernetes control plane node role.
 	SecurityGroupControlPlane = SecurityGroupRole(ControlPlane)
 )
 
@@ -122,13 +122,13 @@ type RouteTable struct {
 type SecurityGroupProtocol string
 
 const (
-	// SecurityGroupProtocolAll is a wildcard for all IP protocols
+	// SecurityGroupProtocolAll is a wildcard for all IP protocols.
 	SecurityGroupProtocolAll = SecurityGroupProtocol("*")
 
-	// SecurityGroupProtocolTCP represents the TCP protocol in ingress rules
+	// SecurityGroupProtocolTCP represents the TCP protocol in ingress rules.
 	SecurityGroupProtocolTCP = SecurityGroupProtocol("Tcp")
 
-	// SecurityGroupProtocolUDP represents the UDP protocol in ingress rules
+	// SecurityGroupProtocolUDP represents the UDP protocol in ingress rules.
 	SecurityGroupProtocolUDP = SecurityGroupProtocol("Udp")
 )
 
@@ -259,7 +259,7 @@ type Image struct {
 	Marketplace *AzureMarketplaceImage `json:"marketplace,omitempty"`
 }
 
-// AzureMarketplaceImage defines an image in the Azure Marketplace to use for VM creation
+// AzureMarketplaceImage defines an image in the Azure Marketplace to use for VM creation.
 type AzureMarketplaceImage struct {
 	// Publisher is the name of the organization that created the image
 	// +kubebuilder:validation:MinLength=1
@@ -286,7 +286,7 @@ type AzureMarketplaceImage struct {
 	ThirdPartyImage bool `json:"thirdPartyImage"`
 }
 
-// AzureSharedGalleryImage defines an image in a Shared Image Gallery to use for VM creation
+// AzureSharedGalleryImage defines an image in a Shared Image Gallery to use for VM creation.
 type AzureSharedGalleryImage struct {
 	// SubscriptionID is the identifier of the subscription that contains the shared image gallery
 	// +kubebuilder:validation:MinLength=1
@@ -309,9 +309,9 @@ type AzureSharedGalleryImage struct {
 	Version string `json:"version"`
 }
 
-// AvailabilityZone specifies an Azure Availability Zone
+// AvailabilityZone specifies an Azure Availability Zone.
 //
-// DEPRECATED: Use FailureDomain instead
+// DEPRECATED: Use FailureDomain instead.
 type AvailabilityZone struct {
 	ID      *string `json:"id,omitempty"`
 	Enabled *bool   `json:"enabled,omitempty"`
@@ -412,10 +412,10 @@ type DiffDiskSettings struct {
 type SubnetRole string
 
 const (
-	// SubnetNode defines a Kubernetes workload node role
+	// SubnetNode defines a Kubernetes workload node role.
 	SubnetNode = SubnetRole(Node)
 
-	// SubnetControlPlane defines a Kubernetes control plane node role
+	// SubnetControlPlane defines a Kubernetes control plane node role.
 	SubnetControlPlane = SubnetRole(ControlPlane)
 )
 

--- a/api/v1alpha4/azurecluster_default.go
+++ b/api/v1alpha4/azurecluster_default.go
@@ -23,21 +23,21 @@ import (
 )
 
 const (
-	// DefaultVnetCIDR is the default Vnet CIDR
+	// DefaultVnetCIDR is the default Vnet CIDR.
 	DefaultVnetCIDR = "10.0.0.0/8"
-	// DefaultControlPlaneSubnetCIDR is the default Control Plane Subnet CIDR
+	// DefaultControlPlaneSubnetCIDR is the default Control Plane Subnet CIDR.
 	DefaultControlPlaneSubnetCIDR = "10.0.0.0/16"
-	// DefaultNodeSubnetCIDR is the default Node Subnet CIDR
+	// DefaultNodeSubnetCIDR is the default Node Subnet CIDR.
 	DefaultNodeSubnetCIDR = "10.1.0.0/16"
-	// DefaultAzureBastionSubnetCIDR is the default Subnet CIDR for AzureBastion
+	// DefaultAzureBastionSubnetCIDR is the default Subnet CIDR for AzureBastion.
 	DefaultAzureBastionSubnetCIDR = "10.255.255.224/27"
-	// DefaultAzureBastionSubnetName is the default Subnet Name for AzureBastion
+	// DefaultAzureBastionSubnetName is the default Subnet Name for AzureBastion.
 	DefaultAzureBastionSubnetName = "AzureBastionSubnet"
-	// DefaultInternalLBIPAddress is the default internal load balancer ip address
+	// DefaultInternalLBIPAddress is the default internal load balancer ip address.
 	DefaultInternalLBIPAddress = "10.0.0.100"
 	// DefaultOutboundRuleIdleTimeoutInMinutes is the default for IdleTimeoutInMinutes for the load balancer.
 	DefaultOutboundRuleIdleTimeoutInMinutes = 4
-	// DefaultAzureCloud is the public cloud that will be used by most users
+	// DefaultAzureCloud is the public cloud that will be used by most users.
 	DefaultAzureCloud = "AzurePublicCloud"
 )
 

--- a/api/v1alpha4/azurecluster_types.go
+++ b/api/v1alpha4/azurecluster_types.go
@@ -27,11 +27,11 @@ const (
 	// removing it from the apiserver.
 	ClusterFinalizer = "azurecluster.infrastructure.cluster.x-k8s.io"
 
-	// ClusterLabelNamespace indicates the namespace of the cluster
+	// ClusterLabelNamespace indicates the namespace of the cluster.
 	ClusterLabelNamespace = "azurecluster.infrastructure.cluster.x-k8s.io/cluster-namespace"
 )
 
-// AzureClusterSpec defines the desired state of AzureCluster
+// AzureClusterSpec defines the desired state of AzureCluster.
 type AzureClusterSpec struct {
 	// NetworkSpec encapsulates all things related to Azure network.
 	NetworkSpec NetworkSpec `json:"networkSpec,omitempty"`
@@ -53,7 +53,7 @@ type AzureClusterSpec struct {
 	// +optional
 	AdditionalTags Tags `json:"additionalTags,omitempty"`
 
-	// IdentityRef is a reference to a AzureIdentity to be used when reconciling this cluster
+	// IdentityRef is a reference to an AzureIdentity to be used when reconciling this cluster
 	// +optional
 	IdentityRef *corev1.ObjectReference `json:"identityRef,omitempty"`
 
@@ -79,7 +79,7 @@ type AzureClusterSpec struct {
 	CloudProviderConfigOverrides *CloudProviderConfigOverrides `json:"cloudProviderConfigOverrides,omitempty"`
 }
 
-// AzureClusterStatus defines the observed state of AzureCluster
+// AzureClusterStatus defines the observed state of AzureCluster.
 type AzureClusterStatus struct {
 	// FailureDomains specifies the list of unique failure domains for the location/region of the cluster.
 	// A FailureDomain maps to Availability Zone with an Azure Region (if the region support them). An
@@ -109,7 +109,7 @@ type AzureClusterStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
-// AzureCluster is the Schema for the azureclusters API
+// AzureCluster is the Schema for the azureclusters API.
 type AzureCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -120,7 +120,7 @@ type AzureCluster struct {
 
 // +kubebuilder:object:root=true
 
-// AzureClusterList contains a list of AzureCluster
+// AzureClusterList contains a list of AzureClusters.
 type AzureClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -132,7 +132,7 @@ func (c *AzureCluster) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureCluster object
+// SetConditions will set the given conditions on an AzureCluster object.
 func (c *AzureCluster) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/api/v1alpha4/azurecluster_validation.go
+++ b/api/v1alpha4/azurecluster_validation.go
@@ -32,17 +32,17 @@ import (
 
 const (
 	// can't use: \/"'[]:|<>+=;,.?*@&, Can't start with underscore. Can't end with period or hyphen.
-	// not using . in the name to avoid issues when the name is part of DNS name
+	// not using . in the name to avoid issues when the name is part of DNS name.
 	clusterNameRegex = `^[a-z0-9][a-z0-9-]{0,42}[a-z0-9]$`
 	// max length of 44 to allow for cluster name to be used as a prefix for VMs and other resources that
-	// have limitations as outlined here https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+	// have limitations as outlined here https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.
 	clusterNameMaxLength = 44
-	// obtained from https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/createorupdate#uri-parameters
+	// obtained from https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/createorupdate#uri-parameters.
 	resourceGroupRegex = `^[-\w\._\(\)]+$`
-	// described in https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+	// described in https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules.
 	subnetRegex       = `^[-\w\._]+$`
 	loadBalancerRegex = `^[-\w\._]+$`
-	// MaxLoadBalancerOutboundIPs is the maximum number of outbound IPs in a Standard LoadBalancer frontend configuration
+	// MaxLoadBalancerOutboundIPs is the maximum number of outbound IPs in a Standard LoadBalancer frontend configuration.
 	MaxLoadBalancerOutboundIPs = 16
 	// MinLBIdleTimeoutInMinutes is the minimum number of minutes for the LB idle timeout.
 	MinLBIdleTimeoutInMinutes = 4
@@ -54,7 +54,7 @@ const (
 	maxRulePriority = 4096
 )
 
-// validateCluster validates a cluster
+// validateCluster validates a cluster.
 func (c *AzureCluster) validateCluster(old *AzureCluster) error {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, c.validateClusterName()...)
@@ -68,7 +68,7 @@ func (c *AzureCluster) validateCluster(old *AzureCluster) error {
 		c.Name, allErrs)
 }
 
-// validateClusterSpec validates a ClusterSpec
+// validateClusterSpec validates a ClusterSpec.
 func (c *AzureCluster) validateClusterSpec(old *AzureCluster) field.ErrorList {
 	var allErrs field.ErrorList
 	var oldNetworkSpec NetworkSpec
@@ -87,7 +87,7 @@ func (c *AzureCluster) validateClusterSpec(old *AzureCluster) field.ErrorList {
 	return allErrs
 }
 
-// validateClusterName validates ClusterName
+// validateClusterName validates ClusterName.
 func (c *AzureCluster) validateClusterName() field.ErrorList {
 	var allErrs field.ErrorList
 	if len(c.Name) > clusterNameMaxLength {
@@ -105,7 +105,7 @@ func (c *AzureCluster) validateClusterName() field.ErrorList {
 	return allErrs
 }
 
-// validateNetworkSpec validates a NetworkSpec
+// validateNetworkSpec validates a NetworkSpec.
 func validateNetworkSpec(networkSpec NetworkSpec, old NetworkSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	// If the user specifies a resourceGroup for vnet, it means
@@ -141,7 +141,7 @@ func validateNetworkSpec(networkSpec NetworkSpec, old NetworkSpec, fldPath *fiel
 	return allErrs
 }
 
-// validateResourceGroup validates a ResourceGroup
+// validateResourceGroup validates a ResourceGroup.
 func validateResourceGroup(resourceGroup string, fldPath *field.Path) *field.Error {
 	if success, _ := regexp.MatchString(resourceGroupRegex, resourceGroup); !success {
 		return field.Invalid(fldPath, resourceGroup,
@@ -150,7 +150,7 @@ func validateResourceGroup(resourceGroup string, fldPath *field.Path) *field.Err
 	return nil
 }
 
-// validateSubnets validates a list of Subnets
+// validateSubnets validates a list of Subnets.
 func validateSubnets(subnets Subnets, vnet VnetSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	subnetNames := make(map[string]bool, len(subnets))
@@ -270,7 +270,7 @@ func validateInternalLBIPAddress(address string, cidrs []string, fldPath *field.
 		fmt.Sprintf("Internal LB IP address needs to be in control plane subnet range (%s)", cidrs))
 }
 
-// validateSecurityRule validates a SecurityRule
+// validateSecurityRule validates a SecurityRule.
 func validateSecurityRule(rule SecurityRule, fldPath *field.Path) *field.Error {
 	if rule.Priority < minRulePriority || rule.Priority > maxRulePriority {
 		return field.Invalid(fldPath, rule.Priority, fmt.Sprintf("security rule priorities should be between %d and %d", minRulePriority, maxRulePriority))
@@ -433,7 +433,7 @@ func validatePrivateDNSZoneName(networkSpec NetworkSpec, fldPath *field.Path) fi
 	return allErrs
 }
 
-// validateCloudProviderConfigOverrides validates CloudProviderConfigOverrides
+// validateCloudProviderConfigOverrides validates CloudProviderConfigOverrides.
 func validateCloudProviderConfigOverrides(old, new *CloudProviderConfigOverrides, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if !reflect.DeepEqual(old, new) {

--- a/api/v1alpha4/azurecluster_webhook.go
+++ b/api/v1alpha4/azurecluster_webhook.go
@@ -43,21 +43,21 @@ func (c *AzureCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Validator = &AzureCluster{}
 var _ webhook.Defaulter = &AzureCluster{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (c *AzureCluster) Default() {
 	clusterlog.Info("default", "name", c.Name)
 
 	c.setDefaults()
 }
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (c *AzureCluster) ValidateCreate() error {
 	clusterlog.Info("validate create", "name", c.Name)
 
 	return c.validateCluster(nil)
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (c *AzureCluster) ValidateUpdate(oldRaw runtime.Object) error {
 	clusterlog.Info("validate update", "name", c.Name)
 	var allErrs field.ErrorList
@@ -113,7 +113,7 @@ func (c *AzureCluster) ValidateUpdate(oldRaw runtime.Object) error {
 	return apierrors.NewInvalid(GroupVersion.WithKind("AzureCluster").GroupKind(), c.Name, allErrs)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (c *AzureCluster) ValidateDelete() error {
 	clusterlog.Info("validate delete", "name", c.Name)
 

--- a/api/v1alpha4/azureclusteridentity_types.go
+++ b/api/v1alpha4/azureclusteridentity_types.go
@@ -23,7 +23,7 @@ import (
 )
 
 // AllowedNamespaces defines the namespaces the clusters are allowed to use the identity from
-// NamespaceList takes precedence over the Selector
+// NamespaceList takes precedence over the Selector.
 type AllowedNamespaces struct {
 	// A nil or empty list indicates that AzureCluster cannot use the identity from any namespace.
 	//
@@ -41,7 +41,7 @@ type AllowedNamespaces struct {
 	Selector *metav1.LabelSelector `json:"selector"`
 }
 
-// AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity
+// AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.
 type AzureClusterIdentitySpec struct {
 	// UserAssignedMSI or Service Principal
 	Type IdentityType `json:"type"`
@@ -66,7 +66,7 @@ type AzureClusterIdentitySpec struct {
 	AllowedNamespaces *AllowedNamespaces `json:"allowedNamespaces"`
 }
 
-// AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity
+// AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity.
 type AzureClusterIdentityStatus struct {
 	// Conditions defines current service state of the AzureClusterIdentity.
 	// +optional
@@ -78,7 +78,7 @@ type AzureClusterIdentityStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
-// AzureClusterIdentity is the Schema for the azureclustersidentities API
+// AzureClusterIdentity is the Schema for the azureclustersidentities API.
 type AzureClusterIdentity struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -89,7 +89,7 @@ type AzureClusterIdentity struct {
 
 // +kubebuilder:object:root=true
 
-// AzureClusterIdentityList contains a list of AzureClusterIdentity
+// AzureClusterIdentityList contains a list of AzureClusterIdentity.
 type AzureClusterIdentityList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -101,7 +101,7 @@ func (c *AzureClusterIdentity) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureClusterIdentity object
+// SetConditions will set the given conditions on an AzureClusterIdentity object.
 func (c *AzureClusterIdentity) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/api/v1alpha4/azureimage_validation.go
+++ b/api/v1alpha4/azureimage_validation.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// ValidateImage validates an image
+// ValidateImage validates an image.
 func ValidateImage(image *Image, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/api/v1alpha4/azuremachine_default.go
+++ b/api/v1alpha4/azuremachine_default.go
@@ -25,7 +25,7 @@ import (
 	utilSSH "sigs.k8s.io/cluster-api-provider-azure/util/ssh"
 )
 
-// SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureMachine
+// SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureMachine.
 func (m *AzureMachine) SetDefaultSSHPublicKey() error {
 	sshKeyData := m.Spec.SSHPublicKey
 	if sshKeyData == "" {
@@ -40,7 +40,7 @@ func (m *AzureMachine) SetDefaultSSHPublicKey() error {
 	return nil
 }
 
-// SetDefaultCachingType sets the default cache type for an AzureMachine
+// SetDefaultCachingType sets the default cache type for an AzureMachine.
 func (m *AzureMachine) SetDefaultCachingType() error {
 	if m.Spec.OSDisk.CachingType == "" {
 		m.Spec.OSDisk.CachingType = "None"
@@ -48,7 +48,7 @@ func (m *AzureMachine) SetDefaultCachingType() error {
 	return nil
 }
 
-// SetDataDisksDefaults sets the data disk defaults for an AzureMachine
+// SetDataDisksDefaults sets the data disk defaults for an AzureMachine.
 func (m *AzureMachine) SetDataDisksDefaults() {
 	set := make(map[int32]struct{})
 	// populate all the existing values in the set

--- a/api/v1alpha4/azuremachine_types.go
+++ b/api/v1alpha4/azuremachine_types.go
@@ -30,7 +30,7 @@ const (
 	MachineFinalizer = "azuremachine.infrastructure.cluster.x-k8s.io"
 )
 
-// AzureMachineSpec defines the desired state of AzureMachine
+// AzureMachineSpec defines the desired state of AzureMachine.
 type AzureMachineSpec struct {
 	// ProviderID is the unique identifier as specified by the cloud provider.
 	// +optional
@@ -110,14 +110,14 @@ type AzureMachineSpec struct {
 	SecurityProfile *SecurityProfile `json:"securityProfile,omitempty"`
 }
 
-// SpotVMOptions defines the options relevant to running the Machine on Spot VMs
+// SpotVMOptions defines the options relevant to running the Machine on Spot VMs.
 type SpotVMOptions struct {
 	// MaxPrice defines the maximum price the user is willing to pay for Spot VM instances
 	// +optional
 	MaxPrice *resource.Quantity `json:"maxPrice,omitempty"`
 }
 
-// AzureMachineStatus defines the observed state of AzureMachine
+// AzureMachineStatus defines the observed state of AzureMachine.
 type AzureMachineStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -184,7 +184,7 @@ type AzureMachineStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
-// AzureMachine is the Schema for the azuremachines API
+// AzureMachine is the Schema for the azuremachines API.
 type AzureMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -195,7 +195,7 @@ type AzureMachine struct {
 
 // +kubebuilder:object:root=true
 
-// AzureMachineList contains a list of AzureMachine
+// AzureMachineList contains a list of AzureMachine.
 type AzureMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -207,7 +207,7 @@ func (m *AzureMachine) GetConditions() clusterv1.Conditions {
 	return m.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureMachine object
+// SetConditions will set the given conditions on an AzureMachine object.
 func (m *AzureMachine) SetConditions(conditions clusterv1.Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/api/v1alpha4/azuremachine_validation.go
+++ b/api/v1alpha4/azuremachine_validation.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// ValidateSSHKey validates an SSHKey
+// ValidateSSHKey validates an SSHKey.
 func ValidateSSHKey(sshKey string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -63,7 +63,7 @@ func ValidateSystemAssignedIdentity(identityType VMIdentity, old, new string, fl
 	return allErrs
 }
 
-// ValidateUserAssignedIdentity validates the user-assigned identities list
+// ValidateUserAssignedIdentity validates the user-assigned identities list.
 func ValidateUserAssignedIdentity(identityType VMIdentity, userAssignedIdenteties []UserAssignedIdentity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -73,7 +73,7 @@ func ValidateUserAssignedIdentity(identityType VMIdentity, userAssignedIdentetie
 	return allErrs
 }
 
-// ValidateDataDisks validates a list of data disks
+// ValidateDataDisks validates a list of data disks.
 func ValidateDataDisks(dataDisks []DataDisk, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	lunSet := make(map[int32]struct{})
@@ -118,7 +118,7 @@ func ValidateDataDisks(dataDisks []DataDisk, fieldPath *field.Path) field.ErrorL
 	return allErrs
 }
 
-// ValidateOSDisk validates the OSDisk spec
+// ValidateOSDisk validates the OSDisk spec.
 func ValidateOSDisk(osDisk OSDisk, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/api/v1alpha4/azuremachine_webhook.go
+++ b/api/v1alpha4/azuremachine_webhook.go
@@ -42,7 +42,7 @@ func (m *AzureMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Validator = &AzureMachine{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (m *AzureMachine) ValidateCreate() error {
 	machinelog.Info("validate create", "name", m.Name)
 	var allErrs field.ErrorList
@@ -77,7 +77,7 @@ func (m *AzureMachine) ValidateCreate() error {
 	return apierrors.NewInvalid(GroupVersion.WithKind("AzureMachine").GroupKind(), m.Name, allErrs)
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (m *AzureMachine) ValidateUpdate(oldRaw runtime.Object) error {
 	machinelog.Info("validate update", "name", m.Name)
 	var allErrs field.ErrorList
@@ -173,14 +173,14 @@ func (m *AzureMachine) ValidateUpdate(oldRaw runtime.Object) error {
 	return apierrors.NewInvalid(GroupVersion.WithKind("AzureMachine").GroupKind(), m.Name, allErrs)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (m *AzureMachine) ValidateDelete() error {
 	machinelog.Info("validate delete", "name", m.Name)
 
 	return nil
 }
 
-// Default implements webhookutil.defaulter so a webhook will be registered for the type
+// Default implements webhookutil.defaulter so a webhook will be registered for the type.
 func (m *AzureMachine) Default() {
 	machinelog.Info("default", "name", m.Name)
 

--- a/api/v1alpha4/azuremachinetemplate_types.go
+++ b/api/v1alpha4/azuremachinetemplate_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate
+// AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate.
 type AzureMachineTemplateSpec struct {
 	Template AzureMachineTemplateResource `json:"template"`
 }
@@ -29,7 +29,7 @@ type AzureMachineTemplateSpec struct {
 // +kubebuilder:resource:path=azuremachinetemplates,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 
-// AzureMachineTemplate is the Schema for the azuremachinetemplates API
+// AzureMachineTemplate is the Schema for the azuremachinetemplates API.
 type AzureMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -39,7 +39,7 @@ type AzureMachineTemplate struct {
 
 // +kubebuilder:object:root=true
 
-// AzureMachineTemplateList contains a list of AzureMachineTemplate
+// AzureMachineTemplateList contains a list of AzureMachineTemplates.
 type AzureMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -50,7 +50,7 @@ func init() {
 	SchemeBuilder.Register(&AzureMachineTemplate{}, &AzureMachineTemplateList{})
 }
 
-// AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template
+// AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template.
 type AzureMachineTemplateResource struct {
 	// Spec is the specification of the desired behavior of the machine.
 	Spec AzureMachineSpec `json:"spec"`

--- a/api/v1alpha4/azuremachinetemplate_webhook.go
+++ b/api/v1alpha4/azuremachinetemplate_webhook.go
@@ -44,12 +44,12 @@ func (r *AzureMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Validator = &AzureMachineTemplate{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureMachineTemplate) ValidateCreate() error {
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureMachineTemplate) ValidateUpdate(oldRaw runtime.Object) error {
 	clusterlog.Info("validate update", "name", r.Name)
 	var allErrs field.ErrorList
@@ -68,7 +68,7 @@ func (r *AzureMachineTemplate) ValidateUpdate(oldRaw runtime.Object) error {
 
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureMachineTemplate) ValidateDelete() error {
 	return nil
 }

--- a/api/v1alpha4/conditions_consts.go
+++ b/api/v1alpha4/conditions_consts.go
@@ -18,15 +18,15 @@ package v1alpha4
 
 import clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 
-// AzureCluster Conditions and Reasons
+// AzureCluster Conditions and Reasons.
 const (
-	// NetworkInfrastructureReadyCondition reports of current status of cluster infrastructure
+	// NetworkInfrastructureReadyCondition reports of current status of cluster infrastructure.
 	NetworkInfrastructureReadyCondition clusterv1.ConditionType = "NetworkInfrastructureReady"
-	// NamespaceNotAllowedByIdentity used to indicate cluster in a namespace not allowed by identity
+	// NamespaceNotAllowedByIdentity used to indicate cluster in a namespace not allowed by identity.
 	NamespaceNotAllowedByIdentity = "NamespaceNotAllowedByIdentity"
 )
 
-// AzureMachine Conditions and Reasons
+// AzureMachine Conditions and Reasons.
 const (
 	// VMRunningCondition reports on current status of the Azure VM.
 	VMRunningCondition clusterv1.ConditionType = "VMRunning"
@@ -50,7 +50,7 @@ const (
 	BootstrapFailedReason = "BootstrapFailed"
 )
 
-// AzureMachinePool Conditions and Reasons
+// AzureMachinePool Conditions and Reasons.
 const (
 	// ScaleSetRunningCondition reports on current status of the Azure Scale Set.
 	ScaleSetRunningCondition clusterv1.ConditionType = "ScaleSetRunning"
@@ -63,15 +63,15 @@ const (
 	// ScaleSetProvisionFailedReason used for failures during scale set provisioning.
 	ScaleSetProvisionFailedReason = "ScaleSetProvisionFailed"
 
-	// ScaleSetDesiredReplicasCondition reports on the scaling state of the machine pool
+	// ScaleSetDesiredReplicasCondition reports on the scaling state of the machine pool.
 	ScaleSetDesiredReplicasCondition clusterv1.ConditionType = "ScaleSetDesiredReplicas"
-	// ScaleSetScaleUpReason describes the machine pool scaling up
+	// ScaleSetScaleUpReason describes the machine pool scaling up.
 	ScaleSetScaleUpReason = "ScaleSetScalingUp"
-	// ScaleSetScaleDownReason describes the machine pool scaling down
+	// ScaleSetScaleDownReason describes the machine pool scaling down.
 	ScaleSetScaleDownReason = "ScaleSetScalingDown"
 
-	// ScaleSetModelUpdatedCondition reports on the model state of the pool
+	// ScaleSetModelUpdatedCondition reports on the model state of the pool.
 	ScaleSetModelUpdatedCondition clusterv1.ConditionType = "ScaleSetModelUpdated"
-	// ScaleSetModelOutOfDateReason describes the machine pool model being out of date
+	// ScaleSetModelOutOfDateReason describes the machine pool model being out of date.
 	ScaleSetModelOutOfDateReason = "ScaleSetModelOutOfDate"
 )

--- a/api/v1alpha4/groupversion_info.go
+++ b/api/v1alpha4/groupversion_info.go
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1alpha4"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/api/v1alpha4/tags.go
+++ b/api/v1alpha4/tags.go
@@ -47,7 +47,7 @@ func (t Tags) HasAzureCloudProviderOwned(cluster string) bool {
 	return ok && ResourceLifecycle(value) == ResourceLifecycleOwned
 }
 
-// GetRole returns the Cluster API role for the tagged resource
+// GetRole returns the Cluster API role for the tagged resource.
 func (t Tags) GetRole() string {
 	return t[NameAzureClusterAPIRole]
 }
@@ -74,13 +74,13 @@ func (t Tags) Merge(other Tags) {
 	}
 }
 
-// AddSpecVersionHashTag adds a spec version hash to the Azure resource tags to determine if state has changed quickly
+// AddSpecVersionHashTag adds a spec version hash to the Azure resource tags to determine quickly if state has changed.
 func (t Tags) AddSpecVersionHashTag(hash string) Tags {
 	t[SpecVersionHashTagKey()] = hash
 	return t
 }
 
-// ResourceLifecycle configures the lifecycle of a resource
+// ResourceLifecycle configures the lifecycle of a resource.
 type ResourceLifecycle string
 
 const (
@@ -98,37 +98,37 @@ const (
 	// separate independent cluster resources. We use it to identify which resources we expect
 	// to be permissive about state changes.
 	// logically independent clusters running in the same AZ.
-	// The tag key = NameKubernetesAzureCloudProviderPrefix + clusterID
-	// The tag value is an ownership value
+	// The tag key = NameKubernetesAzureCloudProviderPrefix + clusterID.
+	// The tag value is an ownership value.
 	NameKubernetesAzureCloudProviderPrefix = "kubernetes.io_cluster_"
 
 	// NameAzureProviderPrefix is the tag prefix we use to differentiate
 	// cluster-api-provider-azure owned components from other tooling that
-	// uses NameKubernetesClusterPrefix
+	// uses NameKubernetesClusterPrefix.
 	NameAzureProviderPrefix = "sigs.k8s.io_cluster-api-provider-azure_"
 
 	// NameAzureProviderOwned is the tag name we use to differentiate
 	// cluster-api-provider-azure owned components from other tooling that
-	// uses NameKubernetesClusterPrefix
+	// uses NameKubernetesClusterPrefix.
 	NameAzureProviderOwned = NameAzureProviderPrefix + "cluster_"
 
 	// NameAzureClusterAPIRole is the tag name we use to mark roles for resources
 	// dedicated to this cluster api provider implementation.
 	NameAzureClusterAPIRole = NameAzureProviderPrefix + "role"
 
-	// APIServerRole describes the value for the apiserver role
+	// APIServerRole describes the value for the apiserver role.
 	APIServerRole = "apiserver"
 
-	// NodeOutboundRole describes the value for the node outbound LB role
+	// NodeOutboundRole describes the value for the node outbound LB role.
 	NodeOutboundRole = "nodeOutbound"
 
-	// ControlPlaneOutboundRole describes the value for the control plane outbound LB role
+	// ControlPlaneOutboundRole describes the value for the control plane outbound LB role.
 	ControlPlaneOutboundRole = "controlPlaneOutbound"
 
-	// BastionRole describes the value for the bastion role
+	// BastionRole describes the value for the bastion role.
 	BastionRole = "bastion"
 
-	// CommonRole describes the value for the common role
+	// CommonRole describes the value for the common role.
 	CommonRole = "common"
 
 	// VMTagsLastAppliedAnnotation is the key for the machine object annotation
@@ -138,7 +138,7 @@ const (
 	VMTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-vm"
 )
 
-// SpecVersionHashTagKey is the key for the spec version hash used to enable quick spec difference comparison
+// SpecVersionHashTagKey is the key for the spec version hash used to enable quick spec difference comparison.
 func SpecVersionHashTagKey() string {
 	return fmt.Sprintf("%s%s", NameAzureProviderPrefix, "spec-version-hash")
 }

--- a/api/v1alpha4/types.go
+++ b/api/v1alpha4/types.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	// ControlPlane machine label
+	// ControlPlane machine label.
 	ControlPlane string = "control-plane"
-	// Node machine label
+	// Node machine label.
 	Node string = "node"
 )
 
-// Future contains the data needed for an Azure long running operation to continue across reconcile loops
+// Future contains the data needed for an Azure long-running operation to continue across reconcile loops.
 type Future struct {
 	// Type describes the type of future, update, create, delete, etc
 	Type string `json:"type"`
@@ -213,7 +213,7 @@ type PublicIPSpec struct {
 }
 
 // VMState describes the state of an Azure virtual machine.
-// DEPRECATED: use ProvisioningState
+// DEPRECATED: use ProvisioningState.
 type VMState string
 
 // ProvisioningState describes the provisioning state of an Azure resource.
@@ -274,7 +274,7 @@ type Image struct {
 	Marketplace *AzureMarketplaceImage `json:"marketplace,omitempty"`
 }
 
-// AzureMarketplaceImage defines an image in the Azure Marketplace to use for VM creation
+// AzureMarketplaceImage defines an image in the Azure Marketplace to use for VM creation.
 type AzureMarketplaceImage struct {
 	// Publisher is the name of the organization that created the image
 	// +kubebuilder:validation:MinLength=1
@@ -301,7 +301,7 @@ type AzureMarketplaceImage struct {
 	ThirdPartyImage bool `json:"thirdPartyImage"`
 }
 
-// AzureSharedGalleryImage defines an image in a Shared Image Gallery to use for VM creation
+// AzureSharedGalleryImage defines an image in a Shared Image Gallery to use for VM creation.
 type AzureSharedGalleryImage struct {
 	// SubscriptionID is the identifier of the subscription that contains the shared image gallery
 	// +kubebuilder:validation:MinLength=1
@@ -430,10 +430,10 @@ type DiffDiskSettings struct {
 type SubnetRole string
 
 const (
-	// SubnetNode defines a Kubernetes workload node role
+	// SubnetNode defines a Kubernetes workload node role.
 	SubnetNode = SubnetRole(Node)
 
-	// SubnetControlPlane defines a Kubernetes control plane node role
+	// SubnetControlPlane defines a Kubernetes control plane node role.
 	SubnetControlPlane = SubnetRole(ControlPlane)
 )
 
@@ -601,7 +601,7 @@ type AzureBastion struct {
 	PublicIP PublicIPSpec `json:"publicIP,omitempty"`
 }
 
-// IsTerminalProvisioningState returns true if the ProvisioningState is a terminal state for an Azure resource
+// IsTerminalProvisioningState returns true if the ProvisioningState is a terminal state for an Azure resource.
 func IsTerminalProvisioningState(state ProvisioningState) bool {
 	return state == Failed || state == Succeeded
 }

--- a/azure/converters/identity.go
+++ b/azure/converters/identity.go
@@ -27,7 +27,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 )
 
-// ErrUserAssignedIdentitiesNotFound is the error thrown when user assigned identities is not passed with the identity type being UserAssigned
+// ErrUserAssignedIdentitiesNotFound is the error thrown when user assigned identities is not passed with the identity type being UserAssigned.
 var ErrUserAssignedIdentitiesNotFound = errors.New("the user-assigned identity provider ids must not be null or empty for 'UserAssigned' identity type")
 
 // UserAssignedIdentitiesToVMSDK converts CAPZ user assigned identities associated with the Virtual Machine to Azure SDK identities
@@ -47,7 +47,7 @@ func UserAssignedIdentitiesToVMSDK(identities []infrav1.UserAssignedIdentity) (m
 }
 
 // UserAssignedIdentitiesToVMSSSDK converts CAPZ user assigned identities associated with the Virtual Machine Scale Set to Azure SDK identities
-// Similar to UserAssignedIdentitiesToVMSDK
+// Similar to UserAssignedIdentitiesToVMSDK.
 func UserAssignedIdentitiesToVMSSSDK(identities []infrav1.UserAssignedIdentity) (map[string]*compute.VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue, error) {
 	if len(identities) == 0 {
 		return nil, ErrUserAssignedIdentitiesNotFound
@@ -61,7 +61,7 @@ func UserAssignedIdentitiesToVMSSSDK(identities []infrav1.UserAssignedIdentity) 
 	return userIdentitiesMap, nil
 }
 
-// sanitized removes "azure://" prefix from the given id
+// sanitized removes "azure://" prefix from the given id.
 func sanitized(id string) string {
 	return strings.TrimPrefix(id, azure.ProviderIDPrefix)
 }

--- a/azure/converters/spotinstances.go
+++ b/azure/converters/spotinstances.go
@@ -24,7 +24,7 @@ import (
 )
 
 // GetSpotVMOptions takes the spot vm options
-// and returns the individual vm priority, eviction policy and billing profile
+// and returns the individual vm priority, eviction policy and billing profile.
 func GetSpotVMOptions(spotVMOptions *infrav1.SpotVMOptions) (compute.VirtualMachinePriorityTypes, compute.VirtualMachineEvictionPolicyTypes, *compute.BillingProfile, error) {
 	// Spot VM not requested, return zero values to apply defaults
 	if spotVMOptions == nil {

--- a/azure/converters/vmss.go
+++ b/azure/converters/vmss.go
@@ -62,7 +62,7 @@ func SDKToVMSS(sdkvmss compute.VirtualMachineScaleSet, sdkinstances []compute.Vi
 	return vmss
 }
 
-// SDKToVMSSVM converts an Azure SDK VirtualMachineScaleSetVM into an infrav1exp.VMSSVM
+// SDKToVMSSVM converts an Azure SDK VirtualMachineScaleSetVM into an infrav1exp.VMSSVM.
 func SDKToVMSSVM(sdkInstance compute.VirtualMachineScaleSetVM) *azure.VMSSVM {
 	instance := azure.VMSSVM{
 		ID:         to.String(sdkInstance.ID),
@@ -95,7 +95,7 @@ func SDKToVMSSVM(sdkInstance compute.VirtualMachineScaleSetVM) *azure.VMSSVM {
 	return &instance
 }
 
-// SDKImageToImage converts a SDK image reference to infrav1.Image
+// SDKImageToImage converts a SDK image reference to infrav1.Image.
 func SDKImageToImage(sdkImageRef *compute.ImageReference, isThirdPartyImage bool) infrav1.Image {
 	return infrav1.Image{
 		ID: sdkImageRef.ID,

--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -30,23 +30,23 @@ import (
 )
 
 const (
-	// DefaultUserName is the default username for created vm
+	// DefaultUserName is the default username for a created VM.
 	DefaultUserName = "capi"
 )
 
 const (
-	// DefaultImageOfferID is the default Azure Marketplace offer ID
+	// DefaultImageOfferID is the default Azure Marketplace offer ID.
 	DefaultImageOfferID = "capi"
-	// DefaultWindowsImageOfferID is the default Azure Marketplace offer ID for Windows
+	// DefaultWindowsImageOfferID is the default Azure Marketplace offer ID for Windows.
 	DefaultWindowsImageOfferID = "capi-windows"
-	// DefaultImagePublisherID is the default Azure Marketplace publisher ID
+	// DefaultImagePublisherID is the default Azure Marketplace publisher ID.
 	DefaultImagePublisherID = "cncf-upstream"
-	// LatestVersion is the image version latest
+	// LatestVersion is the image version latest.
 	LatestVersion = "latest"
 )
 
 const (
-	// WindowsOS is Windows OS value for OSDisk
+	// WindowsOS is Windows OS value for OSDisk.
 	WindowsOS = "Windows"
 )
 
@@ -61,7 +61,7 @@ const (
 )
 
 const (
-	// ControlPlaneNodeGroup will be used to create availability set for control plane machines
+	// ControlPlaneNodeGroup will be used to create availability set for control plane machines.
 	ControlPlaneNodeGroup = "control-plane"
 )
 
@@ -160,7 +160,7 @@ func GenerateAvailabilitySetName(clusterName, nodeGroup string) string {
 	return fmt.Sprintf("%s_%s-as", clusterName, nodeGroup)
 }
 
-// WithIndex appends the index as suffix to a generated name
+// WithIndex appends the index as suffix to a generated name.
 func WithIndex(name string, n int) string {
 	return fmt.Sprintf("%s-%d", name, n)
 }
@@ -295,13 +295,13 @@ func UserAgent() string {
 	return fmt.Sprintf("cluster-api-provider-azure/%s", version.Get().String())
 }
 
-// SetAutoRestClientDefaults set authorizer and user agent for autorest client
+// SetAutoRestClientDefaults set authorizer and user agent for autorest client.
 func SetAutoRestClientDefaults(c *autorest.Client, auth autorest.Authorizer) {
 	c.Authorizer = auth
 	AutoRestClientAppendUserAgent(c, UserAgent())
 }
 
-// AutoRestClientAppendUserAgent autorest client calls "AddToUserAgent" but ignores errors
+// AutoRestClientAppendUserAgent autorest client calls "AddToUserAgent" but ignores errors.
 func AutoRestClientAppendUserAgent(c *autorest.Client, extension string) {
 	_ = c.AddToUserAgent(extension) // intentionally ignore error as it doesn't matter
 }

--- a/azure/errors.go
+++ b/azure/errors.go
@@ -45,43 +45,43 @@ func ResourceNotFound(err error) bool {
 	return errors.As(err, &derr) && derr.StatusCode == 404
 }
 
-// ResourceConflict parses the error to check if it's a resource conflict error (409)
+// ResourceConflict parses the error to check if it's a resource conflict error (409).
 func ResourceConflict(err error) bool {
 	derr := autorest.DetailedError{}
 	return errors.As(err, &derr) && derr.StatusCode == 409
 }
 
-// VMDeletedError is returned when a virtual machine is deleted outside of capz
+// VMDeletedError is returned when a virtual machine is deleted outside of capz.
 type VMDeletedError struct {
 	ProviderID string
 }
 
-// Error returns the error string
+// Error returns the error string.
 func (vde VMDeletedError) Error() string {
 	return fmt.Sprintf("VM with provider id %q has been deleted", vde.ProviderID)
 }
 
 // ReconcileError represents an error that is not automatically recoverable
-// errorType indicates what type of action is required to recover. It can take two values
-// 1. `Transient` - Can be recovered through manual intervention, will be requeued after
-// 2. `Terminal` - Cannot be recovered, will not be requeued
+// errorType indicates what type of action is required to recover. It can take two values:
+// 1. `Transient` - Can be recovered through manual intervention, will be requeued after.
+// 2. `Terminal` - Cannot be recovered, will not be requeued.
 type ReconcileError struct {
 	error
 	errorType    ReconcileErrorType
 	requestAfter time.Duration
 }
 
-// ReconcileErrorType represents the type of a ReconcileError
+// ReconcileErrorType represents the type of a ReconcileError.
 type ReconcileErrorType string
 
 const (
-	// TransientErrorType can be recovered, will be requeued after a configured time interval
+	// TransientErrorType can be recovered, will be requeued after a configured time interval.
 	TransientErrorType ReconcileErrorType = "Transient"
-	// TerminalErrorType cannot be recovered, will not be requeued
+	// TerminalErrorType cannot be recovered, will not be requeued.
 	TerminalErrorType ReconcileErrorType = "Terminal"
 )
 
-// Error returns the error message for a ReconcileError
+// Error returns the error message for a ReconcileError.
 func (t ReconcileError) Error() string {
 	var errStr string
 	if t.error != nil {
@@ -99,54 +99,54 @@ func (t ReconcileError) Error() string {
 	}
 }
 
-// IsTransient returns if the ReconcileError is recoverable
+// IsTransient returns if the ReconcileError is recoverable.
 func (t ReconcileError) IsTransient() bool {
 	return t.errorType == TransientErrorType
 }
 
-// IsTerminal returns if the ReconcileError is recoverable
+// IsTerminal returns if the ReconcileError is recoverable.
 func (t ReconcileError) IsTerminal() bool {
 	return t.errorType == TerminalErrorType
 }
 
-// Is returns true if the target is a ReconcileError
+// Is returns true if the target is a ReconcileError.
 func (t ReconcileError) Is(target error) bool {
 	return errors.As(target, &ReconcileError{})
 }
 
-// RequeueAfter returns requestAfter value
+// RequeueAfter returns requestAfter value.
 func (t ReconcileError) RequeueAfter() time.Duration {
 	return t.requestAfter
 }
 
-// WithTransientError wraps the error in a ReconcileError with errorType as `Transient`
+// WithTransientError wraps the error in a ReconcileError with errorType as `Transient`.
 func WithTransientError(err error, requeueAfter time.Duration) ReconcileError {
 	return ReconcileError{error: err, errorType: TransientErrorType, requestAfter: requeueAfter}
 }
 
-// WithTerminalError wraps the error in a ReconcileError with errorType as `Terminal`
+// WithTerminalError wraps the error in a ReconcileError with errorType as `Terminal`.
 func WithTerminalError(err error) ReconcileError {
 	return ReconcileError{error: err, errorType: TerminalErrorType}
 }
 
-// OperationNotDoneError is used to represent a long running operation that is not yet complete
+// OperationNotDoneError is used to represent a long-running operation that is not yet complete.
 type OperationNotDoneError struct {
 	Future *infrav1.Future
 }
 
-// NewOperationNotDoneError returns a new OperationNotDoneError wrapping a Future
+// NewOperationNotDoneError returns a new OperationNotDoneError wrapping a Future.
 func NewOperationNotDoneError(future *infrav1.Future) *OperationNotDoneError {
 	return &OperationNotDoneError{
 		Future: future,
 	}
 }
 
-// Error returns the error represented as a string
+// Error returns the error represented as a string.
 func (onde OperationNotDoneError) Error() string {
 	return fmt.Sprintf("operation type %s on Azure resource %s/%s is not done", onde.Future.Type, onde.Future.ResourceGroup, onde.Future.Name)
 }
 
-// Is returns true if the target is an OperationNotDoneError
+// Is returns true if the target is an OperationNotDoneError.
 func (onde OperationNotDoneError) Is(target error) bool {
 	return errors.As(target, &OperationNotDoneError{})
 }

--- a/azure/scope/clients.go
+++ b/azure/scope/clients.go
@@ -48,18 +48,18 @@ func (c *AzureClients) TenantID() string {
 	return c.Values[auth.TenantID]
 }
 
-// ClientID returns the Azure client id from the controller environment
+// ClientID returns the Azure client id from the controller environment.
 func (c *AzureClients) ClientID() string {
 	return c.Values[auth.ClientID]
 }
 
-// ClientSecret returns the Azure client secret from the controller environment
+// ClientSecret returns the Azure client secret from the controller environment.
 func (c *AzureClients) ClientSecret() string {
 	return c.Values[auth.ClientSecret]
 }
 
 // SubscriptionID returns the Azure subscription id of the cluster,
-// either specified or from the environment
+// either specified or from the environment.
 func (c *AzureClients) SubscriptionID() string {
 	return c.Values[auth.SubscriptionID]
 }
@@ -151,7 +151,7 @@ func (c *AzureClients) getSettingsFromEnvironment(environmentName string) (s aut
 	return
 }
 
-// adds the specified environment variable value to the Values map if it exists
+// setValue adds the specified environment variable value to the Values map if it exists.
 func setValue(settings auth.EnvironmentSettings, key string) {
 	if v := os.Getenv(key); v != "" {
 		settings.Values[key] = v

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -220,7 +220,7 @@ func (s *ClusterScope) LBSpecs() []azure.LBSpec {
 	return specs
 }
 
-// RouteTableSpecs returns the node route table
+// RouteTableSpecs returns the node route table.
 func (s *ClusterScope) RouteTableSpecs() []azure.RouteTableSpec {
 	routetables := []azure.RouteTableSpec{}
 	if s.ControlPlaneRouteTable().Name != "" {
@@ -558,7 +558,7 @@ func (s *ClusterScope) APIServerHost() string {
 	return s.APIServerPublicIP().DNSName
 }
 
-// SetFailureDomain will set the spec for a for a given key
+// SetFailureDomain will set the spec for a for a given key.
 func (s *ClusterScope) SetFailureDomain(id string, spec clusterv1.FailureDomainSpec) {
 	if s.AzureCluster.Status.FailureDomains == nil {
 		s.AzureCluster.Status.FailureDomains = make(clusterv1.FailureDomains)

--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -37,7 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// AzureCredentialsProvider provides
+// AzureCredentialsProvider provides credentials for an AzureCluster.
 type AzureCredentialsProvider struct {
 	Client       client.Client
 	AzureCluster *infrav1.AzureCluster
@@ -73,7 +73,7 @@ func NewAzureCredentialsProvider(ctx context.Context, kubeClient client.Client, 
 	}, nil
 }
 
-// GetAuthorizer returns an Azure authorizer based on the provided azure identity
+// GetAuthorizer returns an Azure authorizer based on the provided Azure identity.
 func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, resourceManagerEndpoint string) (autorest.Authorizer, error) {
 	azureIdentityType, err := getAzureIdentityType(p.Identity)
 	if err != nil {
@@ -164,13 +164,13 @@ func getAzureIdentityType(identity *infrav1.AzureClusterIdentity) (aadpodv1.Iden
 
 }
 
-// IsClusterNamespaceAllowed indicates if the cluster namespace is allowed
+// IsClusterNamespaceAllowed indicates if the cluster namespace is allowed.
 func IsClusterNamespaceAllowed(ctx context.Context, k8sClient client.Client, allowedNamespaces *infrav1.AllowedNamespaces, namespace string) bool {
 	if allowedNamespaces == nil {
 		return false
 	}
 
-	// empty value matches with all namespaces
+	// empty value matches with all namespaces.
 	if reflect.DeepEqual(*allowedNamespaces, infrav1.AllowedNamespaces{}) {
 		return true
 	}

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -185,7 +185,7 @@ func (m *MachineScope) NICSpecs() []azure.NICSpec {
 	return specs
 }
 
-// NICNames returns the NIC names
+// NICNames returns the NIC names.
 func (m *MachineScope) NICNames() []string {
 	nicNames := make([]string, len(m.NICSpecs()))
 	for i, nic := range m.NICSpecs() {
@@ -240,7 +240,7 @@ func (m *MachineScope) VMExtensionSpecs() []azure.VMExtensionSpec {
 	return []azure.VMExtensionSpec{}
 }
 
-// Subnet returns the machine's subnet based on its role
+// Subnet returns the machine's subnet based on its role.
 func (m *MachineScope) Subnet() infrav1.SubnetSpec {
 	if m.IsControlPlane() {
 		return m.ControlPlaneSubnet()
@@ -313,7 +313,7 @@ func (m *MachineScope) ProviderID() string {
 	return parsed.String()
 }
 
-// AvailabilitySet returns the availability set for this machine if available
+// AvailabilitySet returns the availability set for this machine if available.
 func (m *MachineScope) AvailabilitySet() (string, bool) {
 	if !m.AvailabilitySetEnabled() {
 		return "", false

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -66,7 +66,7 @@ type (
 		vmssState        *azure.VMSS
 	}
 
-	// NodeStatus represents the status of a Kubernetes node
+	// NodeStatus represents the status of a Kubernetes node.
 	NodeStatus struct {
 		Ready   bool
 		Version string
@@ -554,7 +554,7 @@ func (m *MachinePoolScope) GetVMImage() (*infrav1.Image, error) {
 	return defaultImage, nil
 }
 
-// SaveVMImageToStatus persists the AzureMachinePool image to the status
+// SaveVMImageToStatus persists the AzureMachinePool image to the status.
 func (m *MachinePoolScope) SaveVMImageToStatus(image *infrav1.Image) {
 	m.AzureMachinePool.Status.Image = image
 }

--- a/azure/scope/machinepoolmachine.go
+++ b/azure/scope/machinepoolmachine.go
@@ -147,32 +147,32 @@ func NewMachinePoolMachineScope(params MachinePoolMachineScopeParams) (*MachineP
 	}, nil
 }
 
-// Name is the name of the Machine Pool Machine
+// Name is the name of the Machine Pool Machine.
 func (s *MachinePoolMachineScope) Name() string {
 	return s.AzureMachinePoolMachine.Name
 }
 
-// InstanceID is the unique ID of the machine within the Machine Pool
+// InstanceID is the unique ID of the machine within the Machine Pool.
 func (s *MachinePoolMachineScope) InstanceID() string {
 	return s.AzureMachinePoolMachine.Spec.InstanceID
 }
 
-// ScaleSetName is the name of the VMSS
+// ScaleSetName is the name of the VMSS.
 func (s *MachinePoolMachineScope) ScaleSetName() string {
 	return s.MachinePoolScope.Name()
 }
 
-// GetLongRunningOperationState gets a future representing the current state of a long running operation if one exists
+// GetLongRunningOperationState gets a future representing the current state of a long-running operation if one exists.
 func (s *MachinePoolMachineScope) GetLongRunningOperationState() *infrav1.Future {
 	return s.AzureMachinePoolMachine.Status.LongRunningOperationState
 }
 
-// SetLongRunningOperationState sets a future representing the current state of a long running operation
+// SetLongRunningOperationState sets a future representing the current state of a long-running operation.
 func (s *MachinePoolMachineScope) SetLongRunningOperationState(future *infrav1.Future) {
 	s.AzureMachinePoolMachine.Status.LongRunningOperationState = future
 }
 
-// SetVMSSVM update the scope with the current state of the VMSS VM
+// SetVMSSVM update the scope with the current state of the VMSS VM.
 func (s *MachinePoolMachineScope) SetVMSSVM(instance *azure.VMSSVM) {
 	s.instance = instance
 }
@@ -185,7 +185,7 @@ func (s *MachinePoolMachineScope) ProvisioningState() infrav1.ProvisioningState 
 	return ""
 }
 
-// IsReady indicates the machine has successfully provisioned and has a node ref associated
+// IsReady indicates the machine has successfully provisioned and has a node ref associated.
 func (s *MachinePoolMachineScope) IsReady() bool {
 	state := s.AzureMachinePoolMachine.Status.ProvisioningState
 	return s.AzureMachinePoolMachine.Status.Ready && state != nil && *state == infrav1.Succeeded
@@ -206,7 +206,7 @@ func (s *MachinePoolMachineScope) ProviderID() string {
 	return s.AzureMachinePoolMachine.Spec.ProviderID
 }
 
-// Close updates the state of MachinePoolMachine
+// Close updates the state of MachinePoolMachine.
 func (s *MachinePoolMachineScope) Close(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolMachineScope.Close")
 	defer span.End()

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -33,7 +33,8 @@ import (
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha4"
 )
 
-// ManagedControlPlaneScopeParams defines the input parameters used to create a new
+// ManagedControlPlaneScopeParams defines the input parameters used to create a new managed
+// control plane.
 type ManagedControlPlaneScopeParams struct {
 	AzureClients
 	Client           client.Client
@@ -117,7 +118,7 @@ func (s *ManagedControlPlaneScope) Location() string {
 	return s.ControlPlane.Spec.Location
 }
 
-// AvailabilitySetEnabled is always false for a managed control plane
+// AvailabilitySetEnabled is always false for a managed control plane.
 func (s *ManagedControlPlaneScope) AvailabilitySetEnabled() bool {
 	return false // not applicable for a managed control plane
 }

--- a/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
+++ b/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
@@ -36,7 +36,7 @@ type (
 		Surge(desiredReplicaCount int) (int, error)
 	}
 
-	// DeleteSelector is the ability to select nodes to be delete with respect to a desired number of replicas
+	// DeleteSelector is the ability to select nodes to be delete with respect to a desired number of replicas.
 	DeleteSelector interface {
 		SelectMachinesToDelete(ctx context.Context, desiredReplicas int32, machinesByProviderID map[string]infrav1exp.AzureMachinePoolMachine) ([]infrav1exp.AzureMachinePoolMachine, error)
 	}
@@ -74,12 +74,12 @@ func NewMachinePoolDeploymentStrategy(strategy infrav1exp.AzureMachinePoolDeploy
 	}
 }
 
-// Type is the AzureMachinePoolDeploymentStrategyType for the strategy
+// Type is the AzureMachinePoolDeploymentStrategyType for the strategy.
 func (rollingUpdateStrategy *rollingUpdateStrategy) Type() infrav1exp.AzureMachinePoolDeploymentStrategyType {
 	return infrav1exp.RollingUpdateAzureMachinePoolDeploymentStrategyType
 }
 
-// Surge calculates the number of replicas that can be added during an upgrade operation
+// Surge calculates the number of replicas that can be added during an upgrade operation.
 func (rollingUpdateStrategy *rollingUpdateStrategy) Surge(desiredReplicaCount int) (int, error) {
 	if rollingUpdateStrategy.MaxSurge == nil {
 		return 1, nil

--- a/azure/services/agentpools/client.go
+++ b/azure/services/agentpools/client.go
@@ -27,14 +27,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	Get(context.Context, string, string, string) (containerservice.AgentPool, error)
 	CreateOrUpdate(context.Context, string, string, string, containerservice.AgentPool) error
 	Delete(context.Context, string, string, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	agentpools containerservice.AgentPoolsClient
 }

--- a/azure/services/agentpools/service.go
+++ b/azure/services/agentpools/service.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Client
 }

--- a/azure/services/availabilitysets/availabilitysets.go
+++ b/azure/services/availabilitysets/availabilitysets.go
@@ -39,7 +39,7 @@ type AvailabilitySetScope interface {
 	AvailabilitySet() (string, bool)
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope AvailabilitySetScope
 	Client

--- a/azure/services/availabilitysets/client.go
+++ b/azure/services/availabilitysets/client.go
@@ -25,14 +25,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	Get(ctx context.Context, resourceGroup, availabilitySetsName string) (compute.AvailabilitySet, error)
 	CreateOrUpdate(ctx context.Context, resourceGroup, availabilitySetsName string, params compute.AvailabilitySet) (compute.AvailabilitySet, error)
 	Delete(ctx context.Context, resourceGroup, availabilitySetsName string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	availabilitySets compute.AvailabilitySetsClient
 }
@@ -53,7 +53,7 @@ func newAvailabilitySetsClient(subscriptionID string, baseURI string, authorizer
 	return asClient
 }
 
-// Get gets an availability set
+// Get gets an availability set.
 func (a *AzureClient) Get(ctx context.Context, resourceGroup, availabilitySetsName string) (compute.AvailabilitySet, error) {
 	ctx, span := tele.Tracer().Start(ctx, "availabilitysets.AzureClient.Get")
 	defer span.End()
@@ -61,7 +61,7 @@ func (a *AzureClient) Get(ctx context.Context, resourceGroup, availabilitySetsNa
 	return a.availabilitySets.Get(ctx, resourceGroup, availabilitySetsName)
 }
 
-// CreateOrUpdate creates or updates an availability set
+// CreateOrUpdate creates or updates an availability set.
 func (a *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroup string, availabilitySetsName string,
 	params compute.AvailabilitySet) (compute.AvailabilitySet, error) {
 	ctx, span := tele.Tracer().Start(ctx, "availabilitysets.AzureClient.CreateOrUpdate")
@@ -70,7 +70,7 @@ func (a *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroup string, 
 	return a.availabilitySets.CreateOrUpdate(ctx, resourceGroup, availabilitySetsName, params)
 }
 
-// Delete deletes an availability set
+// Delete deletes an availability set.
 func (a *AzureClient) Delete(ctx context.Context, resourceGroup, availabilitySetsName string) error {
 	ctx, span := tele.Tracer().Start(ctx, "availabilitysets.AzureClient.Delete")
 	defer span.End()

--- a/azure/services/bastionhosts/bastionhosts.go
+++ b/azure/services/bastionhosts/bastionhosts.go
@@ -37,7 +37,7 @@ type BastionScope interface {
 	BastionSpec() azure.BastionSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope BastionScope
 	client

--- a/azure/services/bastionhosts/client.go
+++ b/azure/services/bastionhosts/client.go
@@ -26,14 +26,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// client wraps go-sdk
+// client wraps go-sdk.
 type client interface {
 	Get(context.Context, string, string) (network.BastionHost, error)
 	CreateOrUpdate(context.Context, string, string, network.BastionHost) error
 	Delete(context.Context, string, string) error
 }
 
-// azureClient contains the Azure go-sdk Client
+// azureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	interfaces network.BastionHostsClient
 }

--- a/azure/services/disks/client.go
+++ b/azure/services/disks/client.go
@@ -25,12 +25,12 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type client interface {
 	Delete(context.Context, string, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	disks compute.DisksClient
 }
@@ -50,7 +50,7 @@ func newDisksClient(subscriptionID string, baseURI string, authorizer autorest.A
 	return disksClient
 }
 
-// Delete removes the disk client
+// Delete removes the disk client.
 func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, name string) error {
 	ctx, span := tele.Tracer().Start(ctx, "disks.AzureClient.Delete")
 	defer span.End()

--- a/azure/services/disks/disks.go
+++ b/azure/services/disks/disks.go
@@ -33,7 +33,7 @@ type DiskScope interface {
 	DiskSpecs() []azure.DiskSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope DiskScope
 	client

--- a/azure/services/groups/client.go
+++ b/azure/services/groups/client.go
@@ -26,14 +26,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// client wraps go-sdk
+// client wraps go-sdk.
 type client interface {
 	Get(context.Context, string) (resources.Group, error)
 	CreateOrUpdate(context.Context, string, resources.Group) (resources.Group, error)
 	Delete(context.Context, string) error
 }
 
-// azureClient contains the Azure go-sdk Client
+// azureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	groups resources.GroupsClient
 }

--- a/azure/services/groups/groups.go
+++ b/azure/services/groups/groups.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope GroupScope
 	client

--- a/azure/services/inboundnatrules/client.go
+++ b/azure/services/inboundnatrules/client.go
@@ -26,14 +26,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// client wraps go-sdk
+// client wraps go-sdk.
 type client interface {
 	Get(context.Context, string, string, string) (network.InboundNatRule, error)
 	CreateOrUpdate(context.Context, string, string, string, network.InboundNatRule) error
 	Delete(context.Context, string, string, string) error
 }
 
-// azureClient contains the Azure go-sdk Client
+// azureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	inboundnatrules network.InboundNatRulesClient
 }

--- a/azure/services/inboundnatrules/inboundnatrules.go
+++ b/azure/services/inboundnatrules/inboundnatrules.go
@@ -36,7 +36,7 @@ type InboundNatScope interface {
 	InboundNatSpecs() []azure.InboundNatSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope InboundNatScope
 	client

--- a/azure/services/loadbalancers/client.go
+++ b/azure/services/loadbalancers/client.go
@@ -26,14 +26,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	Get(context.Context, string, string) (network.LoadBalancer, error)
 	CreateOrUpdate(context.Context, string, string, network.LoadBalancer) error
 	Delete(context.Context, string, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	loadbalancers network.LoadBalancersClient
 }

--- a/azure/services/loadbalancers/loadbalancers.go
+++ b/azure/services/loadbalancers/loadbalancers.go
@@ -45,7 +45,7 @@ type LBScope interface {
 	LBSpecs() []azure.LBSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope LBScope
 	Client

--- a/azure/services/managedclusters/client.go
+++ b/azure/services/managedclusters/client.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	Get(context.Context, string, string) (containerservice.ManagedCluster, error)
 	GetCredentials(context.Context, string, string) ([]byte, error)
@@ -35,7 +35,7 @@ type Client interface {
 	Delete(context.Context, string, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	managedclusters containerservice.ManagedClustersClient
 }

--- a/azure/services/managedclusters/service.go
+++ b/azure/services/managedclusters/service.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Client
 }

--- a/azure/services/networkinterfaces/client.go
+++ b/azure/services/networkinterfaces/client.go
@@ -26,14 +26,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	Get(context.Context, string, string) (network.Interface, error)
 	CreateOrUpdate(context.Context, string, string, network.Interface) error
 	Delete(context.Context, string, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	interfaces network.InterfacesClient
 }

--- a/azure/services/networkinterfaces/networkinterfaces.go
+++ b/azure/services/networkinterfaces/networkinterfaces.go
@@ -36,7 +36,7 @@ type NICScope interface {
 	NICSpecs() []azure.NICSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope NICScope
 	Client

--- a/azure/services/privatedns/client.go
+++ b/azure/services/privatedns/client.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type client interface {
 	CreateOrUpdateZone(context.Context, string, string, privatedns.PrivateZone) error
 	DeleteZone(context.Context, string, string) error
@@ -36,7 +36,7 @@ type client interface {
 	DeleteRecordSet(context.Context, string, string, privatedns.RecordType, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	privatezones privatedns.PrivateZonesClient
 	vnetlinks    privatedns.VirtualNetworkLinksClient

--- a/azure/services/publicips/client.go
+++ b/azure/services/publicips/client.go
@@ -26,14 +26,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	Get(context.Context, string, string) (network.PublicIPAddress, error)
 	CreateOrUpdate(context.Context, string, string, network.PublicIPAddress) error
 	Delete(context.Context, string, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	publicips network.PublicIPAddressesClient
 }

--- a/azure/services/resourceskus/cache.go
+++ b/azure/services/resourceskus/cache.go
@@ -48,13 +48,13 @@ type Cache struct {
 	data []compute.ResourceSku
 }
 
-// Cacher describes the ability to get and to add items to cache
+// Cacher describes the ability to get and to add items to cache.
 type Cacher interface {
 	Get(key interface{}) (value interface{}, ok bool)
 	Add(key interface{}, value interface{}) bool
 }
 
-// NewCacheFunc allows for mocking out the underlying client
+// NewCacheFunc allows for mocking out the underlying client.
 type NewCacheFunc func(azure.Authorizer, string) *Cache
 
 var (
@@ -71,7 +71,7 @@ func newCache(auth azure.Authorizer, location string) *Cache {
 	}
 }
 
-// GetCache either creates a new SKUs cache or returns an existing one based on the location + Authorizer HashKey()
+// GetCache either creates a new SKUs cache or returns an existing one based on the location + Authorizer HashKey().
 func GetCache(auth azure.Authorizer, location string) (*Cache, error) {
 	var err error
 	doOnce.Do(func() {

--- a/azure/services/resourceskus/client.go
+++ b/azure/services/resourceskus/client.go
@@ -27,12 +27,12 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	List(context.Context, string) ([]compute.ResourceSku, error)
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	skus compute.ResourceSkusClient
 }

--- a/azure/services/resourceskus/sku.go
+++ b/azure/services/resourceskus/sku.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// SKU is a thin layer over the Azure resource SKU API to better introspect capabilities
+// SKU is a thin layer over the Azure resource SKU API to better introspect capabilities.
 type SKU compute.ResourceSku
 
 // ResourceType models available resource types as a set of known string constants.
@@ -43,9 +43,9 @@ const (
 type Supported string
 
 const (
-	// CapabilitySupported is the value returned by this API from Azure when the capability is supported
+	// CapabilitySupported is the value returned by this API from Azure when the capability is supported.
 	CapabilitySupported Supported = "True"
-	// CapabilityUnsupported is the value returned by this API from Azure when the capability is unsupported
+	// CapabilityUnsupported is the value returned by this API from Azure when the capability is unsupported.
 	CapabilityUnsupported Supported = "False"
 )
 
@@ -64,14 +64,14 @@ const (
 	MinimumMemory = 2
 	// EncryptionAtHost identifies the capability for encryption at host.
 	EncryptionAtHost = "EncryptionAtHostSupported"
-	// MaximumPlatformFaultDomainCount identifies the maximum fault domain count for an availability set  in a region
+	// MaximumPlatformFaultDomainCount identifies the maximum fault domain count for an availability set in a region.
 	MaximumPlatformFaultDomainCount = "MaximumPlatformFaultDomainCount"
 )
 
 // HasCapability return true for a capability which can be either
 // supported or not. Examples include "EphemeralOSDiskSupported",
 // "UltraSSDAvavailable" "EncryptionAtHostSupported",
-// "AcceleratedNetworkingEnabled", and "RdmaEnabled"
+// "AcceleratedNetworkingEnabled", and "RdmaEnabled".
 func (s SKU) HasCapability(name string) bool {
 	if s.Capabilities != nil {
 		for _, capability := range *s.Capabilities {
@@ -92,7 +92,7 @@ func (s SKU) HasCapability(name string) bool {
 // "MemoryGB","MaxDataDiskCount", "CombinedTempDiskAndCachedIOPS",
 // "CombinedTempDiskAndCachedReadBytesPerSecond",
 // "CombinedTempDiskAndCachedWriteBytesPerSecond", "UncachedDiskIOPS",
-// and "UncachedDiskBytesPerSecond"
+// and "UncachedDiskBytesPerSecond".
 func (s SKU) HasCapabilityWithCapacity(name string, value int64) (bool, error) {
 	if s.Capabilities == nil {
 		return false, nil
@@ -116,8 +116,8 @@ func (s SKU) HasCapabilityWithCapacity(name string, value int64) (bool, error) {
 	return false, nil
 }
 
-// GetCapability gets the value assigned to the given capability
-// Eg. MaximumPlatformFaultDomainCount -> "3" will return "3" for the capability "MaximumPlatformFaultDomainCount"
+// GetCapability gets the value assigned to the given capability.
+// Eg. MaximumPlatformFaultDomainCount -> "3" will return "3" for the capability "MaximumPlatformFaultDomainCount".
 func (s SKU) GetCapability(name string) (string, bool) {
 	if s.Capabilities != nil {
 		for _, capability := range *s.Capabilities {

--- a/azure/services/roleassignments/client.go
+++ b/azure/services/roleassignments/client.go
@@ -26,12 +26,12 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// client wraps go-sdk
+// client wraps go-sdk.
 type client interface {
 	Create(context.Context, string, string, authorization.RoleAssignmentCreateParameters) (authorization.RoleAssignment, error)
 }
 
-// azureClient contains the Azure go-sdk Client
+// azureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	roleassignments authorization.RoleAssignmentsClient
 }

--- a/azure/services/roleassignments/roleassignments.go
+++ b/azure/services/roleassignments/roleassignments.go
@@ -40,7 +40,7 @@ type RoleAssignmentScope interface {
 	RoleAssignmentSpecs() []azure.RoleAssignmentSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope RoleAssignmentScope
 	client

--- a/azure/services/routetables/client.go
+++ b/azure/services/routetables/client.go
@@ -26,14 +26,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// client wraps go-sdk
+// client wraps go-sdk.
 type client interface {
 	Get(context.Context, string, string) (network.RouteTable, error)
 	CreateOrUpdate(context.Context, string, string, network.RouteTable) error
 	Delete(context.Context, string, string) error
 }
 
-// azureClient contains the Azure go-sdk Client
+// azureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	routetables network.RouteTablesClient
 }

--- a/azure/services/routetables/routetables.go
+++ b/azure/services/routetables/routetables.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// RouteTableScope defines the scope interface for route table service
+// RouteTableScope defines the scope interface for route table service.
 type RouteTableScope interface {
 	logr.Logger
 	azure.ClusterDescriber
@@ -37,7 +37,7 @@ type RouteTableScope interface {
 	RouteTableSpecs() []azure.RouteTableSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on azure resources.
 type Service struct {
 	Scope RouteTableScope
 	client

--- a/azure/services/scalesets/client.go
+++ b/azure/services/scalesets/client.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	List(context.Context, string) ([]compute.VirtualMachineScaleSet, error)
 	ListInstances(context.Context, string, string) ([]compute.VirtualMachineScaleSetVM, error)
@@ -51,7 +51,7 @@ type Client interface {
 }
 
 type (
-	// AzureClient contains the Azure go-sdk Client
+	// AzureClient contains the Azure go-sdk Client.
 	AzureClient struct {
 		scalesetvms compute.VirtualMachineScaleSetVMsClient
 		scalesets   compute.VirtualMachineScaleSetsClient
@@ -74,11 +74,11 @@ type (
 )
 
 const (
-	// PatchFuture is a future that was derived from a PATCH request to VMSS
+	// PatchFuture is a future that was derived from a PATCH request to VMSS.
 	PatchFuture string = "PATCH"
-	// PutFuture is a future that was derived from a PUT request to VMSS
+	// PutFuture is a future that was derived from a PUT request to VMSS.
 	PutFuture string = "PUT"
-	// DeleteFuture is a future that was derived from a DELETE request to VMSS
+	// DeleteFuture is a future that was derived from a DELETE request to VMSS.
 	DeleteFuture string = "DELETE"
 )
 
@@ -266,7 +266,7 @@ func (ac *AzureClient) UpdateAsync(ctx context.Context, resourceGroupName, vmssN
 	}, nil
 }
 
-// GetResultIfDone fetches the result of a long running operation future if it is done
+// GetResultIfDone fetches the result of a long-running operation future if it is done.
 func (ac *AzureClient) GetResultIfDone(ctx context.Context, future *infrav1.Future) (compute.VirtualMachineScaleSet, error) {
 	var genericFuture genericScaleSetFuture
 	futureData, err := base64.URLEncoding.DecodeString(future.FutureData)

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -55,7 +55,7 @@ type (
 		SetVMSSState(*azure.VMSS)
 	}
 
-	// Service provides operations on azure resources
+	// Service provides operations on Azure resources.
 	Service struct {
 		Scope ScaleSetScope
 		Client
@@ -112,7 +112,7 @@ func (s *Service) Reconcile(ctx context.Context) (retErr error) {
 
 	switch {
 	case err != nil && !azure.ResourceNotFound(err):
-		// There was an error and it was not an HTTP 404 not found. This is either a transient error, like long running operation not done, or a Azure service error.
+		// There was an error and it was not an HTTP 404 not found. This is either a transient error, like long running operation not done, or an Azure service error.
 		return errors.Wrapf(err, "failed to get VMSS %s", s.Scope.ScaleSetSpec().Name)
 	case err != nil && azure.ResourceNotFound(err):
 		// HTTP(404) resource was not found, so we need to create it with a PUT
@@ -462,7 +462,7 @@ func (s *Service) buildVMSSFromSpec(ctx context.Context, vmssSpec azure.ScaleSet
 	return vmss, nil
 }
 
-// getVirtualMachineScaleSet provides information about a Virtual Machine Scale Set and its instances
+// getVirtualMachineScaleSet provides information about a Virtual Machine Scale Set and its instances.
 func (s *Service) getVirtualMachineScaleSet(ctx context.Context) (*azure.VMSS, error) {
 	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.getVirtualMachineScaleSet")
 	defer span.End()
@@ -481,7 +481,7 @@ func (s *Service) getVirtualMachineScaleSet(ctx context.Context) (*azure.VMSS, e
 	return converters.SDKToVMSS(vmss, vmssInstances), nil
 }
 
-// getVirtualMachineScaleSetIfDone gets a Virtual Machine Scale Set and its instances from Azure if the future is completed
+// getVirtualMachineScaleSetIfDone gets a Virtual Machine Scale Set and its instances from Azure if the future is completed.
 func (s *Service) getVirtualMachineScaleSetIfDone(ctx context.Context, future *infrav1.Future) (*azure.VMSS, error) {
 	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.getVirtualMachineScaleSetIfDone")
 	defer span.End()

--- a/azure/services/scalesetvms/client.go
+++ b/azure/services/scalesetvms/client.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// client wraps go-sdk
+// client wraps go-sdk.
 type client interface {
 	Get(context.Context, string, string, string) (compute.VirtualMachineScaleSetVM, error)
 	GetResultIfDone(ctx context.Context, future *infrav1.Future) (compute.VirtualMachineScaleSetVM, error)
@@ -39,7 +39,7 @@ type client interface {
 }
 
 type (
-	// azureClient contains the Azure go-sdk Client
+	// azureClient contains the Azure go-sdk Client.
 	azureClient struct {
 		scalesetvms compute.VirtualMachineScaleSetVMsClient
 	}
@@ -55,7 +55,7 @@ type (
 )
 
 const (
-	// DeleteFuture is a future that was derived from a DELETE request to VMSS
+	// DeleteFuture is a future that was derived from a DELETE request to VMSS.
 	DeleteFuture string = "DELETE"
 )
 
@@ -77,7 +77,7 @@ func newVirtualMachineScaleSetVMsClient(subscriptionID string, baseURI string, a
 	return c
 }
 
-// Get retrieves the Virtual Machine Scale Set Virtual Machine
+// Get retrieves the Virtual Machine Scale Set Virtual Machine.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmssName, instanceID string) (compute.VirtualMachineScaleSetVM, error) {
 	ctx, span := tele.Tracer().Start(ctx, "scalesetvms.azureClient.Get")
 	defer span.End()
@@ -85,7 +85,7 @@ func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmssName, ins
 	return ac.scalesetvms.Get(ctx, resourceGroupName, vmssName, instanceID, "")
 }
 
-// GetResultIfDone fetches the result of a long running operation future if it is done
+// GetResultIfDone fetches the result of a long-running operation future if it is done.
 func (ac *azureClient) GetResultIfDone(ctx context.Context, future *infrav1.Future) (compute.VirtualMachineScaleSetVM, error) {
 	ctx, span := tele.Tracer().Start(ctx, "scalesetvms.azureClient.GetResultIfDone")
 	defer span.End()

--- a/azure/services/scalesetvms/scalesetvms.go
+++ b/azure/services/scalesetvms/scalesetvms.go
@@ -41,7 +41,7 @@ type (
 		SetLongRunningOperationState(future *infrav1.Future)
 	}
 
-	// Service provides operations on azure resources
+	// Service provides operations on Azure resources.
 	Service struct {
 		Client client
 		Scope  ScaleSetVMScope
@@ -80,7 +80,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	return nil
 }
 
-// Delete deletes a scaleset instance asynchronously returning a future which encapsulates the long running operation.
+// Delete deletes a scaleset instance asynchronously returning a future which encapsulates the long-running operation.
 func (s *Service) Delete(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "scalesetvms.Service.Delete")
 	defer span.End()

--- a/azure/services/securitygroups/client.go
+++ b/azure/services/securitygroups/client.go
@@ -26,14 +26,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// client wraps go-sdk
+// client wraps go-sdk.
 type client interface {
 	Get(context.Context, string, string) (network.SecurityGroup, error)
 	CreateOrUpdate(context.Context, string, string, network.SecurityGroup) error
 	Delete(context.Context, string, string) error
 }
 
-// azureClient contains the Azure go-sdk Client
+// azureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	securitygroups network.SecurityGroupsClient
 }

--- a/azure/services/securitygroups/securitygroups.go
+++ b/azure/services/securitygroups/securitygroups.go
@@ -38,7 +38,7 @@ type NSGScope interface {
 	NSGSpecs() []azure.NSGSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope NSGScope
 	client

--- a/azure/services/subnets/client.go
+++ b/azure/services/subnets/client.go
@@ -26,14 +26,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	Get(context.Context, string, string, string) (network.Subnet, error)
 	CreateOrUpdate(context.Context, string, string, string, network.Subnet) error
 	Delete(context.Context, string, string, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	subnets network.SubnetsClient
 }

--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -37,7 +37,7 @@ type SubnetScope interface {
 	SubnetSpecs() []azure.SubnetSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope SubnetScope
 	Client

--- a/azure/services/tags/client.go
+++ b/azure/services/tags/client.go
@@ -26,13 +26,13 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// client wraps go-sdk
+// client wraps go-sdk.
 type client interface {
 	GetAtScope(context.Context, string) (resources.TagsResource, error)
 	CreateOrUpdateAtScope(context.Context, string, resources.TagsResource) (resources.TagsResource, error)
 }
 
-// azureClient contains the Azure go-sdk Client
+// azureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	tags resources.TagsClient
 }

--- a/azure/services/tags/tags.go
+++ b/azure/services/tags/tags.go
@@ -37,7 +37,7 @@ type TagScope interface {
 	UpdateAnnotationJSON(string, map[string]interface{}) error
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope TagScope
 	client

--- a/azure/services/virtualmachines/client.go
+++ b/azure/services/virtualmachines/client.go
@@ -27,14 +27,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	Get(context.Context, string, string) (compute.VirtualMachine, error)
 	CreateOrUpdate(context.Context, string, string, compute.VirtualMachine) error
 	Delete(context.Context, string, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	virtualmachines compute.VirtualMachinesClient
 }

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -55,7 +55,7 @@ type VMScope interface {
 	UpdateStatus()
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope VMScope
 	Client
@@ -324,7 +324,7 @@ func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine) (
 	return addresses, nil
 }
 
-// getPublicIPAddress will fetch a public ip address resource by name and return a nodeaddresss representation
+// getPublicIPAddress will fetch a public ip address resource by name and return a nodeaddresss representation.
 func (s *Service) getPublicIPAddress(ctx context.Context, publicIPAddressName string) (corev1.NodeAddress, error) {
 	ctx, span := tele.Tracer().Start(ctx, "virtualmachines.Service.getPublicIPAddress")
 	defer span.End()

--- a/azure/services/virtualnetworks/client.go
+++ b/azure/services/virtualnetworks/client.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type Client interface {
 	Get(context.Context, string, string) (network.VirtualNetwork, error)
 	CreateOrUpdate(context.Context, string, string, network.VirtualNetwork) error
@@ -34,7 +34,7 @@ type Client interface {
 	CheckIPAddressAvailability(context.Context, string, string, string) (network.IPAddressAvailabilityResult, error)
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type AzureClient struct {
 	virtualnetworks network.VirtualNetworksClient
 }

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -38,7 +38,7 @@ type VNetScope interface {
 	VNetSpec() azure.VNetSpec
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope VNetScope
 	Client

--- a/azure/services/vmextensions/client.go
+++ b/azure/services/vmextensions/client.go
@@ -25,14 +25,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// client wraps go-sdk.
 type client interface {
 	Get(ctx context.Context, resourceGroupName, vmName, name string) (compute.VirtualMachineExtension, error)
 	CreateOrUpdateAsync(context.Context, string, string, string, compute.VirtualMachineExtension) error
 	Delete(context.Context, string, string, string) error
 }
 
-// AzureClient contains the Azure go-sdk Client
+// azureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	vmextensions compute.VirtualMachineExtensionsClient
 }
@@ -52,7 +52,7 @@ func newVirtualMachineExtensionsClient(subscriptionID string, baseURI string, au
 	return vmextensionsClient
 }
 
-// Get the virtual machine extension
+// Get the virtual machine extension.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmName, name string) (compute.VirtualMachineExtension, error) {
 	ctx, span := tele.Tracer().Start(ctx, "vmextensions.AzureClient.Get")
 	defer span.End()

--- a/azure/services/vmextensions/vmextensions.go
+++ b/azure/services/vmextensions/vmextensions.go
@@ -35,7 +35,7 @@ type VMExtensionScope interface {
 	SetBootstrapConditions(string, string) error
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope VMExtensionScope
 	client

--- a/azure/services/vmssextensions/client.go
+++ b/azure/services/vmssextensions/client.go
@@ -25,12 +25,12 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk
+// Client wraps go-sdk.
 type client interface {
 	Get(context.Context, string, string, string) (compute.VirtualMachineScaleSetExtension, error)
 }
 
-// AzureClient contains the Azure go-sdk Client
+// AzureClient contains the Azure go-sdk Client.
 type azureClient struct {
 	vmssextensions compute.VirtualMachineScaleSetExtensionsClient
 }
@@ -50,7 +50,7 @@ func newVirtualMachineScaleSetExtensionsClient(subscriptionID string, baseURI st
 	return vmssextensionsClient
 }
 
-// Get creates or updates the virtual machine scale set extension
+// Get creates or updates the virtual machine scale set extension.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmssName, name string) (compute.VirtualMachineScaleSetExtension, error) {
 	ctx, span := tele.Tracer().Start(ctx, "vmssextensions.AzureClient.Get")
 	defer span.End()

--- a/azure/services/vmssextensions/vmssextensions.go
+++ b/azure/services/vmssextensions/vmssextensions.go
@@ -34,7 +34,7 @@ type VMSSExtensionScope interface {
 	SetBootstrapConditions(string, string) error
 }
 
-// Service provides operations on azure resources
+// Service provides operations on Azure resources.
 type Service struct {
 	Scope VMSSExtensionScope
 	client

--- a/azure/types.go
+++ b/azure/types.go
@@ -108,7 +108,7 @@ type RoleAssignmentSpec struct {
 }
 
 // ResourceType defines the type azure resource being reconciled.
-// Eg. Virtual Machine, Virtual Machine Scale Sets
+// Eg. Virtual Machine, Virtual Machine Scale Sets.
 type ResourceType string
 
 const (
@@ -252,7 +252,7 @@ func (vmss VMSS) HasModelChanges(other VMSS) bool {
 	return !equal
 }
 
-// InstancesByProviderID returns VMSSVMs by ID
+// InstancesByProviderID returns VMSSVMs by ID.
 func (vmss VMSS) InstancesByProviderID() map[string]VMSSVM {
 	instancesByProviderID := make(map[string]VMSSVM, len(vmss.Instances))
 	for _, instance := range vmss.Instances {
@@ -262,12 +262,12 @@ func (vmss VMSS) InstancesByProviderID() map[string]VMSSVM {
 	return instancesByProviderID
 }
 
-// ProviderID returns the K8s provider ID for the VMSS instance
+// ProviderID returns the K8s provider ID for the VMSS instance.
 func (vm VMSSVM) ProviderID() string {
 	return ProviderIDPrefix + vm.ID
 }
 
-// HasLatestModelAppliedToAll returns true if all VMSS instance have the latest model applied
+// HasLatestModelAppliedToAll returns true if all VMSS instance have the latest model applied.
 func (vmss VMSS) HasLatestModelAppliedToAll() bool {
 	for _, instance := range vmss.Instances {
 		if !vmss.HasLatestModelApplied(instance) {
@@ -278,7 +278,7 @@ func (vmss VMSS) HasLatestModelAppliedToAll() bool {
 	return true
 }
 
-// HasEnoughLatestModelOrNotMixedModel returns true if VMSS instance have the latest model applied to all or equal to the capacity
+// HasEnoughLatestModelOrNotMixedModel returns true if VMSS instance have the latest model applied to all or equal to the capacity.
 func (vmss VMSS) HasEnoughLatestModelOrNotMixedModel() bool {
 	if vmss.HasLatestModelAppliedToAll() {
 		return true
@@ -294,7 +294,7 @@ func (vmss VMSS) HasEnoughLatestModelOrNotMixedModel() bool {
 	return counter == vmss.Capacity
 }
 
-// HasLatestModelApplied returns true if the VMSS instance matches the VMSS image reference
+// HasLatestModelApplied returns true if the VMSS instance matches the VMSS image reference.
 func (vmss VMSS) HasLatestModelApplied(vm VMSSVM) bool {
 	// if the images match, then the VM is of the same model
 	return reflect.DeepEqual(vm.Image, vmss.Image)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
@@ -21,7 +21,7 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureClusterIdentity is the Schema for the azureclustersidentities API
+        description: AzureClusterIdentity is the Schema for the azureclustersidentities API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -32,7 +32,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity
+            description: AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.
             properties:
               allowedNamespaces:
                 description: "AllowedNamespaces is an array of namespaces that AzureClusters can use this Identity from. \n An empty list (default) indicates that AzureClusters can use this Identity from any namespace. This field is intentionally not a pointer because the nil behavior (no namespaces) is undesirable here."
@@ -70,7 +70,7 @@ spec:
             - type
             type: object
           status:
-            description: AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity
+            description: AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity.
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureClusterIdentity.
@@ -110,7 +110,7 @@ spec:
   - name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AzureClusterIdentity is the Schema for the azureclustersidentities API
+        description: AzureClusterIdentity is the Schema for the azureclustersidentities API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -121,7 +121,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity
+            description: AzureClusterIdentitySpec defines the parameters that are used to create an AzureIdentity.
             properties:
               allowedNamespaces:
                 description: AllowedNamespaces is used to identify the namespaces the clusters are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AzureClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.
@@ -195,7 +195,7 @@ spec:
             - type
             type: object
           status:
-            description: AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity
+            description: AzureClusterIdentityStatus defines the observed state of AzureClusterIdentity.
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureClusterIdentity.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -46,7 +46,7 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureCluster is the Schema for the azureclusters API
+        description: AzureCluster is the Schema for the azureclusters API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -57,7 +57,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureClusterSpec defines the desired state of AzureCluster
+            description: AzureClusterSpec defines the desired state of AzureCluster.
             properties:
               additionalTags:
                 additionalProperties:
@@ -266,7 +266,7 @@ spec:
             - location
             type: object
           status:
-            description: AzureClusterStatus defines the observed state of AzureCluster
+            description: AzureClusterStatus defines the observed state of AzureCluster.
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureCluster.
@@ -349,7 +349,7 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AzureCluster is the Schema for the azureclusters API
+        description: AzureCluster is the Schema for the azureclusters API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -360,7 +360,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureClusterSpec defines the desired state of AzureCluster
+            description: AzureClusterSpec defines the desired state of AzureCluster.
             properties:
               additionalTags:
                 additionalProperties:
@@ -567,7 +567,7 @@ spec:
                 - port
                 type: object
               identityRef:
-                description: IdentityRef is a reference to a AzureIdentity to be used when reconciling this cluster
+                description: IdentityRef is a reference to an AzureIdentity to be used when reconciling this cluster
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -815,7 +815,7 @@ spec:
             - location
             type: object
           status:
-            description: AzureClusterStatus defines the observed state of AzureCluster
+            description: AzureClusterStatus defines the observed state of AzureCluster.
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureCluster.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepoolmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepoolmachines.yaml
@@ -46,7 +46,7 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AzureMachinePoolMachine is the Schema for the azuremachinepoolmachines API
+        description: AzureMachinePoolMachine is the Schema for the azuremachinepoolmachines API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -57,7 +57,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachinePoolMachineSpec defines the desired state of AzureMachinePoolMachine
+            description: AzureMachinePoolMachineSpec defines the desired state of AzureMachinePoolMachine.
             properties:
               instanceID:
                 description: InstanceID is the identification of the Machine Instance within the VMSS
@@ -70,7 +70,7 @@ spec:
             - providerID
             type: object
           status:
-            description: AzureMachinePoolMachineStatus defines the observed state of AzureMachinePoolMachine
+            description: AzureMachinePoolMachineStatus defines the observed state of AzureMachinePoolMachine.
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureMachinePool.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -56,7 +56,7 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureMachinePool is the Schema for the azuremachinepools API
+        description: AzureMachinePool is the Schema for the azuremachinepools API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -67,7 +67,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachinePoolSpec defines the desired state of AzureMachinePool
+            description: AzureMachinePoolSpec defines the desired state of AzureMachinePool.
             properties:
               additionalTags:
                 additionalProperties:
@@ -296,7 +296,7 @@ spec:
             - template
             type: object
           status:
-            description: AzureMachinePoolStatus defines the observed state of AzureMachinePool
+            description: AzureMachinePoolStatus defines the observed state of AzureMachinePool.
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureMachinePool.
@@ -336,7 +336,7 @@ spec:
               instances:
                 description: Instances is the VM instance status for each VM in the VMSS
                 items:
-                  description: AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS
+                  description: AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.
                   properties:
                     instanceID:
                       description: InstanceID is the identification of the Machine Instance within the VMSS
@@ -364,16 +364,16 @@ spec:
                 description: LongRunningOperationState saves the state for an Azure long running operations so it can be continued on the next reconciliation loop.
                 properties:
                   futureData:
-                    description: FutureData is the base64 url encoded json Azure AutoRest Future
+                    description: FutureData is the base64 url encoded json Azure AutoRest Future.
                     type: string
                   name:
-                    description: Name is the name of the Azure resource
+                    description: Name is the name of the Azure resource.
                     type: string
                   resourceGroup:
-                    description: ResourceGroup is the Azure resource group for the resource
+                    description: ResourceGroup is the Azure resource group for the resource.
                     type: string
                   type:
-                    description: Type describes the type of future, update, create, delete, etc
+                    description: Type describes the type of future, update, create, delete, etc.
                     type: string
                 required:
                 - type
@@ -433,7 +433,7 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AzureMachinePool is the Schema for the azuremachinepools API
+        description: AzureMachinePool is the Schema for the azuremachinepools API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -444,7 +444,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachinePoolSpec defines the desired state of AzureMachinePool
+            description: AzureMachinePoolSpec defines the desired state of AzureMachinePool.
             properties:
               additionalTags:
                 additionalProperties:
@@ -720,7 +720,7 @@ spec:
             - template
             type: object
           status:
-            description: AzureMachinePoolStatus defines the observed state of AzureMachinePool
+            description: AzureMachinePoolStatus defines the observed state of AzureMachinePool.
             properties:
               conditions:
                 description: Conditions defines current service state of the AzureMachinePool.
@@ -826,7 +826,7 @@ spec:
               instances:
                 description: Instances is the VM instance status for each VM in the VMSS
                 items:
-                  description: AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS
+                  description: AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.
                   properties:
                     instanceID:
                       description: InstanceID is the identification of the Machine Instance within the VMSS
@@ -851,7 +851,7 @@ spec:
                   type: object
                 type: array
               longRunningOperationState:
-                description: LongRunningOperationState saves the state for an Azure long running operations so it can be continued on the next reconciliation loop.
+                description: LongRunningOperationState saves the state for an Azure long-running operations so it can be continued on the next reconciliation loop.
                 properties:
                   futureData:
                     description: FutureData is the base64 url encoded json Azure AutoRest Future

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -50,7 +50,7 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureMachine is the Schema for the azuremachines API
+        description: AzureMachine is the Schema for the azuremachines API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -61,7 +61,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachineSpec defines the desired state of AzureMachine
+            description: AzureMachineSpec defines the desired state of AzureMachine.
             properties:
               acceleratedNetworking:
                 description: AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.
@@ -258,7 +258,7 @@ spec:
                     type: boolean
                 type: object
               spotVMOptions:
-                description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
+                description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM.
                 properties:
                   maxPrice:
                     anyOf:
@@ -291,7 +291,7 @@ spec:
             - vmSize
             type: object
           status:
-            description: AzureMachineStatus defines the observed state of AzureMachine
+            description: AzureMachineStatus defines the observed state of AzureMachine.
             properties:
               addresses:
                 description: Addresses contains the Azure instance associated addresses.
@@ -388,7 +388,7 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AzureMachine is the Schema for the azuremachines API
+        description: AzureMachine is the Schema for the azuremachines API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -399,7 +399,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachineSpec defines the desired state of AzureMachine
+            description: AzureMachineSpec defines the desired state of AzureMachine.
             properties:
               acceleratedNetworking:
                 description: AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.
@@ -622,7 +622,7 @@ spec:
             - vmSize
             type: object
           status:
-            description: AzureMachineStatus defines the observed state of AzureMachine
+            description: AzureMachineStatus defines the observed state of AzureMachine.
             properties:
               addresses:
                 description: Addresses contains the Azure instance associated addresses.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -21,7 +21,7 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureMachineTemplate is the Schema for the azuremachinetemplates API
+        description: AzureMachineTemplate is the Schema for the azuremachinetemplates API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -32,10 +32,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate
+            description: AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate.
             properties:
               template:
-                description: AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template
+                description: AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template.
                 properties:
                   spec:
                     description: Spec is the specification of the desired behavior of the machine.
@@ -235,7 +235,7 @@ spec:
                             type: boolean
                         type: object
                       spotVMOptions:
-                        description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
+                        description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM.
                         properties:
                           maxPrice:
                             anyOf:
@@ -279,7 +279,7 @@ spec:
   - name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AzureMachineTemplate is the Schema for the azuremachinetemplates API
+        description: AzureMachineTemplate is the Schema for the azuremachinetemplates API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -290,10 +290,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate
+            description: AzureMachineTemplateSpec defines the desired state of AzureMachineTemplate.
             properties:
               template:
-                description: AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template
+                description: AzureMachineTemplateResource describes the data needed to create an AzureMachine from a template.
                 properties:
                   spec:
                     description: Spec is the specification of the desired behavior of the machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedclusters.yaml
@@ -23,7 +23,7 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureManagedCluster is the Schema for the azuremanagedclusters API
+        description: AzureManagedCluster is the Schema for the azuremanagedclusters API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureManagedClusterSpec defines the desired state of AzureManagedCluster
+            description: AzureManagedClusterSpec defines the desired state of AzureManagedCluster.
             properties:
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
@@ -52,7 +52,7 @@ spec:
                 type: object
             type: object
           status:
-            description: AzureManagedClusterStatus defines the observed state of AzureManagedCluster
+            description: AzureManagedClusterStatus defines the observed state of AzureManagedCluster.
             properties:
               ready:
                 description: Ready is true when the provider resource is ready.
@@ -66,7 +66,7 @@ spec:
   - name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AzureManagedCluster is the Schema for the azuremanagedclusters API
+        description: AzureManagedCluster is the Schema for the azuremanagedclusters API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -77,7 +77,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureManagedClusterSpec defines the desired state of AzureManagedCluster
+            description: AzureManagedClusterSpec defines the desired state of AzureManagedCluster.
             properties:
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
@@ -95,7 +95,7 @@ spec:
                 type: object
             type: object
           status:
-            description: AzureManagedClusterStatus defines the observed state of AzureManagedCluster
+            description: AzureManagedClusterStatus defines the observed state of AzureManagedCluster.
             properties:
               ready:
                 description: Ready is true when the provider resource is ready.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -23,7 +23,7 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API
+        description: AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane
+            description: AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.
             properties:
               additionalTags:
                 additionalProperties:
@@ -133,7 +133,7 @@ spec:
             - version
             type: object
           status:
-            description: AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane
+            description: AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.
             properties:
               initialized:
                 description: Initialized is true when the the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.
@@ -150,7 +150,7 @@ spec:
   - name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API
+        description: AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -161,7 +161,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane
+            description: AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.
             properties:
               additionalTags:
                 additionalProperties:
@@ -259,7 +259,7 @@ spec:
             - version
             type: object
           status:
-            description: AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane
+            description: AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.
             properties:
               initialized:
                 description: Initialized is true when the the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
@@ -23,7 +23,7 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API
+        description: AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool
+            description: AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.
             properties:
               osDiskSizeGB:
                 description: OSDiskSizeGB is the disk size for every machine in this agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
@@ -52,7 +52,7 @@ spec:
             - sku
             type: object
           status:
-            description: AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool
+            description: AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.
             properties:
               errorMessage:
                 description: Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.
@@ -76,7 +76,7 @@ spec:
   - name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API
+        description: AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -87,7 +87,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool
+            description: AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.
             properties:
               osDiskSizeGB:
                 description: OSDiskSizeGB is the disk size for every machine in this agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
@@ -105,7 +105,7 @@ spec:
             - sku
             type: object
           status:
-            description: AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool
+            description: AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.
             properties:
               errorMessage:
                 description: Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -48,7 +48,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// AzureClusterReconciler reconciles a AzureCluster object
+// AzureClusterReconciler reconciles an AzureCluster object.
 type AzureClusterReconciler struct {
 	client.Client
 	Log                       logr.Logger
@@ -60,7 +60,7 @@ type AzureClusterReconciler struct {
 
 type azureClusterServiceCreator func(clusterScope *scope.ClusterScope) (*azureClusterService, error)
 
-// NewAzureClusterReconciler returns a new AzureClusterReconciler instance
+// NewAzureClusterReconciler returns a new AzureClusterReconciler instance.
 func NewAzureClusterReconciler(client client.Client, log logr.Logger, recorder record.EventRecorder, reconcileTimeout time.Duration, watchFilterValue string) *AzureClusterReconciler {
 	acr := &AzureClusterReconciler{
 		Client:           client,

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// azureClusterService is the reconciler called by the AzureCluster controller
+// azureClusterService is the reconciler called by the AzureCluster controller.
 type azureClusterService struct {
 	scope            *scope.ClusterScope
 	groupsSvc        azure.Reconciler
@@ -52,7 +52,7 @@ type azureClusterService struct {
 	skuCache         *resourceskus.Cache
 }
 
-// newAzureClusterService populates all the services based on input scope
+// newAzureClusterService populates all the services based on input scope.
 func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, error) {
 	skuCache, err := resourceskus.GetCache(scope, scope.Location())
 	if err != nil {
@@ -76,7 +76,7 @@ func newAzureClusterService(scope *scope.ClusterScope) (*azureClusterService, er
 
 var _ azure.Reconciler = (*azureClusterService)(nil)
 
-// Reconcile reconciles all the services in pre determined order
+// Reconcile reconciles all the services in a predetermined order.
 func (s *azureClusterService) Reconcile(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureClusterService.Reconcile")
 	defer span.End()
@@ -127,7 +127,7 @@ func (s *azureClusterService) Reconcile(ctx context.Context) error {
 	return nil
 }
 
-// Delete reconciles all the services in pre determined order
+// Delete reconciles all the services in a predetermined order.
 func (s *azureClusterService) Delete(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureClusterService.Delete")
 	defer span.End()

--- a/controllers/azureidentity_controller.go
+++ b/controllers/azureidentity_controller.go
@@ -44,7 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-// AzureIdentityReconciler reconciles azure identity objects
+// AzureIdentityReconciler reconciles Azure identity objects.
 type AzureIdentityReconciler struct {
 	client.Client
 	Log              logr.Logger
@@ -53,7 +53,7 @@ type AzureIdentityReconciler struct {
 	WatchFilterValue string
 }
 
-// SetupWithManager initializes this controller with a manager
+// SetupWithManager initializes this controller with a manager.
 func (r *AzureIdentityReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	log := r.Log.WithValues("controller", "AzureIdentity")
 	c, err := ctrl.NewControllerManagedBy(mgr).

--- a/controllers/azurejson_machine_controller.go
+++ b/controllers/azurejson_machine_controller.go
@@ -45,7 +45,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// AzureJSONMachineReconciler reconciles azure json secrets for AzureMachine objects
+// AzureJSONMachineReconciler reconciles Azure json secrets for AzureMachine objects.
 type AzureJSONMachineReconciler struct {
 	client.Client
 	Log              logr.Logger
@@ -53,7 +53,7 @@ type AzureJSONMachineReconciler struct {
 	ReconcileTimeout time.Duration
 }
 
-// SetupWithManager initializes this controller with a manager
+// SetupWithManager initializes this controller with a manager.
 func (r *AzureJSONMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.AzureMachine{}).
@@ -77,7 +77,7 @@ func (f filterUnclonedMachinesPredicate) Update(e event.UpdateEvent) bool {
 	})
 }
 
-// Generic implements default GenericEvent filter
+// Generic implements a default GenericEvent filter.
 func (f filterUnclonedMachinesPredicate) Generic(e event.GenericEvent) bool {
 	if e.Object == nil {
 		f.log.Error(nil, "Generic event has no old metadata", "event", e)
@@ -94,7 +94,7 @@ func (f filterUnclonedMachinesPredicate) Generic(e event.GenericEvent) bool {
 	return !isClonedFromTemplate
 }
 
-// Reconcile reconciles the azure json for a specific machine not in a machine deployment
+// Reconcile reconciles the Azure json for a specific machine not in a machine deployment.
 func (r *AzureJSONMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()

--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// AzureJSONMachinePoolReconciler reconciles azure json secrets for AzureMachinePool objects
+// AzureJSONMachinePoolReconciler reconciles Azure json secrets for AzureMachinePool objects.
 type AzureJSONMachinePoolReconciler struct {
 	client.Client
 	Log              logr.Logger
@@ -50,7 +50,7 @@ type AzureJSONMachinePoolReconciler struct {
 	ReconcileTimeout time.Duration
 }
 
-// SetupWithManager initializes this controller with a manager
+// SetupWithManager initializes this controller with a manager.
 func (r *AzureJSONMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&expv1.AzureMachinePool{}).
@@ -58,7 +58,7 @@ func (r *AzureJSONMachinePoolReconciler) SetupWithManager(ctx context.Context, m
 		Complete(r)
 }
 
-// Reconcile reconciles the azure json for AzureMachinePool objects
+// Reconcile reconciles the Azure json for AzureMachinePool objects.
 func (r *AzureJSONMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()

--- a/controllers/azurejson_machinetemplate_controller.go
+++ b/controllers/azurejson_machinetemplate_controller.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// AzureJSONTemplateReconciler reconciles azure json secrets for AzureMachineTemplate objects
+// AzureJSONTemplateReconciler reconciles Azure json secrets for AzureMachineTemplate objects.
 type AzureJSONTemplateReconciler struct {
 	client.Client
 	Log              logr.Logger
@@ -59,7 +59,7 @@ func (r *AzureJSONTemplateReconciler) SetupWithManager(ctx context.Context, mgr 
 		Complete(r)
 }
 
-// Reconcile reconciles azure json secrets for azure machine templates
+// Reconcile reconciles Azure json secrets for Azure machine templates.
 func (r *AzureJSONTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -48,7 +48,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// AzureMachineReconciler reconciles a AzureMachine object
+// AzureMachineReconciler reconciles an AzureMachine object.
 type AzureMachineReconciler struct {
 	client.Client
 	Log                       logr.Logger
@@ -60,7 +60,7 @@ type AzureMachineReconciler struct {
 
 type azureMachineServiceCreator func(machineScope *scope.MachineScope) (*azureMachineService, error)
 
-// NewAzureMachineReconciler returns a new AzureMachineReconciler instance
+// NewAzureMachineReconciler returns a new AzureMachineReconciler instance.
 func NewAzureMachineReconciler(client client.Client, log logr.Logger, recorder record.EventRecorder, reconcileTimeout time.Duration, watchFilterValue string) *AzureMachineReconciler {
 	amr := &AzureMachineReconciler{
 		Client:           client,

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -73,7 +73,7 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	}, nil
 }
 
-// Reconcile reconciles all the services in pre determined order
+// Reconcile reconciles all the services in a predetermined order.
 func (s *azureMachineService) Reconcile(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureMachineService.Reconcile")
 	defer span.End()
@@ -113,7 +113,7 @@ func (s *azureMachineService) Reconcile(ctx context.Context) error {
 	return nil
 }
 
-// Delete deletes all the services in pre determined order
+// Delete deletes all the services in a predetermined order.
 func (s *azureMachineService) Delete(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureMachineService.Delete")
 	defer span.End()

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -50,7 +50,7 @@ import (
 )
 
 type (
-	// Options are controller options extended
+	// Options are controller options extended.
 	Options struct {
 		controller.Options
 		Cache *coalescing.ReconcileCache
@@ -142,7 +142,7 @@ func GetObjectsToRequestsByNamespaceAndClusterName(ctx context.Context, c client
 	return results
 }
 
-// Returns true if a and b point to the same object
+// referSameObject returns true if a and b point to the same object.
 func referSameObject(a, b metav1.OwnerReference) bool {
 	aGV, err := schema.ParseGroupVersion(a.APIVersion)
 	if err != nil {
@@ -330,7 +330,7 @@ func toCloudProviderRateLimitConfig(source infrav1.RateLimitConfig) *RateLimitCo
 	return &rateLimitConfig
 }
 
-// CloudProviderConfig is an abbreviated version of the same struct in k/k
+// CloudProviderConfig is an abbreviated version of the same struct in k/k.
 type CloudProviderConfig struct {
 	Cloud                        string `json:"cloud"`
 	TenantID                     string `json:"tenantId"`

--- a/exp/api/v1alpha3/azuremachinepool_types.go
+++ b/exp/api/v1alpha3/azuremachinepool_types.go
@@ -68,7 +68,7 @@ type (
 		SpotVMOptions *infrav1.SpotVMOptions `json:"spotVMOptions,omitempty"`
 	}
 
-	// AzureMachinePoolSpec defines the desired state of AzureMachinePool
+	// AzureMachinePoolSpec defines the desired state of AzureMachinePool.
 	AzureMachinePoolSpec struct {
 		// Location is the Azure region location e.g. westus2
 		Location string `json:"location"`
@@ -113,7 +113,7 @@ type (
 		RoleAssignmentName string `json:"roleAssignmentName,omitempty"`
 	}
 
-	// AzureMachinePoolStatus defines the observed state of AzureMachinePool
+	// AzureMachinePoolStatus defines the observed state of AzureMachinePool.
 	AzureMachinePoolStatus struct {
 		// Ready is true when the provider resource is ready.
 		// +optional
@@ -183,7 +183,7 @@ type (
 		LongRunningOperationState *infrav1.Future `json:"longRunningOperationState,omitempty"`
 	}
 
-	// AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS
+	// AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.
 	AzureMachinePoolInstanceStatus struct {
 		// Version defines the Kubernetes version for the VM Instance
 		// +optional
@@ -222,7 +222,7 @@ type (
 	// +kubebuilder:printcolumn:name="VMSS ID",type="string",priority=1,JSONPath=".spec.providerID",description="Azure VMSS ID"
 	// +kubebuilder:printcolumn:name="VM Size",type="string",priority=1,JSONPath=".spec.template.vmSize",description="Azure VM Size"
 
-	// AzureMachinePool is the Schema for the azuremachinepools API
+	// AzureMachinePool is the Schema for the azuremachinepools API.
 	AzureMachinePool struct {
 		metav1.TypeMeta   `json:",inline"`
 		metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -233,7 +233,7 @@ type (
 
 	// +kubebuilder:object:root=true
 
-	// AzureMachinePoolList contains a list of AzureMachinePool
+	// AzureMachinePoolList contains a list of AzureMachinePools.
 	AzureMachinePoolList struct {
 		metav1.TypeMeta `json:",inline"`
 		metav1.ListMeta `json:"metadata,omitempty"`
@@ -246,7 +246,7 @@ func (amp *AzureMachinePool) GetConditions() clusterv1.Conditions {
 	return amp.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureMachinePool object
+// SetConditions will set the given conditions on an AzureMachinePool object.
 func (amp *AzureMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	amp.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha3/azuremanagedcluster_types.go
+++ b/exp/api/v1alpha3/azuremanagedcluster_types.go
@@ -21,14 +21,14 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
-// AzureManagedClusterSpec defines the desired state of AzureManagedCluster
+// AzureManagedClusterSpec defines the desired state of AzureManagedCluster.
 type AzureManagedClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
 }
 
-// AzureManagedClusterStatus defines the observed state of AzureManagedCluster
+// AzureManagedClusterStatus defines the observed state of AzureManagedCluster.
 type AzureManagedClusterStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -39,7 +39,7 @@ type AzureManagedClusterStatus struct {
 // +kubebuilder:resource:path=azuremanagedclusters,scope=Namespaced,categories=cluster-api,shortName=amc
 // +kubebuilder:subresource:status
 
-// AzureManagedCluster is the Schema for the azuremanagedclusters API
+// AzureManagedCluster is the Schema for the azuremanagedclusters API.
 type AzureManagedCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -50,7 +50,7 @@ type AzureManagedCluster struct {
 
 // +kubebuilder:object:root=true
 
-// AzureManagedClusterList contains a list of AzureManagedCluster
+// AzureManagedClusterList contains a list of AzureManagedClusters.
 type AzureManagedClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
@@ -24,7 +24,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 )
 
-// AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane
+// AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.
 type AzureManagedControlPlaneSpec struct {
 	// Version defines the desired Kubernetes version.
 	// +kubebuilder:validation:MinLength:=2
@@ -96,7 +96,7 @@ type ManagedControlPlaneSubnet struct {
 	CIDRBlock string `json:"cidrBlock"`
 }
 
-// AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane
+// AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.
 type AzureManagedControlPlaneStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -113,7 +113,7 @@ type AzureManagedControlPlaneStatus struct {
 // +kubebuilder:resource:path=azuremanagedcontrolplanes,scope=Namespaced,categories=cluster-api,shortName=amcp
 // +kubebuilder:subresource:status
 
-// AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API
+// AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API.
 type AzureManagedControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -124,7 +124,7 @@ type AzureManagedControlPlane struct {
 
 // +kubebuilder:object:root=true
 
-// AzureManagedControlPlaneList contains a list of AzureManagedControlPlane
+// AzureManagedControlPlaneList contains a list of AzureManagedControlPlanes.
 type AzureManagedControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/api/v1alpha3/azuremanagedmachinepool_types.go
+++ b/exp/api/v1alpha3/azuremanagedmachinepool_types.go
@@ -21,7 +21,7 @@ import (
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
-// AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool
+// AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.
 type AzureManagedMachinePoolSpec struct {
 	// SKU is the size of the VMs in the node pool.
 	SKU string `json:"sku"`
@@ -35,7 +35,7 @@ type AzureManagedMachinePoolSpec struct {
 	ProviderIDList []string `json:"providerIDList,omitempty"`
 }
 
-// AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool
+// AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.
 type AzureManagedMachinePoolStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -62,7 +62,7 @@ type AzureManagedMachinePoolStatus struct {
 // +kubebuilder:resource:path=azuremanagedmachinepools,scope=Namespaced,categories=cluster-api,shortName=ammp
 // +kubebuilder:subresource:status
 
-// AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API
+// AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API.
 type AzureManagedMachinePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -73,7 +73,7 @@ type AzureManagedMachinePool struct {
 
 // +kubebuilder:object:root=true
 
-// AzureManagedMachinePoolList contains a list of AzureManagedMachinePool
+// AzureManagedMachinePoolList contains a list of AzureManagedMachinePools.
 type AzureManagedMachinePoolList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/api/v1alpha3/groupversion_info.go
+++ b/exp/api/v1alpha3/groupversion_info.go
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is the group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1alpha3"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/exp/api/v1alpha4/azuremachinepool_default.go
+++ b/exp/api/v1alpha4/azuremachinepool_default.go
@@ -26,7 +26,7 @@ import (
 	utilSSH "sigs.k8s.io/cluster-api-provider-azure/util/ssh"
 )
 
-// SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureMachinePool
+// SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureMachinePool.
 func (amp *AzureMachinePool) SetDefaultSSHPublicKey() error {
 	sshKeyData := amp.Spec.Template.SSHPublicKey
 	if sshKeyData == "" {

--- a/exp/api/v1alpha4/azuremachinepool_types.go
+++ b/exp/api/v1alpha4/azuremachinepool_types.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	// MachinePoolNameLabel indicates the AzureMachinePool name the AzureMachinePoolMachine belongs
+	// MachinePoolNameLabel indicates the AzureMachinePool name the AzureMachinePoolMachine belongs.
 	MachinePoolNameLabel = "azuremachinepool.infrastructure.cluster.x-k8s.io/machine-pool"
 
 	// RollingUpdateAzureMachinePoolDeploymentStrategyType replaces AzureMachinePoolMachines with older models with
@@ -34,11 +34,11 @@ const (
 	// i.e. gradually scale down the old AzureMachinePoolMachines and scale up the new ones.
 	RollingUpdateAzureMachinePoolDeploymentStrategyType AzureMachinePoolDeploymentStrategyType = "RollingUpdate"
 
-	// OldestDeletePolicyType will delete machines with the oldest creation date first
+	// OldestDeletePolicyType will delete machines with the oldest creation date first.
 	OldestDeletePolicyType AzureMachinePoolDeletePolicyType = "Oldest"
-	// NewestDeletePolicyType will delete machines with the newest creation date first
+	// NewestDeletePolicyType will delete machines with the newest creation date first.
 	NewestDeletePolicyType AzureMachinePoolDeletePolicyType = "Newest"
-	// RandomDeletePolicyType will delete machines in random order
+	// RandomDeletePolicyType will delete machines in random order.
 	RandomDeletePolicyType AzureMachinePoolDeletePolicyType = "Random"
 )
 
@@ -86,7 +86,7 @@ type (
 		SpotVMOptions *infrav1.SpotVMOptions `json:"spotVMOptions,omitempty"`
 	}
 
-	// AzureMachinePoolSpec defines the desired state of AzureMachinePool
+	// AzureMachinePoolSpec defines the desired state of AzureMachinePool.
 	AzureMachinePoolSpec struct {
 		// Location is the Azure region location e.g. westus2
 		Location string `json:"location"`
@@ -137,7 +137,7 @@ type (
 	}
 
 	// AzureMachinePoolDeploymentStrategyType is the type of deployment strategy employed to rollout a new version of
-	// the AzureMachinePool
+	// the AzureMachinePool.
 	AzureMachinePoolDeploymentStrategyType string
 
 	// AzureMachinePoolDeploymentStrategy describes how to replace existing machines with new ones.
@@ -156,7 +156,7 @@ type (
 	}
 
 	// AzureMachinePoolDeletePolicyType is the type of DeletePolicy employed to select machines to be deleted during an
-	// upgrade
+	// upgrade.
 	AzureMachinePoolDeletePolicyType string
 
 	// MachineRollingUpdateDeployment is used to control the desired behavior of rolling update.
@@ -203,7 +203,7 @@ type (
 		DeletePolicy AzureMachinePoolDeletePolicyType `json:"deletePolicy,omitempty"`
 	}
 
-	// AzureMachinePoolStatus defines the observed state of AzureMachinePool
+	// AzureMachinePoolStatus defines the observed state of AzureMachinePool.
 	AzureMachinePoolStatus struct {
 		// Ready is true when the provider resource is ready.
 		// +optional
@@ -272,13 +272,13 @@ type (
 		// +optional
 		Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 
-		// LongRunningOperationState saves the state for an Azure long running operations so it can be continued on the
+		// LongRunningOperationState saves the state for an Azure long-running operations so it can be continued on the
 		// next reconciliation loop.
 		// +optional
 		LongRunningOperationState *infrav1.Future `json:"longRunningOperationState,omitempty"`
 	}
 
-	// AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS
+	// AzureMachinePoolInstanceStatus provides status information for each instance in the VMSS.
 	AzureMachinePoolInstanceStatus struct {
 		// Version defines the Kubernetes version for the VM Instance
 		// +optional
@@ -318,7 +318,7 @@ type (
 	// +kubebuilder:printcolumn:name="VMSS ID",type="string",priority=1,JSONPath=".spec.providerID",description="Azure VMSS ID"
 	// +kubebuilder:printcolumn:name="VM Size",type="string",priority=1,JSONPath=".spec.template.vmSize",description="Azure VM Size"
 
-	// AzureMachinePool is the Schema for the azuremachinepools API
+	// AzureMachinePool is the Schema for the azuremachinepools API.
 	AzureMachinePool struct {
 		metav1.TypeMeta   `json:",inline"`
 		metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -329,7 +329,7 @@ type (
 
 	// +kubebuilder:object:root=true
 
-	// AzureMachinePoolList contains a list of AzureMachinePool
+	// AzureMachinePoolList contains a list of AzureMachinePools.
 	AzureMachinePoolList struct {
 		metav1.TypeMeta `json:",inline"`
 		metav1.ListMeta `json:"metadata,omitempty"`
@@ -342,7 +342,7 @@ func (amp *AzureMachinePool) GetConditions() clusterv1.Conditions {
 	return amp.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureMachinePool object
+// SetConditions will set the given conditions on an AzureMachinePool object.
 func (amp *AzureMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	amp.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha4/azuremachinepool_webhook.go
+++ b/exp/api/v1alpha4/azuremachinepool_webhook.go
@@ -46,7 +46,7 @@ func (amp *AzureMachinePool) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Defaulter = &AzureMachinePool{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (amp *AzureMachinePool) Default() {
 	azuremachinepoollog.Info("default", "name", amp.Name)
 
@@ -60,25 +60,25 @@ func (amp *AzureMachinePool) Default() {
 
 var _ webhook.Validator = &AzureMachinePool{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (amp *AzureMachinePool) ValidateCreate() error {
 	azuremachinepoollog.Info("validate create", "name", amp.Name)
 	return amp.Validate(nil)
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (amp *AzureMachinePool) ValidateUpdate(old runtime.Object) error {
 	azuremachinepoollog.Info("validate update", "name", amp.Name)
 	return amp.Validate(old)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (amp *AzureMachinePool) ValidateDelete() error {
 	azuremachinepoollog.Info("validate delete", "name", amp.Name)
 	return nil
 }
 
-// Validate the Azure Machine Pool and return an aggregate error
+// Validate the Azure Machine Pool and return an aggregate error.
 func (amp *AzureMachinePool) Validate(old runtime.Object) error {
 	validators := []func() error{
 		amp.ValidateImage,
@@ -99,7 +99,7 @@ func (amp *AzureMachinePool) Validate(old runtime.Object) error {
 	return kerrors.NewAggregate(errs)
 }
 
-// ValidateImage of an AzureMachinePool
+// ValidateImage of an AzureMachinePool.
 func (amp *AzureMachinePool) ValidateImage() error {
 	if amp.Spec.Template.Image != nil {
 		image := amp.Spec.Template.Image
@@ -113,7 +113,7 @@ func (amp *AzureMachinePool) ValidateImage() error {
 	return nil
 }
 
-// ValidateTerminateNotificationTimeout termination notification timeout to be between 5 and 15
+// ValidateTerminateNotificationTimeout termination notification timeout to be between 5 and 15.
 func (amp *AzureMachinePool) ValidateTerminateNotificationTimeout() error {
 	if amp.Spec.Template.TerminateNotificationTimeout == nil {
 		return nil
@@ -129,7 +129,7 @@ func (amp *AzureMachinePool) ValidateTerminateNotificationTimeout() error {
 	return nil
 }
 
-// ValidateSSHKey validates an SSHKey
+// ValidateSSHKey validates an SSHKey.
 func (amp *AzureMachinePool) ValidateSSHKey() error {
 	if amp.Spec.Template.SSHPublicKey != "" {
 		sshKey := amp.Spec.Template.SSHPublicKey
@@ -143,7 +143,7 @@ func (amp *AzureMachinePool) ValidateSSHKey() error {
 	return nil
 }
 
-// ValidateUserAssignedIdentity validates the user-assigned identities list
+// ValidateUserAssignedIdentity validates the user-assigned identities list.
 func (amp *AzureMachinePool) ValidateUserAssignedIdentity() error {
 	fldPath := field.NewPath("UserAssignedIdentities")
 	if errs := infrav1.ValidateUserAssignedIdentity(amp.Spec.Identity, amp.Spec.UserAssignedIdentities, fldPath); len(errs) > 0 {
@@ -153,7 +153,7 @@ func (amp *AzureMachinePool) ValidateUserAssignedIdentity() error {
 	return nil
 }
 
-// ValidateStrategy validates the strategy
+// ValidateStrategy validates the strategy.
 func (amp *AzureMachinePool) ValidateStrategy() func() error {
 	return func() error {
 		if amp.Spec.Strategy.Type == RollingUpdateAzureMachinePoolDeploymentStrategyType && amp.Spec.Strategy.RollingUpdate != nil {
@@ -170,7 +170,7 @@ func (amp *AzureMachinePool) ValidateStrategy() func() error {
 	}
 }
 
-// ValidateSystemAssignedIdentity validates system-assigned identity role
+// ValidateSystemAssignedIdentity validates system-assigned identity role.
 func (amp *AzureMachinePool) ValidateSystemAssignedIdentity(old runtime.Object) func() error {
 	return func() error {
 		var oldRole string

--- a/exp/api/v1alpha4/azuremachinepoolmachine_types.go
+++ b/exp/api/v1alpha4/azuremachinepoolmachine_types.go
@@ -32,7 +32,7 @@ const (
 
 type (
 
-	// AzureMachinePoolMachineSpec defines the desired state of AzureMachinePoolMachine
+	// AzureMachinePoolMachineSpec defines the desired state of AzureMachinePoolMachine.
 	AzureMachinePoolMachineSpec struct {
 		// ProviderID is the identification ID of the Virtual Machine Scale Set
 		ProviderID string `json:"providerID"`
@@ -41,7 +41,7 @@ type (
 		InstanceID string `json:"instanceID"`
 	}
 
-	// AzureMachinePoolMachineStatus defines the observed state of AzureMachinePoolMachine
+	// AzureMachinePoolMachineStatus defines the observed state of AzureMachinePoolMachine.
 	AzureMachinePoolMachineStatus struct {
 		// NodeRef will point to the corresponding Node if it exists.
 		// +optional
@@ -107,7 +107,7 @@ type (
 	// +kubebuilder:printcolumn:name="Cluster",type="string",priority=1,JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this AzureMachinePoolMachine belongs"
 	// +kubebuilder:printcolumn:name="VMSS VM ID",type="string",priority=1,JSONPath=".spec.providerID",description="Azure VMSS VM ID"
 
-	// AzureMachinePoolMachine is the Schema for the azuremachinepoolmachines API
+	// AzureMachinePoolMachine is the Schema for the azuremachinepoolmachines API.
 	AzureMachinePoolMachine struct {
 		metav1.TypeMeta   `json:",inline"`
 		metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -118,7 +118,7 @@ type (
 
 	// +kubebuilder:object:root=true
 
-	// AzureMachinePoolMachineList contains a list of AzureMachinePoolMachine
+	// AzureMachinePoolMachineList contains a list of AzureMachinePoolMachines.
 	AzureMachinePoolMachineList struct {
 		metav1.TypeMeta `json:",inline"`
 		metav1.ListMeta `json:"metadata,omitempty"`
@@ -131,7 +131,7 @@ func (ampm *AzureMachinePoolMachine) GetConditions() clusterv1.Conditions {
 	return ampm.Status.Conditions
 }
 
-// SetConditions will set the given conditions on an AzureMachinePool object
+// SetConditions will set the given conditions on an AzureMachinePool object.
 func (ampm *AzureMachinePoolMachine) SetConditions(conditions clusterv1.Conditions) {
 	ampm.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha4/azuremachinepoolmachine_webhook.go
+++ b/exp/api/v1alpha4/azuremachinepoolmachine_webhook.go
@@ -38,13 +38,13 @@ func (ampm *AzureMachinePoolMachine) SetupWebhookWithManager(mgr ctrl.Manager) e
 
 var _ webhook.Validator = &AzureMachinePoolMachine{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (ampm *AzureMachinePoolMachine) ValidateCreate() error {
 	azuremachinepoolmachinelog.Info("validate create", "name", ampm.Name)
 	return nil
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (ampm *AzureMachinePoolMachine) ValidateUpdate(old runtime.Object) error {
 	azuremachinepoolmachinelog.Info("validate update", "name", ampm.Name)
 	oldMachine, ok := old.(*AzureMachinePoolMachine)
@@ -59,7 +59,7 @@ func (ampm *AzureMachinePoolMachine) ValidateUpdate(old runtime.Object) error {
 	return nil
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (ampm *AzureMachinePoolMachine) ValidateDelete() error {
 	azuremachinepoolmachinelog.Info("validate delete", "name", ampm.Name)
 	return nil

--- a/exp/api/v1alpha4/azuremanagedcluster_types.go
+++ b/exp/api/v1alpha4/azuremanagedcluster_types.go
@@ -21,14 +21,14 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
-// AzureManagedClusterSpec defines the desired state of AzureManagedCluster
+// AzureManagedClusterSpec defines the desired state of AzureManagedCluster.
 type AzureManagedClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
 }
 
-// AzureManagedClusterStatus defines the observed state of AzureManagedCluster
+// AzureManagedClusterStatus defines the observed state of AzureManagedCluster.
 type AzureManagedClusterStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -40,7 +40,7 @@ type AzureManagedClusterStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
-// AzureManagedCluster is the Schema for the azuremanagedclusters API
+// AzureManagedCluster is the Schema for the azuremanagedclusters API.
 type AzureManagedCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -51,7 +51,7 @@ type AzureManagedCluster struct {
 
 // +kubebuilder:object:root=true
 
-// AzureManagedClusterList contains a list of AzureManagedCluster
+// AzureManagedClusterList contains a list of AzureManagedClusters.
 type AzureManagedClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/api/v1alpha4/azuremanagedcontrolplane_default.go
+++ b/exp/api/v1alpha4/azuremanagedcontrolplane_default.go
@@ -26,13 +26,13 @@ import (
 )
 
 const (
-	// defaultAKSVnetCIDR is the default Vnet CIDR
+	// defaultAKSVnetCIDR is the default Vnet CIDR.
 	defaultAKSVnetCIDR = "10.0.0.0/8"
-	// defaultAKSNodeSubnetCIDR is the default Node Subnet CIDR
+	// defaultAKSNodeSubnetCIDR is the default Node Subnet CIDR.
 	defaultAKSNodeSubnetCIDR = "10.240.0.0/16"
 )
 
-// setDefaultSSHPublicKey sets the default SSHPublicKey for an AzureManagedControlPlane
+// setDefaultSSHPublicKey sets the default SSHPublicKey for an AzureManagedControlPlane.
 func (r *AzureManagedControlPlane) setDefaultSSHPublicKey() error {
 	sshKeyData := r.Spec.SSHPublicKey
 	if sshKeyData == "" {
@@ -47,14 +47,14 @@ func (r *AzureManagedControlPlane) setDefaultSSHPublicKey() error {
 	return nil
 }
 
-// setDefaultNodeResourceGroupName sets the default NodeResourceGroup for an AzureManagedControlPlane
+// setDefaultNodeResourceGroupName sets the default NodeResourceGroup for an AzureManagedControlPlane.
 func (r *AzureManagedControlPlane) setDefaultNodeResourceGroupName() {
 	if r.Spec.NodeResourceGroupName == "" {
 		r.Spec.NodeResourceGroupName = fmt.Sprintf("MC_%s_%s_%s", r.Spec.ResourceGroupName, r.Name, r.Spec.Location)
 	}
 }
 
-// setDefaultVirtualNetwork sets the default VirtualNetwork for an AzureManagedControlPlane
+// setDefaultVirtualNetwork sets the default VirtualNetwork for an AzureManagedControlPlane.
 func (r *AzureManagedControlPlane) setDefaultVirtualNetwork() {
 	if r.Spec.VirtualNetwork.Name == "" {
 		r.Spec.VirtualNetwork.Name = r.Name
@@ -64,7 +64,7 @@ func (r *AzureManagedControlPlane) setDefaultVirtualNetwork() {
 	}
 }
 
-// setDefaultSubnet sets the default Subnet for an AzureManagedControlPlane
+// setDefaultSubnet sets the default Subnet for an AzureManagedControlPlane.
 func (r *AzureManagedControlPlane) setDefaultSubnet() {
 	if r.Spec.VirtualNetwork.Subnet.Name == "" {
 		r.Spec.VirtualNetwork.Subnet.Name = r.Name

--- a/exp/api/v1alpha4/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1alpha4/azuremanagedcontrolplane_types.go
@@ -24,7 +24,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 )
 
-// AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane
+// AzureManagedControlPlaneSpec defines the desired state of AzureManagedControlPlane.
 type AzureManagedControlPlaneSpec struct {
 	// Version defines the desired Kubernetes version.
 	// +kubebuilder:validation:MinLength:=2
@@ -97,7 +97,7 @@ type ManagedControlPlaneSubnet struct {
 	CIDRBlock string `json:"cidrBlock"`
 }
 
-// AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane
+// AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.
 type AzureManagedControlPlaneStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -115,7 +115,7 @@ type AzureManagedControlPlaneStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
-// AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API
+// AzureManagedControlPlane is the Schema for the azuremanagedcontrolplanes API.
 type AzureManagedControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -126,7 +126,7 @@ type AzureManagedControlPlane struct {
 
 // +kubebuilder:object:root=true
 
-// AzureManagedControlPlaneList contains a list of AzureManagedControlPlane
+// AzureManagedControlPlaneList contains a list of AzureManagedControlPlane.
 type AzureManagedControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/api/v1alpha4/azuremanagedcontrolplane_webhook.go
+++ b/exp/api/v1alpha4/azuremanagedcontrolplane_webhook.go
@@ -49,7 +49,7 @@ func (r *AzureManagedControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) err
 
 var _ webhook.Defaulter = &AzureManagedControlPlane{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *AzureManagedControlPlane) Default() {
 	azuremanagedcontrolplanelog.Info("default", "name", r.Name)
 
@@ -85,14 +85,14 @@ func (r *AzureManagedControlPlane) Default() {
 
 var _ webhook.Validator = &AzureManagedControlPlane{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureManagedControlPlane) ValidateCreate() error {
 	azuremanagedcontrolplanelog.Info("validate create", "name", r.Name)
 
 	return r.Validate()
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureManagedControlPlane) ValidateUpdate(oldRaw runtime.Object) error {
 	azuremanagedcontrolplanelog.Info("validate update", "name", r.Name)
 	var allErrs field.ErrorList
@@ -234,14 +234,14 @@ func (r *AzureManagedControlPlane) ValidateUpdate(oldRaw runtime.Object) error {
 	return apierrors.NewInvalid(GroupVersion.WithKind("AzureManagedControlPlane").GroupKind(), r.Name, allErrs)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureManagedControlPlane) ValidateDelete() error {
 	azuremanagedcontrolplanelog.Info("validate delete", "name", r.Name)
 
 	return nil
 }
 
-// Validate the Azure Machine Pool and return an aggregate error
+// Validate the Azure Machine Pool and return an aggregate error.
 func (r *AzureManagedControlPlane) Validate() error {
 	validators := []func() error{
 		r.validateVersion,
@@ -259,7 +259,7 @@ func (r *AzureManagedControlPlane) Validate() error {
 	return kerrors.NewAggregate(errs)
 }
 
-// validate DNSServiceIP
+// validate DNSServiceIP.
 func (r *AzureManagedControlPlane) validateDNSServiceIP() error {
 	if r.Spec.DNSServiceIP != nil {
 		if net.ParseIP(*r.Spec.DNSServiceIP) == nil {
@@ -278,7 +278,7 @@ func (r *AzureManagedControlPlane) validateVersion() error {
 	return nil
 }
 
-// ValidateSSHKey validates an SSHKey
+// ValidateSSHKey validates an SSHKey.
 func (r *AzureManagedControlPlane) validateSSHKey() error {
 	if r.Spec.SSHPublicKey != "" {
 		sshKey := r.Spec.SSHPublicKey

--- a/exp/api/v1alpha4/azuremanagedmachinepool_types.go
+++ b/exp/api/v1alpha4/azuremanagedmachinepool_types.go
@@ -21,7 +21,7 @@ import (
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
-// AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool
+// AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.
 type AzureManagedMachinePoolSpec struct {
 	// SKU is the size of the VMs in the node pool.
 	SKU string `json:"sku"`
@@ -35,7 +35,7 @@ type AzureManagedMachinePoolSpec struct {
 	ProviderIDList []string `json:"providerIDList,omitempty"`
 }
 
-// AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool
+// AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.
 type AzureManagedMachinePoolStatus struct {
 	// Ready is true when the provider resource is ready.
 	// +optional
@@ -63,7 +63,7 @@ type AzureManagedMachinePoolStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 
-// AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API
+// AzureManagedMachinePool is the Schema for the azuremanagedmachinepools API.
 type AzureManagedMachinePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -74,7 +74,7 @@ type AzureManagedMachinePool struct {
 
 // +kubebuilder:object:root=true
 
-// AzureManagedMachinePoolList contains a list of AzureManagedMachinePool
+// AzureManagedMachinePoolList contains a list of AzureManagedMachinePools.
 type AzureManagedMachinePoolList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/api/v1alpha4/groupversion_info.go
+++ b/exp/api/v1alpha4/groupversion_info.go
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1alpha4"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -51,7 +51,7 @@ import (
 )
 
 type (
-	// AzureMachinePoolReconciler reconciles a AzureMachinePool object
+	// AzureMachinePoolReconciler reconciles an AzureMachinePool object.
 	AzureMachinePoolReconciler struct {
 		client.Client
 		Log                           logr.Logger
@@ -62,7 +62,7 @@ type (
 		createAzureMachinePoolService azureMachinePoolServiceCreator
 	}
 
-	// annotationReaderWriter provides an interface to read and write annotations
+	// annotationReaderWriter provides an interface to read and write annotations.
 	annotationReaderWriter interface {
 		GetAnnotations() map[string]string
 		SetAnnotations(annotations map[string]string)
@@ -71,7 +71,7 @@ type (
 
 type azureMachinePoolServiceCreator func(machinePoolScope *scope.MachinePoolScope) (*azureMachinePoolService, error)
 
-// NewAzureMachinePoolReconciler returns a new AzureMachinePoolReconciler instance
+// NewAzureMachinePoolReconciler returns a new AzureMachinePoolReconciler instance.
 func NewAzureMachinePoolReconciler(client client.Client, log logr.Logger, recorder record.EventRecorder, reconcileTimeout time.Duration, watchFilterValue string) *AzureMachinePoolReconciler {
 	ampr := &AzureMachinePoolReconciler{
 		Client:           client,

--- a/exp/controllers/azuremachinepoolmachine_controller.go
+++ b/exp/controllers/azuremachinepoolmachine_controller.go
@@ -54,7 +54,7 @@ import (
 type (
 	azureMachinePoolMachineReconcilerFactory func(*scope.MachinePoolMachineScope) azure.Reconciler
 
-	// AzureMachinePoolMachineController handles Kubernetes change events for a AzureMachinePoolMachine resources
+	// AzureMachinePoolMachineController handles Kubernetes change events for AzureMachinePoolMachine resources.
 	AzureMachinePoolMachineController struct {
 		client.Client
 		Log               logr.Logger
@@ -350,7 +350,7 @@ func newAzureMachinePoolMachineReconciler(scope *scope.MachinePoolMachineScope) 
 	}
 }
 
-// Reconcile will reconcile the state of the Machine Pool Machine with the state of the Azure VMSS VM
+// Reconcile will reconcile the state of the Machine Pool Machine with the state of the Azure VMSS VM.
 func (r *azureMachinePoolMachineReconciler) Reconcile(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureMachinePoolMachineReconciler.Reconcile")
 	defer span.End()
@@ -366,7 +366,7 @@ func (r *azureMachinePoolMachineReconciler) Reconcile(ctx context.Context) error
 	return nil
 }
 
-// Delete will attempt to drain and delete the Azure VMSS VM
+// Delete will attempt to drain and delete the Azure VMSS VM.
 func (r *azureMachinePoolMachineReconciler) Delete(ctx context.Context) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureMachinePoolMachineReconciler.Delete")
 	defer span.End()

--- a/exp/controllers/azuremanagedcluster_controller.go
+++ b/exp/controllers/azuremanagedcluster_controller.go
@@ -44,7 +44,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// AzureManagedClusterReconciler reconciles a AzureManagedCluster object
+// AzureManagedClusterReconciler reconciles an AzureManagedCluster object.
 type AzureManagedClusterReconciler struct {
 	client.Client
 	Log              logr.Logger

--- a/exp/controllers/azuremanagedcontrolplane_controller.go
+++ b/exp/controllers/azuremanagedcontrolplane_controller.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// AzureManagedControlPlaneReconciler reconciles a AzureManagedControlPlane object
+// AzureManagedControlPlaneReconciler reconciles an AzureManagedControlPlane object.
 type AzureManagedControlPlaneReconciler struct {
 	client.Client
 	Log              logr.Logger

--- a/exp/controllers/azuremanagedmachinepool_controller.go
+++ b/exp/controllers/azuremanagedmachinepool_controller.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// AzureManagedMachinePoolReconciler reconciles a AzureManagedMachinePool object
+// AzureManagedMachinePoolReconciler reconciles an AzureManagedMachinePool object.
 type AzureManagedMachinePoolReconciler struct {
 	client.Client
 	Log                                  logr.Logger
@@ -59,7 +59,7 @@ type AzureManagedMachinePoolReconciler struct {
 
 type azureManagedMachinePoolServiceCreator func(managedControlPlaneScope *scope.ManagedControlPlaneScope) *azureManagedMachinePoolService
 
-// NewAzureManagedMachinePoolReconciler returns a new AzureManagedMachinePoolReconciler instance
+// NewAzureManagedMachinePoolReconciler returns a new AzureManagedMachinePoolReconciler instance.
 func NewAzureManagedMachinePoolReconciler(client client.Client, log logr.Logger, recorder record.EventRecorder, reconcileTimeout time.Duration, watchFilterValue string) *AzureManagedMachinePoolReconciler {
 	ampr := &AzureManagedMachinePoolReconciler{
 		Client:           client,

--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -33,14 +33,14 @@ import (
 )
 
 type (
-	// azureManagedMachinePoolService are list of services required by cluster controller
+	// azureManagedMachinePoolService contains the services required by the cluster controller.
 	azureManagedMachinePoolService struct {
 		kubeclient    client.Client
 		agentPoolsSvc azure.OldService
 		scaleSetsSvc  NodeLister
 	}
 
-	// AgentPoolVMSSNotFoundError represents a reconcile error when the VMSS for an agent pool can't be found
+	// AgentPoolVMSSNotFoundError represents a reconcile error when the VMSS for an agent pool can't be found.
 	AgentPoolVMSSNotFoundError struct {
 		NodeResourceGroup string
 		PoolName          string
@@ -57,7 +57,7 @@ var (
 	notFoundErr = new(AgentPoolVMSSNotFoundError)
 )
 
-// NewAgentPoolVMSSNotFoundError creates a new AgentPoolVMSSNotFoundError
+// NewAgentPoolVMSSNotFoundError creates a new AgentPoolVMSSNotFoundError.
 func NewAgentPoolVMSSNotFoundError(nodeResourceGroup, poolName string) *AgentPoolVMSSNotFoundError {
 	return &AgentPoolVMSSNotFoundError{
 		NodeResourceGroup: nodeResourceGroup,
@@ -77,7 +77,7 @@ func (a *AgentPoolVMSSNotFoundError) Is(target error) bool {
 	return ok
 }
 
-// newAzureManagedMachinePoolService populates all the services based on input scope
+// newAzureManagedMachinePoolService populates all the services based on input scope.
 func newAzureManagedMachinePoolService(scope *scope.ManagedControlPlaneScope) *azureManagedMachinePoolService {
 	return &azureManagedMachinePoolService{
 		kubeclient:    scope.Client,
@@ -86,7 +86,7 @@ func newAzureManagedMachinePoolService(scope *scope.ManagedControlPlaneScope) *a
 	}
 }
 
-// Reconcile reconciles all the services in pre determined order
+// Reconcile reconciles all the services in a predetermined order.
 func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context, scope *scope.ManagedControlPlaneScope) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureManagedMachinePoolService.Reconcile")
 	defer span.End()
@@ -163,7 +163,7 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context, scope *s
 	return nil
 }
 
-// Delete reconciles all the services in pre determined order
+// Delete reconciles all the services in a predetermined order.
 func (s *azureManagedMachinePoolService) Delete(ctx context.Context, scope *scope.ManagedControlPlaneScope) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureManagedMachinePoolService.Delete")
 	defer span.End()
@@ -181,7 +181,7 @@ func (s *azureManagedMachinePoolService) Delete(ctx context.Context, scope *scop
 	return nil
 }
 
-// IsAgentPoolVMSSNotFoundError returns true if the error is a AgentPoolVMSSNotFoundError
+// IsAgentPoolVMSSNotFoundError returns true if the error is an AgentPoolVMSSNotFoundError.
 func IsAgentPoolVMSSNotFoundError(err error) bool {
 	return errors.Is(err, notFoundErr)
 }

--- a/exp/controllers/azuremangedcontrolplane_reconciler.go
+++ b/exp/controllers/azuremangedcontrolplane_reconciler.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// azureManagedControlPlaneReconciler are list of services required by cluster controller
+// azureManagedControlPlaneReconciler contains the services required by the cluster controller.
 type azureManagedControlPlaneReconciler struct {
 	kubeclient         client.Client
 	managedClustersSvc *managedclusters.Service
@@ -51,7 +51,7 @@ type azureManagedControlPlaneReconciler struct {
 	subnetsSvc         azure.Reconciler
 }
 
-// newAzureManagedControlPlaneReconciler populates all the services based on input scope
+// newAzureManagedControlPlaneReconciler populates all the services based on input scope.
 func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope) *azureManagedControlPlaneReconciler {
 	return &azureManagedControlPlaneReconciler{
 		kubeclient:         scope.Client,
@@ -62,7 +62,7 @@ func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope
 	}
 }
 
-// Reconcile reconciles all the services in pre determined order
+// Reconcile reconciles all the services in a predetermined order.
 func (r *azureManagedControlPlaneReconciler) Reconcile(ctx context.Context, scope *scope.ManagedControlPlaneScope) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureManagedControlPlaneReconciler.Reconcile")
 	defer span.End()
@@ -132,7 +132,7 @@ func (r *azureManagedControlPlaneReconciler) Reconcile(ctx context.Context, scop
 	return nil
 }
 
-// Delete reconciles all the services in pre determined order
+// Delete reconciles all the services in a predetermined order.
 func (r *azureManagedControlPlaneReconciler) Delete(ctx context.Context, scope *scope.ManagedControlPlaneScope) error {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.azureManagedControlPlaneReconciler.Delete")
 	defer span.End()

--- a/exp/controllers/helpers.go
+++ b/exp/controllers/helpers.go
@@ -97,7 +97,7 @@ func AzureClusterToAzureMachinePoolsMapper(ctx context.Context, c client.Client,
 	}, nil
 }
 
-// AzureMachinePoolMachineMapper creates a mapping handler to transform AzureMachinePoolMachine to AzureMachinePools
+// AzureMachinePoolMachineMapper creates a mapping handler to transform AzureMachinePoolMachine to AzureMachinePools.
 func AzureMachinePoolMachineMapper(scheme *runtime.Scheme, log logr.Logger) handler.MapFunc {
 	return func(o client.Object) []ctrl.Request {
 		gvk, err := apiutil.GVKForObject(new(infrav1exp.AzureMachinePool), scheme)
@@ -503,8 +503,8 @@ func AzureClusterToAzureMachinePoolsFunc(ctx context.Context, kClient client.Cli
 	}
 }
 
-// AzureMachinePoolToAzureMachinePoolMachines maps an AzureMachinePool to it's child AzureMachinePoolMachines through
-// Cluster and MachinePool labels
+// AzureMachinePoolToAzureMachinePoolMachines maps an AzureMachinePool to its child AzureMachinePoolMachines through
+// Cluster and MachinePool labels.
 func AzureMachinePoolToAzureMachinePoolMachines(ctx context.Context, kClient client.Client, log logr.Logger) handler.MapFunc {
 	return func(o client.Object) []reconcile.Request {
 		ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultMappingTimeout)
@@ -542,7 +542,7 @@ func AzureMachinePoolToAzureMachinePoolMachines(ctx context.Context, kClient cli
 	}
 }
 
-// MachinePoolModelHasChanged predicates any events based on changes to the AzureMachinePool model
+// MachinePoolModelHasChanged predicates any events based on changes to the AzureMachinePool model.
 func MachinePoolModelHasChanged(logger logr.Logger) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -576,7 +576,7 @@ func MachinePoolModelHasChanged(logger logr.Logger) predicate.Funcs {
 }
 
 // MachinePoolMachineHasStateOrVersionChange predicates any events based on changes to the AzureMachinePoolMachine status
-// relevant for the AzureMachinePool controller
+// relevant for the AzureMachinePool controller.
 func MachinePoolMachineHasStateOrVersionChange(logger logr.Logger) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -22,8 +22,10 @@ import (
 )
 
 const (
-	// Every capz-specific feature gate should add method here following this template:
+	// nolint:godot
+	// Every capz-specific feature gate should add a method here following this template:
 	//
+	// // MyFeature is the feature gate for my feature.
 	// // owner: @username
 	// // alpha: v1.X
 	// MyFeature featuregate.Feature = "MyFeature"

--- a/internal/test/matchers/gomega/matchers.go
+++ b/internal/test/matchers/gomega/matchers.go
@@ -46,7 +46,7 @@ type (
 	}
 )
 
-// DiffEq will verify cmp.Diff(expected, actual) == "" using github.com/google/go-cmp/cmp
+// DiffEq will verify cmp.Diff(expected, actual) == "" using github.com/google/go-cmp/cmp.
 func DiffEq(x interface{}) types.GomegaMatcher {
 	return &cmpMatcher{
 		x: x,

--- a/internal/test/record/logger.go
+++ b/internal/test/record/logger.go
@@ -42,7 +42,7 @@ type LogEntry struct {
 	Values []interface{}
 }
 
-// Option is a configuration option supplied to NewLogger
+// Option is a configuration option supplied to NewLogger.
 type Option func(*Logger)
 
 // WithThreshold implements a New Option that allows to set the threshold level for a new logger.
@@ -53,7 +53,7 @@ func WithThreshold(threshold *int) Option {
 	}
 }
 
-// WithWriter configures the logger to write to the io.Writer
+// WithWriter configures the logger to write to the io.Writer.
 func WithWriter(wr io.Writer) Option {
 	return func(c *Logger) {
 		c.writer = wr
@@ -74,7 +74,7 @@ func NewLogger(options ...Option) *Logger {
 var _ logr.Logger = (*Logger)(nil)
 
 type (
-	// Logger defines a test friendly logr.Logger
+	// Logger defines a test friendly logr.Logger.
 	Logger struct {
 		threshold  *int
 		level      int
@@ -142,7 +142,7 @@ func (l *Logger) removeListener(id string) {
 	delete(l.listeners, id)
 }
 
-// Enabled is always enabled
+// Enabled is always enabled.
 func (l *Logger) Enabled() bool {
 	return true
 }

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -27,7 +27,7 @@ const (
 	DefaultEventualTimeout = 20 * time.Second
 )
 
-// RandomName will generate a random name "{prefix}-{rand(len)}"
+// RandomName will generate a random name "{prefix}-{rand(len)}".
 func RandomName(prefix string, len int) string {
 	return fmt.Sprintf("%s-%s", prefix, rand.String(len))
 }

--- a/pkg/coalescing/reconciler.go
+++ b/pkg/coalescing/reconciler.go
@@ -39,13 +39,13 @@ type (
 	}
 
 	// ReconcileCacher describes an interface for determining if a request should be reconciled through a call to
-	// ShouldProcess and if ok, reset the cool down through a call to Reconciled
+	// ShouldProcess and if ok, reset the cool down through a call to Reconciled.
 	ReconcileCacher interface {
 		ShouldProcess(key string) (expiration time.Time, ok bool)
 		Reconciled(key string)
 	}
 
-	// reconciler is the caching reconciler middleware that uses the cache or
+	// reconciler is the caching reconciler middleware that uses the cache.
 	reconciler struct {
 		upstream reconcile.Reconciler
 		cache    ReconcileCacher
@@ -72,14 +72,14 @@ func (cache *ReconcileCache) ShouldProcess(key string) (time.Time, bool) {
 	return expiration, !ok
 }
 
-// Reconciled updates the cache expiry for a given key
+// Reconciled updates the cache expiry for a given key.
 func (cache *ReconcileCache) Reconciled(key string) {
 	cache.lastSuccessfulReconciliationCache.Add(key, nil)
 }
 
 // NewReconciler returns a reconcile wrapper that will delay new reconcile.Requests
 // after the cache expiry of the request string key.
-// A successful reconciliation is defined as as one where no error is returned
+// A successful reconciliation is defined as as one where no error is returned.
 func NewReconciler(upstream reconcile.Reconciler, cache ReconcileCacher, log logr.Logger) reconcile.Reconciler {
 	return &reconciler{
 		upstream: upstream,
@@ -88,7 +88,7 @@ func NewReconciler(upstream reconcile.Reconciler, cache ReconcileCacher, log log
 	}
 }
 
-// Reconcile sends a request to the upstream reconciler if the request is outside of the debounce window
+// Reconcile sends a request to the upstream reconciler if the request is outside of the debounce window.
 func (rc *reconciler) Reconcile(ctx context.Context, r reconcile.Request) (reconcile.Result, error) {
 	ctx, span := tele.Tracer().Start(ctx, "controllers.reconciler.Reconcile",
 		trace.WithAttributes(

--- a/pkg/ot/opentelemetry.go
+++ b/pkg/ot/opentelemetry.go
@@ -26,7 +26,7 @@ import (
 )
 
 type (
-	// OpenTelemetryAutorestTracer implements the tracing interface for AutoRest
+	// OpenTelemetryAutorestTracer implements the tracing interface for AutoRest.
 	OpenTelemetryAutorestTracer struct {
 		tracer trace.Tracer
 	}
@@ -34,7 +34,7 @@ type (
 
 var _ tracing.Tracer = (*OpenTelemetryAutorestTracer)(nil)
 
-// NewOpenTelemetryAutorestTracer creates a new Autorest tracing adapter for OpenTelemetry
+// NewOpenTelemetryAutorestTracer creates a new Autorest tracing adapter for OpenTelemetry.
 func NewOpenTelemetryAutorestTracer(tracer trace.Tracer) *OpenTelemetryAutorestTracer {
 	return &OpenTelemetryAutorestTracer{
 		tracer: tracer,
@@ -42,19 +42,19 @@ func NewOpenTelemetryAutorestTracer(tracer trace.Tracer) *OpenTelemetryAutorestT
 }
 
 // NewTransport creates a new http.RoundTripper which will augment the base http.RoundTripper with OpenTelemetry
-// tracing and metrics
+// tracing and metrics.
 func (ot *OpenTelemetryAutorestTracer) NewTransport(base *http.Transport) http.RoundTripper {
 	return otelhttp.NewTransport(base)
 }
 
-// StartSpan creates a new span of a given name and adds it to the given context.Context
+// StartSpan creates a new span of a given name and adds it to the given context.Context.
 func (ot *OpenTelemetryAutorestTracer) StartSpan(ctx context.Context, name string) context.Context {
 	ctx, _ = ot.tracer.Start(ctx, name)
 	return ctx
 }
 
 // EndSpan ends the current context span. It ignores the httpsStatusCode and error since they are recorded by
-// the otelhttp.Transport
+// the otelhttp.Transport.
 func (ot *OpenTelemetryAutorestTracer) EndSpan(ctx context.Context, httpStatusCode int, err error) {
 	span := trace.SpanFromContext(ctx)
 	span.End()

--- a/util/cache/ttllru/ttllru.go
+++ b/util/cache/ttllru/ttllru.go
@@ -26,21 +26,21 @@ import (
 
 type (
 	// Cache is a TTL LRU cache which caches items with a max time to live and with
-	// bounded length
+	// bounded length.
 	Cache struct {
 		Cacher
 		TimeToLive time.Duration
 		mu         sync.Mutex
 	}
 
-	// Cacher describes a basic cache
+	// Cacher describes a basic cache.
 	Cacher interface {
 		Get(key interface{}) (value interface{}, ok bool)
 		Add(key interface{}, value interface{}) (evicted bool)
 		Remove(key interface{}) (ok bool)
 	}
 
-	// PeekingCacher describes a basic cache with the ability to peek
+	// PeekingCacher describes a basic cache with the ability to peek.
 	PeekingCacher interface {
 		Cacher
 		Peek(key interface{}) (value interface{}, expiration time.Time, ok bool)
@@ -53,7 +53,7 @@ type (
 )
 
 // New creates a new TTL LRU cache which caches items with a max time to live and with
-// bounded length
+// bounded length.
 func New(size int, timeToLive time.Duration) (PeekingCacher, error) {
 	c, err := lru.New(size)
 	if err != nil {
@@ -70,7 +70,7 @@ func newCache(timeToLive time.Duration, cache Cacher) (PeekingCacher, error) {
 	}, nil
 }
 
-// Get returns a value and a bool indicating the value was found for a given key
+// Get returns a value and a bool indicating the value was found for a given key.
 func (ttlCache *Cache) Get(key interface{}) (value interface{}, ok bool) {
 	ttlItem, ok := ttlCache.peekItem(key)
 	if !ok {
@@ -81,7 +81,7 @@ func (ttlCache *Cache) Get(key interface{}) (value interface{}, ok bool) {
 	return ttlItem.Value, true
 }
 
-// Add will add a value for a given key
+// Add will add a value for a given key.
 func (ttlCache *Cache) Add(key interface{}, val interface{}) bool {
 	ttlCache.mu.Lock()
 	defer ttlCache.mu.Unlock()
@@ -92,7 +92,7 @@ func (ttlCache *Cache) Add(key interface{}, val interface{}) bool {
 	})
 }
 
-// Peek will fetch an item from the cache, but will not update the expiration time
+// Peek will fetch an item from the cache, but will not update the expiration time.
 func (ttlCache *Cache) Peek(key interface{}) (value interface{}, expiration time.Time, ok bool) {
 	ttlItem, ok := ttlCache.peekItem(key)
 	if !ok {

--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
@@ -21,13 +21,13 @@ import (
 )
 
 const (
-	// DefaultLoopTimeout is the default timeout for a reconcile loop (defaulted to the max ARM template duration)
+	// DefaultLoopTimeout is the default timeout for a reconcile loop (defaulted to the max ARM template duration).
 	DefaultLoopTimeout = 90 * time.Minute
-	// DefaultMappingTimeout is the default timeout for a controller request mapping func
+	// DefaultMappingTimeout is the default timeout for a controller request mapping func.
 	DefaultMappingTimeout = 60 * time.Second
 )
 
-// DefaultedLoopTimeout will default the timeout if it is zero valued
+// DefaultedLoopTimeout will default the timeout if it is zero-valued.
 func DefaultedLoopTimeout(timeout time.Duration) time.Duration {
 	if timeout <= 0 {
 		return DefaultLoopTimeout

--- a/util/ssh/ssh.go
+++ b/util/ssh/ssh.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// GenerateSSHKey generates a private and public ssh key
+// GenerateSSHKey generates a private and public ssh key.
 func GenerateSSHKey() (*rsa.PrivateKey, ssh.PublicKey, error) {
 	privateKey, perr := rsa.GenerateKey(rand.Reader, 2048)
 	if perr != nil {

--- a/util/system/namespace.go
+++ b/util/system/namespace.go
@@ -19,13 +19,13 @@ package system
 import "os"
 
 const (
-	// NamespaceEnvVarName is the env var coming from DownwardAPI in the manager manifest
+	// NamespaceEnvVarName is the env var coming from DownwardAPI in the manager manifest.
 	NamespaceEnvVarName = "POD_NAMESPACE"
-	// DefaultNamespace is the default value from manifest
+	// DefaultNamespace is the default value from manifest.
 	DefaultNamespace = "capz-system"
 )
 
-// GetManagerNamespace return the namespace where the controller is running
+// GetManagerNamespace returns the namespace where the controller is running.
 func GetManagerNamespace() string {
 	managerNamespace := os.Getenv(NamespaceEnvVarName)
 	if managerNamespace == "" {

--- a/util/tele/tele.go
+++ b/util/tele/tele.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/otel/api/trace"
 )
 
-// Tracer returns the default opentelemetry tracer
+// Tracer returns the default opentelemetry tracer.
 func Tracer() trace.Tracer {
 	return global.Tracer("capz")
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds the [`godot`](https://github.com/tetafro/godot) linter to the golangci-lint config to ensure that Go doc comments end with periods. This linter is also [enabled in CAPI](https://github.com/kubernetes-sigs/cluster-api/blob/master/.golangci.yml#L14).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

This is a pet peeve of mine, but feel free to close it if this isn't considered productive. Sorry it's so big--I can split it up if necessary.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
