### PR TITLE
Make azure credentials optional in manager deployment

### DIFF
--- a/config/default/credentials.yaml
+++ b/config/default/credentials.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: system
 type: Opaque
 data:
-  subscription-id: ${AZURE_SUBSCRIPTION_ID_B64}
-  tenant-id: ${AZURE_TENANT_ID_B64}
-  client-id: ${AZURE_CLIENT_ID_B64}
-  client-secret: ${AZURE_CLIENT_SECRET_B64}
+  subscription-id: ${AZURE_SUBSCRIPTION_ID_B64:=""}
+  tenant-id: ${AZURE_TENANT_ID_B64:=""}
+  client-id: ${AZURE_CLIENT_ID_B64:=""}
+  client-secret: ${AZURE_CLIENT_SECRET_B64:=""}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Following up on #1386 and #977, this makes the Azure credentials environment variables optional in the infrastructure components yaml spec by defaulting the values to "". When not setting the environment variables in the manager, the user will need to specify an AzureClusterIdentity for each workload cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

- this should be merged after #1386  
/hold
- this requires envsubst to be used to install CAPZ components (which is already required due to EXP feature flags)
- how can we make the UX better for new users who don't set manager variables and thus have to create an AzureClusterIdentity on their cluster ?


_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make azure credentials optional in manager deployment
```
