### PR TITLE
Add whitespace linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - unconvert
     - unused
     - varcheck
+    - whitespace
   # Run with --fast=false for more extensive checks
   fast: true
 issues:

--- a/api/v1alpha4/azurecluster_default.go
+++ b/api/v1alpha4/azurecluster_default.go
@@ -155,7 +155,6 @@ func (c *AzureCluster) setAPIServerLBDefaults() {
 				},
 			}
 		}
-
 	} else if lb.Type == Internal {
 		if lb.Name == "" {
 			lb.Name = generateInternalLBName(c.ObjectMeta.Name)
@@ -214,7 +213,6 @@ func (c *AzureCluster) setNodeOutboundLBDefaults() {
 				},
 			}
 		}
-
 	}
 }
 

--- a/api/v1alpha4/azurecluster_validation_test.go
+++ b/api/v1alpha4/azurecluster_validation_test.go
@@ -86,7 +86,6 @@ func TestClusterNameValidation(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			azureCluster := AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tc.clusterName,

--- a/api/v1alpha4/azuremachine_default_test.go
+++ b/api/v1alpha4/azuremachine_default_test.go
@@ -248,7 +248,6 @@ func TestAzureMachine_SetDataDisksDefaults(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func createMachineWithSSHPublicKey(t *testing.T, sshPublicKey string) *AzureMachine {

--- a/api/v1alpha4/azuremachine_webhook_test.go
+++ b/api/v1alpha4/azuremachine_webhook_test.go
@@ -569,7 +569,6 @@ func createMachineWithSharedImage(t *testing.T, subscriptionID, resourceGroup, n
 			OSDisk:       validOSDisk,
 		},
 	}
-
 }
 
 func createMachineWithtMarketPlaceImage(t *testing.T, publisher, offer, sku, version string) *AzureMachine {

--- a/api/v1alpha4/azuremachinetemplate_webhook.go
+++ b/api/v1alpha4/azuremachinetemplate_webhook.go
@@ -65,7 +65,6 @@ func (r *AzureMachineTemplate) ValidateUpdate(oldRaw runtime.Object) error {
 		return nil
 	}
 	return apierrors.NewInvalid(GroupVersion.WithKind("AzureMachineTemplate").GroupKind(), r.Name, allErrs)
-
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/api/v1alpha4/azuremachinetemplate_webhook_test.go
+++ b/api/v1alpha4/azuremachinetemplate_webhook_test.go
@@ -125,5 +125,4 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/azure/converters/image.go
+++ b/azure/converters/image.go
@@ -27,7 +27,6 @@ import (
 
 // ImageToSDK converts a CAPZ Image (as RawExtension) to a Azure SDK Image Reference.
 func ImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
-
 	if image.ID != nil {
 		return specificImageToSDK(image)
 	}
@@ -39,7 +38,6 @@ func ImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	}
 
 	return nil, errors.New("unable to convert image as no options set")
-
 }
 
 func mpImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
@@ -49,7 +47,6 @@ func mpImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 		Sku:       &image.Marketplace.SKU,
 		Version:   &image.Marketplace.Version,
 	}, nil
-
 }
 
 func sigImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {

--- a/azure/converters/vmss.go
+++ b/azure/converters/vmss.go
@@ -54,7 +54,6 @@ func SDKToVMSS(sdkvmss compute.VirtualMachineScaleSet, sdkinstances []compute.Vi
 	if sdkvmss.VirtualMachineProfile != nil &&
 		sdkvmss.VirtualMachineProfile.StorageProfile != nil &&
 		sdkvmss.VirtualMachineProfile.StorageProfile.ImageReference != nil {
-
 		imageRef := sdkvmss.VirtualMachineProfile.StorageProfile.ImageReference
 		vmss.Image = SDKImageToImage(imageRef, sdkvmss.Plan != nil)
 	}

--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -161,7 +161,6 @@ func getAzureIdentityType(identity *infrav1.AzureClusterIdentity) (aadpodv1.Iden
 	}
 
 	return 0, errors.New("AzureIdentity does not have a vaild type")
-
 }
 
 // IsClusterNamespaceAllowed indicates if the cluster namespace is allowed.

--- a/azure/scope/identity_test.go
+++ b/azure/scope/identity_test.go
@@ -119,7 +119,6 @@ func TestAllowedNamespaces(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			fakeNamespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "namespace8",

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -122,7 +122,6 @@ func TestMachineScope_Name(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			got := tt.machineScope.Name()
 			if got != tt.want {
 				t.Errorf("MachineScope.Name() = %v, want %v", got, tt.want)
@@ -172,7 +171,6 @@ func TestMachineScope_GetVMID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			got := tt.machineScope.GetVMID()
 			if got != tt.want {
 				t.Errorf("MachineScope.GetVMID() = %v, want %v", got, tt.want)
@@ -218,7 +216,6 @@ func TestMachineScope_ProviderID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			got := tt.machineScope.ProviderID()
 			if got != tt.want {
 				t.Errorf("MachineScope.ProviderID() = %v, want %v", got, tt.want)

--- a/azure/services/availabilitysets/availabilitysets_test.go
+++ b/azure/services/availabilitysets/availabilitysets_test.go
@@ -77,7 +77,6 @@ func TestReconcileAvailabilitySets(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -117,7 +116,6 @@ func TestReconcileAvailabilitySets(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 	}

--- a/azure/services/networkinterfaces/networkinterfaces.go
+++ b/azure/services/networkinterfaces/networkinterfaces.go
@@ -58,7 +58,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	defer span.End()
 
 	for _, nicSpec := range s.Scope.NICSpecs() {
-
 		_, err := s.Client.Get(ctx, s.Scope.ResourceGroup(), nicSpec.Name)
 		switch {
 		case err != nil && !azure.ResourceNotFound(err):

--- a/azure/services/resourceskus/cache_test.go
+++ b/azure/services/resourceskus/cache_test.go
@@ -98,7 +98,6 @@ func TestCacheGet(t *testing.T) {
 					t.Fatalf("expected kind to be %s, but was %s", tc.resourceType, *val.ResourceType)
 				}
 			}
-
 		})
 	}
 }

--- a/azure/services/roleassignments/roleassignments.go
+++ b/azure/services/roleassignments/roleassignments.go
@@ -64,7 +64,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	defer span.End()
 
 	for _, roleSpec := range s.Scope.RoleAssignmentSpecs() {
-
 		switch roleSpec.ResourceType {
 		case azure.VirtualMachine:
 			return s.reconcileVM(ctx, roleSpec)
@@ -74,7 +73,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			return errors.Errorf("unexpected resource type %q. Expected one of [%s, %s]", roleSpec.ResourceType,
 				azure.VirtualMachine, azure.VirtualMachineScaleSet)
 		}
-
 	}
 	return nil
 }

--- a/azure/services/securitygroups/securitygroups.go
+++ b/azure/services/securitygroups/securitygroups.go
@@ -94,7 +94,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			for _, rule := range nsgSpec.SecurityRules {
 				securityRules = append(securityRules, converters.SecurityRuleToSDK(rule))
 			}
-
 		}
 		sg := network.SecurityGroup{
 			Location: to.StringPtr(s.Scope.Location()),

--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -120,9 +120,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			}
 
 			s.Scope.V(2).Info("successfully created subnet in vnet", "subnet", subnetSpec.Name, "vnet", subnetSpec.VNetName)
-
 		}
-
 	}
 	return nil
 }

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -279,7 +279,6 @@ func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine) (
 		return addresses, nil
 	}
 	for _, nicRef := range *vm.NetworkProfile.NetworkInterfaces {
-
 		// The full ID includes the name at the very end. Split the string and pull the last element
 		// Ex: /subscriptions/$SUB/resourceGroups/$RG/providers/Microsoft.Network/networkInterfaces/$NICNAME
 		// We'll check to see if ID is nil and bail early if we don't have it

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -475,7 +475,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -547,7 +546,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -619,7 +617,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -692,7 +689,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -749,7 +745,6 @@ func TestReconcileVM(t *testing.T) {
 					g.Expect(*vm.VirtualMachineProperties.OsProfile.AdminPassword).Should(HaveLen(123))
 					g.Expect(*vm.VirtualMachineProperties.OsProfile.AdminUsername).Should(Equal("capi"))
 					g.Expect(*vm.VirtualMachineProperties.OsProfile.WindowsConfiguration.EnableAutomaticUpdates).Should(Equal(false))
-
 				})
 			},
 			ExpectedError: "",
@@ -826,7 +821,6 @@ func TestReconcileVM(t *testing.T) {
 				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
 					g.Expect(vm.VirtualMachineProperties.StorageProfile.OsDisk.ManagedDisk.DiskEncryptionSet.ID).To(Equal(to.StringPtr("my-diskencryptionset-id")))
-
 				})
 			},
 			ExpectedError: "",
@@ -858,7 +852,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -895,7 +888,6 @@ func TestReconcileVM(t *testing.T) {
 				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
 					g.Expect(*vm.VirtualMachineProperties.SecurityProfile.EncryptionAtHost).To(Equal(true))
-
 				})
 			},
 			ExpectedError: "",
@@ -931,7 +923,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 
 				svc.resourceSKUCache = resourceskus.NewStaticCache(skus, "")
-
 			},
 		},
 		{
@@ -1088,7 +1079,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -1214,7 +1204,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -1281,7 +1270,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -1348,7 +1336,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -1422,7 +1409,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{
@@ -1587,7 +1573,6 @@ func TestReconcileVM(t *testing.T) {
 				}
 				resourceSkusCache := resourceskus.NewStaticCache(skus, "")
 				svc.resourceSKUCache = resourceSkusCache
-
 			},
 		},
 		{

--- a/azure/services/virtualnetworks/virtualnetworks_test.go
+++ b/azure/services/virtualnetworks/virtualnetworks_test.go
@@ -355,7 +355,6 @@ func TestDeleteVnet(t *testing.T) {
 				})
 				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists").
 					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Honk Server"))
-
 			},
 		},
 	}

--- a/azure/services/vmextensions/vmextensions_test.go
+++ b/azure/services/vmextensions/vmextensions_test.go
@@ -173,7 +173,6 @@ func TestReconcileVMExtension(t *testing.T) {
 				s.Location().AnyTimes().Return("test-location")
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm", "my-extension-1").
 					Return(compute.VirtualMachineExtension{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
-
 			},
 		},
 		{
@@ -200,7 +199,6 @@ func TestReconcileVMExtension(t *testing.T) {
 				m.Get(gomockinternal.AContext(), "my-rg", "my-vm", "my-extension-1").
 					Return(compute.VirtualMachineExtension{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 				m.CreateOrUpdateAsync(gomockinternal.AContext(), "my-rg", "my-vm", "my-extension-1", gomock.AssignableToTypeOf(compute.VirtualMachineExtension{})).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
-
 			},
 		},
 	}

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -165,7 +165,6 @@ func (s *azureClusterService) Delete(ctx context.Context) error {
 			if err := s.bastionSvc.Delete(ctx); err != nil {
 				return errors.Wrap(err, "failed to delete bastion")
 			}
-
 		} else {
 			return errors.Wrap(err, "failed to delete resource group")
 		}

--- a/controllers/azurecluster_reconciler_test.go
+++ b/controllers/azurecluster_reconciler_test.go
@@ -140,5 +140,4 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/controllers/azureidentity_controller.go
+++ b/controllers/azureidentity_controller.go
@@ -133,7 +133,6 @@ func (r *AzureIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			} else {
 				return ctrl.Result{}, errors.Wrap(err, "failed to get AzureCluster")
 			}
-
 		}
 		expectedIdentityName := identity.GetAzureIdentityName(azCluster.Name, azCluster.Namespace, azCluster.Spec.IdentityRef.Name)
 		if binding.Spec.AzureIdentity != expectedIdentityName {

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -190,7 +190,6 @@ func TestConditions(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func conditionsMatch(i, j clusterv1.Condition) bool {

--- a/exp/controllers/azuremanagedmachinepool_reconciler_test.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler_test.go
@@ -59,5 +59,4 @@ func TestIsAgentPoolVMSSNotFoundError(t *testing.T) {
 			g.Expect(IsAgentPoolVMSSNotFoundError(c.Err)).To(gomega.Equal(c.Expected))
 		})
 	}
-
 }

--- a/exp/controllers/helpers.go
+++ b/exp/controllers/helpers.go
@@ -550,7 +550,6 @@ func MachinePoolModelHasChanged(logger logr.Logger) predicate.Funcs {
 
 			oldAmp, ok := e.ObjectOld.(*infrav1exp.AzureMachinePool)
 			if !ok {
-
 				log.V(4).Info("Expected AzureMachinePool", "type", e.ObjectOld.GetObjectKind().GroupVersionKind().String())
 				return false
 			}
@@ -584,7 +583,6 @@ func MachinePoolMachineHasStateOrVersionChange(logger logr.Logger) predicate.Fun
 
 			oldAmp, ok := e.ObjectOld.(*infrav1exp.AzureMachinePoolMachine)
 			if !ok {
-
 				log.V(4).Info("Expected AzureMachinePoolMachine", "type", e.ObjectOld.GetObjectKind().GroupVersionKind().String())
 				return false
 			}


### PR DESCRIPTION
**What type of PR is this?**:

/kind cleanup

**What this PR does / why we need it**:

Adds the [`whitespace`](https://github.com/ultraware/whitespace) linter to the golangci-lint config to police dangling blank lines. This linter is also [enabled in CAPI](https://github.com/kubernetes-sigs/cluster-api/blob/master/.golangci.yml#L38).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
