### PR TITLE
Adding correlation IDs to reconcile loops

### DIFF
--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -137,7 +137,8 @@ func (r *AzureMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			attribute.String("namespace", req.Namespace),
 			attribute.String("name", req.Name),
 			attribute.String("kind", "AzureMachine"),
-		))
+		),
+	)
 	defer span.End()
 
 	// Fetch the AzureMachine VM.

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -168,7 +168,8 @@ func (ampr *AzureMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.
 			attribute.String("namespace", req.Namespace),
 			attribute.String("name", req.Name),
 			attribute.String("kind", "AzureMachinePool"),
-		))
+		),
+	)
 	defer span.End()
 
 	azMachinePool := &infrav1exp.AzureMachinePool{}

--- a/exp/controllers/azuremachinepoolmachine_controller.go
+++ b/exp/controllers/azuremachinepoolmachine_controller.go
@@ -136,7 +136,8 @@ func (ampmr *AzureMachinePoolMachineController) Reconcile(ctx context.Context, r
 			attribute.String("namespace", req.Namespace),
 			attribute.String("name", req.Name),
 			attribute.String("kind", "AzureMachinePoolMachine"),
-		))
+		),
+	)
 	defer span.End()
 
 	machine := &infrav1exp.AzureMachinePoolMachine{}

--- a/util/tele/corr_id.go
+++ b/util/tele/corr_id.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tele
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type corrIDKey string
+
+// CorrID is a correlation ID that the cluster API provider
+// sends with all API requests to Azure. Do not create one
+// of these manually. Instead, use the CtxWithCorrelationID function
+// to create one of these within a context.Context.
+type CorrID string
+
+const corrIDKeyVal corrIDKey = "x-ms-correlation-id"
+
+// ctxWithCorrID creates a CorrID and creates a new context.Context
+// with the new CorrID in it. It returns the _new_ context and the
+// newly created CorrID. If there was a problem creating the correlation
+// ID, the new context will not have the correlation ID in it and the
+// returned CorrID will be the empty string.After you call this function, prefer to
+// use the newly created context over the old one. Common usage is
+// below:
+//
+// 	ctx := context.Background()
+//	ctx, newCorrID := CtxWithCorrID(ctx)
+//	fmt.Println("new corr ID: ", newCorrID)
+//	doSomething(ctx)
+func ctxWithCorrID(ctx context.Context) (context.Context, CorrID) {
+	currentCorrIDIface := ctx.Value(corrIDKeyVal)
+	if currentCorrIDIface != nil {
+		currentCorrID, ok := currentCorrIDIface.(CorrID)
+		if ok {
+			return ctx, currentCorrID
+		}
+	}
+	uid, err := uuid.NewRandom()
+	if err != nil {
+		return nil, CorrID("")
+	}
+	newCorrID := CorrID(uid.String())
+	ctx = context.WithValue(ctx, corrIDKeyVal, newCorrID)
+	return ctx, newCorrID
+}
+
+// CorrIDFromCtx attempts to fetch a correlation ID from the given
+// context.Context. If none exists, returns an empty CorrID and false.
+// Otherwise returns the CorrID value and true.
+func CorrIDFromCtx(ctx context.Context) (CorrID, bool) {
+	currentCorrIDIface := ctx.Value(corrIDKeyVal)
+	if currentCorrIDIface == nil {
+		return CorrID(""), false
+	}
+
+	if corrID, ok := currentCorrIDIface.(CorrID); ok {
+		return corrID, ok
+	}
+
+	return CorrID(""), false
+}


### PR DESCRIPTION
Signed-off-by: Aaron Schlesinger <aaron@ecomaz.net>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

This PR adds shared correlation IDs to `context.Context`s passed to reconcile loops, so that the API requests made to Azure get logged and tracked properly. That feature is especially useful for debugging.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1310

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add 'x-ms-correlation-id' headers to all Azure API calls via distributed traces.
```
