### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/book/src/topics/gpu.md
+++ b/docs/book/src/topics/gpu.md
@@ -18,7 +18,7 @@ Let's create a CAPZ cluster with an N-series node and run a GPU-powered vector c
 
 ### Generate an nvidia-gpu cluster template
 
-Use the `clusterctl config cluster` command to generate a manifest that defines your GPU-enabled
+Use the `clusterctl generate cluster` command to generate a manifest that defines your GPU-enabled
 workload cluster.
 
 Remember to use the `nvidia-gpu` flavor with N-series nodes.
@@ -27,7 +27,7 @@ Remember to use the `nvidia-gpu` flavor with N-series nodes.
 AZURE_CONTROL_PLANE_MACHINE_TYPE=Standard_D2s_v3 \
 AZURE_NODE_MACHINE_TYPE=Standard_NC6s_v3 \
 AZURE_LOCATION=southcentralus \
-clusterctl config cluster azure-gpu \
+clusterctl generate cluster azure-gpu \
   --kubernetes-version=v1.19.7 \
   --worker-machine-count=1 \
   --flavor=nvidia-gpu > azure-gpu-cluster.yaml

--- a/docs/book/src/topics/identity.md
+++ b/docs/book/src/topics/identity.md
@@ -146,7 +146,7 @@ spec:
 
 The CAPZ controller will look for `SystemAssigned` value in `identity` field under `AzureMachinePool`, and enable system-assigned managed identity in the virtual machine scale set.
 
-Alternatively, you can also use the `system-assigned-identity`, and `machinepool-system-assigned-identity` flavors by setting the `{flavor}` in `clusterctl config cluster --flavor {flavor}` to use system-assigned managed identity in machine deployment, and machine pool respectively.
+Alternatively, you can also use the `system-assigned-identity`, and `machinepool-system-assigned-identity` flavors by setting the `{flavor}` in `clusterctl generate cluster --flavor {flavor}` to use system-assigned managed identity in machine deployment, and machine pool respectively.
 
 #### User-assigned managed identity
 
@@ -249,4 +249,4 @@ spec:
 
 The CAPZ controller will look for `UserAssigned` value in `identity` field under `AzureMachinePool`, and assign the user identities listed in `userAssignedIdentities` to the virtual machine scale set.
 
-Similar to system assigned identity, you can use the `user-assigned-identity`, and `machinepool-user-assigned-identity` flavors by setting the `{flavor}` in `clusterctl config cluster --flavor {flavor}` to use user-assigned managed identity in machine deployment, and machine pool respectively.
+Similar to system assigned identity, you can use the `user-assigned-identity`, and `machinepool-user-assigned-identity` flavors by setting the `{flavor}` in `clusterctl generate cluster --flavor {flavor}` to use user-assigned managed identity in machine deployment, and machine pool respectively.

--- a/docs/book/src/topics/machinepools.md
+++ b/docs/book/src/topics/machinepools.md
@@ -39,16 +39,16 @@ which provides the cloud provider specific resource for orchestrating a group of
 ⚠️ Cloud provider for Azure does not currently support clusters in mixed mode (both vmss and vmas node pools), so it is not supported to have both `AzureMachinePools` and `AzureMachines` in the same workload cluster.
 
 ### Using `clusterctl` to deploy
-To deploy a MachinePool / AzureMachinePool via `clusterctl config` there's a [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/config-cluster.html#flavors)
+To deploy a MachinePool / AzureMachinePool via `clusterctl generate` there's a [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-cluster.html#flavors)
 for that.
 
 Make sure to set up your Azure environment as described [here](https://cluster-api.sigs.k8s.io/user/quick-start.html).
 
 ```shell
-clusterctl config cluster my-cluster --kubernetes-version v1.19.7 --flavor machinepool > my-cluster.yaml
+clusterctl generate cluster my-cluster --kubernetes-version v1.19.7 --flavor machinepool > my-cluster.yaml
 ```
 
-The template used for this [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/config-cluster.html#flavors)
+The template used for this [flavor](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-cluster.html#flavors)
 is located [here](https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/templates/cluster-template-machinepool.yaml).
 
 ### Example MachinePool, AzureMachinePool and KubeadmConfig Resources

--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -58,7 +58,7 @@ Execute clusterctl to template the resources, then apply to a management cluster
 
 ```bash
 clusterctl init --infrastructure azure
-clusterctl config cluster ${CLUSTER_NAME} --kubernetes-version ${KUBERNETES_VERSION} --flavor aks > cluster.yaml
+clusterctl generate cluster ${CLUSTER_NAME} --kubernetes-version ${KUBERNETES_VERSION} --flavor aks > cluster.yaml
 
 # assumes an existing management cluster
 kubectl apply -f cluster.yaml

--- a/templates/flavors/README.md
+++ b/templates/flavors/README.md
@@ -6,7 +6,7 @@ or flavors; use the --flavor flag to specify which flavor to use; e.g
 clusterctl config cluster my-cluster --kubernetes-version v1.19.7 \
     --flavor external-cloud-provider > my-cluster.yaml
 ```
-See [`clusterctl` flavors docs](https://cluster-api.sigs.k8s.io/clusterctl/commands/config-cluster.html#flavors).
+See [`clusterctl` flavors docs](https://cluster-api.sigs.k8s.io/clusterctl/commands/generate-cluster.html#flavors).
 
 This directory contains each of the flavors for CAPZ. Each directory besides `base` will be used to
 create a flavor by running `kustomize build` on the directory. The name of the directory will be


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind documentation

**What this PR does / why we need it**:
There is a broken link in the docs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The root cause is CAPI [renaming `clusterctl config cluster` to `clusterctl generate cluster`](https://github.com/kubernetes-sigs/cluster-api/pull/4778).

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix broken link in docs after clusterctl changes
```
