### PR TITLE
Make tilt watch relevant folders

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -138,7 +138,7 @@ def capz():
     local_resource(
         "manager",
         cmd = 'mkdir -p .tiltbuild;CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \'-extldflags "-static"\' -o .tiltbuild/manager',
-        deps = ["api", "cloud", "config", "controllers", "exp", "feature", "pkg", "go.mod", "go.sum", "main.go"]
+        deps = ["api", "azure", "config", "controllers", "exp", "feature", "pkg", "util", "go.mod", "go.sum", "main.go"]
     )
 
     dockerfile_contents = "\n".join([


### PR DESCRIPTION
**What type of PR is this?**
/kind other


**What this PR does / why we need it**:
Tilt can watch folders to that when code changes the deployed capz is updated. But the `azure` folder is not included in this list, which means that developers need to manually run the Tilt task again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I believe it was like this before, but the `cloud` folder got renamed to `azure` and the `Tiltfile` was never updated.

I also added the `util` folder.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make tilt watch relevant folders
```
