### PR TITLE
SinglePlacementGroup=false for Azure VMSS (MachinePool)

### DIFF
--- a/azure/converters/vmss_test.go
+++ b/azure/converters/vmss_test.go
@@ -52,7 +52,8 @@ func Test_SDKToVMSS(t *testing.T) {
 						Location: to.StringPtr("westus2"),
 						Tags:     tags,
 						VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-							ProvisioningState: to.StringPtr(string(compute.ProvisioningState1Succeeded)),
+							SinglePlacementGroup: to.BoolPtr(false),
+							ProvisioningState:    to.StringPtr(string(compute.ProvisioningState1Succeeded)),
 						},
 					},
 					[]compute.VirtualMachineScaleSetVM{

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -387,6 +387,7 @@ func (s *Service) buildVMSSFromSpec(ctx context.Context, vmssSpec azure.ScaleSet
 		Zones: to.StringSlicePtr(vmssSpec.FailureDomains),
 		Plan:  s.generateImagePlan(),
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+			SinglePlacementGroup: to.BoolPtr(false),
 			UpgradePolicy: &compute.UpgradePolicy{
 				Mode: compute.UpgradeModeManual,
 			},

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -150,7 +150,8 @@ func TestGetExistingVMSS(t *testing.T) {
 						Name:     to.StringPtr("Standard_D2"),
 					},
 					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-						ProvisioningState: to.StringPtr("Succeeded"),
+						SinglePlacementGroup: to.BoolPtr(false),
+						ProvisioningState:    to.StringPtr("Succeeded"),
 					},
 					Zones: &[]string{"1", "3"},
 				}, nil)
@@ -182,7 +183,8 @@ func TestGetExistingVMSS(t *testing.T) {
 					ID:   to.StringPtr("my-id"),
 					Name: to.StringPtr("my-vmss"),
 					VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
-						ProvisioningState: to.StringPtr("Succeeded"),
+						SinglePlacementGroup: to.BoolPtr(false),
+						ProvisioningState:    to.StringPtr("Succeeded"),
 					},
 				}, nil)
 				m.ListInstances(gomockinternal.AContext(), "my-rg", "my-vmss").Return([]compute.VirtualMachineScaleSetVM{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
@@ -853,6 +855,7 @@ func newDefaultVMSS() compute.VirtualMachineScaleSet {
 		},
 		Zones: &[]string{"1", "3"},
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
+			SinglePlacementGroup: to.BoolPtr(false),
 			UpgradePolicy: &compute.UpgradePolicy{
 				Mode: compute.UpgradeModeManual,
 			},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind feature

**What this PR does / why we need it**:

This PR changes the AzureMachinePool implementation so that we do not create the underlying VMSS in a SinglePlacementGroup configuration.

A single placement group restricts the size of the VMSS (and thus the AzureMachinePool) to 100, whereas using multiple placement groups allows for a pool size of up to 1000.

Ref: https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-placement-groups#placement-groups

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #484

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
SinglePlacementGroup=false for Azure VMSS (MachinePool)
```
