### PR TITLE
feat: automatic AllocatedOutboundPorts LB value

### DIFF
--- a/azure/services/loadbalancers/loadbalancers.go
+++ b/azure/services/loadbalancers/loadbalancers.go
@@ -240,6 +240,7 @@ func (s *Service) getOutboundRules(lbSpec azure.LBSpec, frontendIDs []network.Su
 				BackendAddressPool: &network.SubResource{
 					ID: to.StringPtr(azure.AddressPoolID(s.Scope.SubscriptionID(), s.Scope.ResourceGroup(), lbSpec.Name, lbSpec.BackendPoolName)),
 				},
+				AllocatedOutboundPorts: to.Int32Ptr(0),
 			},
 		},
 	}

--- a/azure/services/loadbalancers/loadbalancers_test.go
+++ b/azure/services/loadbalancers/loadbalancers_test.go
@@ -404,8 +404,9 @@ func newDefaultNodeOutboundLB() network.LoadBalancer {
 						BackendAddressPool: &network.SubResource{
 							ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-cluster/backendAddressPools/my-cluster-outboundBackendPool"),
 						},
-						Protocol:             network.LoadBalancerOutboundRuleProtocolAll,
-						IdleTimeoutInMinutes: to.Int32Ptr(30),
+						Protocol:               network.LoadBalancerOutboundRuleProtocolAll,
+						IdleTimeoutInMinutes:   to.Int32Ptr(30),
+						AllocatedOutboundPorts: to.Int32Ptr(0),
 					},
 				},
 			},
@@ -479,8 +480,9 @@ func newDefaultPublicAPIServerLB() network.LoadBalancer {
 						BackendAddressPool: &network.SubResource{
 							ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-publiclb/backendAddressPools/my-publiclb-backendPool"),
 						},
-						Protocol:             network.LoadBalancerOutboundRuleProtocolAll,
-						IdleTimeoutInMinutes: to.Int32Ptr(4),
+						Protocol:               network.LoadBalancerOutboundRuleProtocolAll,
+						IdleTimeoutInMinutes:   to.Int32Ptr(4),
+						AllocatedOutboundPorts: to.Int32Ptr(0),
 					},
 				},
 			},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind feature

**What this PR does / why we need it**:

This PR ensures that we use the Azure defaults for allocated outbound ports when creating a LoadBalancer, as different VMSS (AzureMachinePool) sizes are better suited to different values. Using "0" is the way to express "automatic".

To be clear, this configuration change will affect both AzureMachine (plain VMs) and AzureMachinePools (VMSS) resources. Azure's documentation guidance suggests VMSS, but our experience using this configuration in other Azure scenerios suggests it is appropriate for all VM types.

We will want to do some follow-up tests to validate how the "automatic" configuration adapts when the size of the AzureMachinePool changes. In other Azure + Kubernetes environments, using "0" when creating the cluster backed by VMSS works well in highly dynamic environments.

Ref:

https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections#outboundrules

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
LBs use automatic AllocatedOutboundPorts value
```
