### PR TITLE
Remove owner ref from AzureClusterIdentity

### DIFF
--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
-	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -161,16 +160,6 @@ func (r *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if !scope.IsClusterNamespaceAllowed(ctx, r.Client, identity.Spec.AllowedNamespaces, azureCluster.Namespace) {
 			conditions.MarkFalse(azureCluster, infrav1.NetworkInfrastructureReadyCondition, infrav1.NamespaceNotAllowedByIdentity, clusterv1.ConditionSeverityError, "")
 			return reconcile.Result{}, errors.New("AzureClusterIdentity list of allowed namespaces doesn't include current cluster namespace")
-		}
-		if identity.Namespace == azureCluster.Namespace {
-			patchhelper, err := patch.NewHelper(identity, r.Client)
-			if err != nil {
-				return reconcile.Result{}, errors.Wrap(err, "failed to init patch helper")
-			}
-			identity.ObjectMeta.OwnerReferences = azureCluster.GetOwnerReferences()
-			if err := patchhelper.Patch(ctx, identity); err != nil {
-				return reconcile.Result{}, err
-			}
 		}
 	} else {
 		warningMessage := ("You're using deprecated functionality: ")

--- a/exp/controllers/azuremanagedcontrolplane_controller.go
+++ b/exp/controllers/azuremanagedcontrolplane_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/cluster-api/util/patch"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -204,16 +203,6 @@ func (r *AzureManagedControlPlaneReconciler) Reconcile(ctx context.Context, req 
 		}
 		if !scope.IsClusterNamespaceAllowed(ctx, r.Client, identity.Spec.AllowedNamespaces, azureControlPlane.Namespace) {
 			return reconcile.Result{}, errors.New("AzureClusterIdentity list of allowed namespaces doesn't include current azure managed control plane namespace")
-		}
-		if identity.Namespace == azureControlPlane.Namespace {
-			patchHelper, err := patch.NewHelper(identity, r.Client)
-			if err != nil {
-				return reconcile.Result{}, errors.Wrap(err, "failed to init patch helper")
-			}
-			identity.ObjectMeta.OwnerReferences = azureControlPlane.GetOwnerReferences()
-			if err := patchHelper.Patch(ctx, identity); err != nil {
-				return reconcile.Result{}, err
-			}
 		}
 	} else {
 		warningMessage := ("You're using deprecated functionality: ")

--- a/templates/azure-cluster-identity/azure-cluster-identity.yaml
+++ b/templates/azure-cluster-identity/azure-cluster-identity.yaml
@@ -3,6 +3,8 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
   name: "${CLUSTER_IDENTITY_NAME}"
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
 spec:
   type: ServicePrincipal
   allowedNamespaces: {}

--- a/templates/cluster-template-aad.yaml
+++ b/templates/cluster-template-aad.yaml
@@ -210,6 +210,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -102,6 +102,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-azure-bastion.yaml
+++ b/templates/cluster-template-azure-bastion.yaml
@@ -203,6 +203,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -207,6 +207,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -202,6 +202,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -181,6 +181,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -156,6 +156,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -205,6 +205,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-nat-gateway.yaml
+++ b/templates/cluster-template-nat-gateway.yaml
@@ -214,6 +214,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-nvidia-gpu.yaml
+++ b/templates/cluster-template-nvidia-gpu.yaml
@@ -140,6 +140,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -319,6 +319,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -201,6 +201,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -219,6 +219,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -207,6 +207,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -186,6 +186,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -376,6 +376,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
@@ -161,6 +161,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -210,6 +210,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -145,6 +145,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -330,6 +330,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -302,6 +302,8 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureClusterIdentity
 metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: ${CLUSTER_IDENTITY_NAME}
   namespace: default
 spec:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
- Remove AzureClusterIdentity owner reference to avoid issues with a reference to an owner (Cluster) in a different namespace
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AzureClusterIdentity should not have an owner reference of a Cluster
```
