### PR TITLE
ensure e2e specs fail if Azure resources are leaked

### DIFF
--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -141,6 +141,10 @@ func (s *azureClusterService) Delete(ctx context.Context) error {
 
 	if err := s.groupsSvc.Delete(ctx); err != nil {
 		if errors.Is(err, azure.ErrNotOwned) {
+			if err := s.bastionSvc.Delete(ctx); err != nil {
+				return errors.Wrap(err, "failed to delete bastion")
+			}
+
 			if err := s.privateDNSSvc.Delete(ctx); err != nil {
 				return errors.Wrap(err, "failed to delete private dns")
 			}
@@ -171,10 +175,6 @@ func (s *azureClusterService) Delete(ctx context.Context) error {
 
 			if err := s.vnetSvc.Delete(ctx); err != nil {
 				return errors.Wrap(err, "failed to delete virtual network")
-			}
-
-			if err := s.bastionSvc.Delete(ctx); err != nil {
-				return errors.Wrap(err, "failed to delete bastion")
 			}
 		} else {
 			return errors.Wrap(err, "failed to delete resource group")

--- a/controllers/azurecluster_reconciler_test.go
+++ b/controllers/azurecluster_reconciler_test.go
@@ -59,6 +59,7 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 			expect: func(grp *mocks.MockReconcilerMockRecorder, vnet *mocks.MockReconcilerMockRecorder, sg *mocks.MockReconcilerMockRecorder, rt *mocks.MockReconcilerMockRecorder, sn *mocks.MockReconcilerMockRecorder, natg *mocks.MockReconcilerMockRecorder, pip *mocks.MockReconcilerMockRecorder, lb *mocks.MockReconcilerMockRecorder, dns *mocks.MockReconcilerMockRecorder, bastion *mocks.MockReconcilerMockRecorder) {
 				gomock.InOrder(
 					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
+					bastion.Delete(gomockinternal.AContext()),
 					dns.Delete(gomockinternal.AContext()),
 					lb.Delete(gomockinternal.AContext()),
 					sn.Delete(gomockinternal.AContext()),
@@ -67,7 +68,6 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 					rt.Delete(gomockinternal.AContext()),
 					sg.Delete(gomockinternal.AContext()),
 					vnet.Delete(gomockinternal.AContext()),
-					bastion.Delete(gomockinternal.AContext()),
 				)
 			},
 		},
@@ -76,6 +76,7 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 			expect: func(grp *mocks.MockReconcilerMockRecorder, vnet *mocks.MockReconcilerMockRecorder, sg *mocks.MockReconcilerMockRecorder, rt *mocks.MockReconcilerMockRecorder, sn *mocks.MockReconcilerMockRecorder, pip *mocks.MockReconcilerMockRecorder, natg *mocks.MockReconcilerMockRecorder, lb *mocks.MockReconcilerMockRecorder, dns *mocks.MockReconcilerMockRecorder, bastion *mocks.MockReconcilerMockRecorder) {
 				gomock.InOrder(
 					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
+					bastion.Delete(gomockinternal.AContext()),
 					dns.Delete(gomockinternal.AContext()),
 					lb.Delete(gomockinternal.AContext()).Return(errors.New("some error happened")),
 				)
@@ -86,6 +87,7 @@ func TestAzureClusterReconcilerDelete(t *testing.T) {
 			expect: func(grp *mocks.MockReconcilerMockRecorder, vnet *mocks.MockReconcilerMockRecorder, sg *mocks.MockReconcilerMockRecorder, rt *mocks.MockReconcilerMockRecorder, sn *mocks.MockReconcilerMockRecorder, pip *mocks.MockReconcilerMockRecorder, natg *mocks.MockReconcilerMockRecorder, lb *mocks.MockReconcilerMockRecorder, dns *mocks.MockReconcilerMockRecorder, bastion *mocks.MockReconcilerMockRecorder) {
 				gomock.InOrder(
 					grp.Delete(gomockinternal.AContext()).Return(azure.ErrNotOwned),
+					bastion.Delete(gomockinternal.AContext()),
 					dns.Delete(gomockinternal.AContext()),
 					lb.Delete(gomockinternal.AContext()),
 					sn.Delete(gomockinternal.AContext()),

--- a/test/e2e/azure_selfhosted.go
+++ b/test/e2e/azure_selfhosted.go
@@ -228,7 +228,16 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 			selfHostedCancelWatches()
 		}
 
+		cleanInput := cleanupInput{
+			SpecName:        specName,
+			Cluster:         clusterResources.Cluster,
+			ClusterProxy:    input.BootstrapClusterProxy,
+			Namespace:       namespace,
+			CancelWatches:   cancelWatches,
+			IntervalsGetter: input.E2EConfig.GetIntervals,
+			SkipCleanup:     input.SkipCleanup,
+		}
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
-		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+		dumpSpecResourcesAndCleanup(ctx, cleanInput)
 	})
 }

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -193,8 +193,17 @@ var _ = Describe("Conformance Tests", func() {
 			_ = bootstrapClusterProxy.GetClient().Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace.Name}, result.Cluster)
 		}
 
+		cleanInput := cleanupInput{
+			SpecName:          specName,
+			Cluster:           result.Cluster,
+			ClusterProxy:      bootstrapClusterProxy,
+			Namespace:         namespace,
+			CancelWatches:     cancelWatches,
+			IntervalsGetter:   e2eConfig.GetIntervals,
+			SkipCleanup:       skipCleanup,
+		}
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
-		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, result.Cluster, e2eConfig.GetIntervals, skipCleanup)
+		dumpSpecResourcesAndCleanup(ctx, cleanInput)
 
 		Expect(os.Unsetenv(AzureResourceGroup)).NotTo(HaveOccurred())
 		Expect(os.Unsetenv(AzureVNetName)).NotTo(HaveOccurred())


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
This PR will check for the presence of the cluster resource group in Azure after the cluster has been cleaned up in K8s. This will fail a spec when a cluster leaks Azure resources. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1505 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix to ensure Azure Bastion resource and other cluster resources are deleted when resource group is not owned.
```
