### PR TITLE
add daemonset implementation of timesync validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	sigs.k8s.io/cluster-api/test v0.4.0
 	sigs.k8s.io/controller-runtime v0.9.1
 	sigs.k8s.io/kind v0.11.1
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v0.4.0

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -460,9 +460,9 @@ var _ = Describe("Workload cluster creation", func() {
 				},
 			}, result)
 
-			Context("Validating AKS Resources", func() {
-				AKSResourcesValidationSpec(ctx, func() AKSResourcesValidationSpecInput {
-					return AKSResourcesValidationSpecInput{
+			Context("Validating AKS time synchronization", func() {
+				AzureDaemonsetTimeSyncSpec(ctx, func() AzureTimeSyncSpecInput {
+					return AzureTimeSyncSpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,

--- a/test/e2e/azure_timesync.go
+++ b/test/e2e/azure_timesync.go
@@ -21,14 +21,21 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"strings"
 	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	e2e_pod "sigs.k8s.io/cluster-api-provider-azure/test/e2e/kubernetes/pod"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	kinderrors "sigs.k8s.io/kind/pkg/errors"
+	"sigs.k8s.io/yaml"
 )
 
 // AzureTimeSyncSpecInput is the input for AzureTimeSyncSpec.
@@ -93,4 +100,138 @@ func AzureTimeSyncSpec(ctx context.Context, inputGetter func() AzureTimeSyncSpec
 
 		return kinderrors.AggregateConcurrent(testFuncs)
 	}, thirty, thirty).Should(Succeed())
+}
+
+const (
+	nsenterWorkloadFile = "workloads/nsenter/daemonset.yaml"
+)
+
+// AzureDaemonsetTimeSyncSpec implements a test that verifies time synchronization is healthy for
+// the nodes in a cluster. It uses a privileged daemonset and nsenter instead of SSH.
+func AzureDaemonsetTimeSyncSpec(ctx context.Context, inputGetter func() AzureTimeSyncSpecInput) {
+	var (
+		specName = "azure-timesync"
+		input    AzureTimeSyncSpecInput
+		sixty    = 60 * time.Second
+		five     = 5 * time.Second
+	)
+
+	input = inputGetter()
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	namespace, clusterName := input.Namespace.Name, input.ClusterName
+	workloadCluster := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, namespace, clusterName)
+	kubeclient := workloadCluster.GetClient()
+	clientset := workloadCluster.GetClientSet()
+	config := workloadCluster.GetRESTConfig()
+	var nsenterDs unstructured.Unstructured
+
+	yamlData, err := ioutil.ReadFile(nsenterWorkloadFile)
+	Expect(err).NotTo(HaveOccurred(), "failed to unmarshal nsenter daemonset from yaml")
+
+	var jsonData []byte
+	jsonData, err = yaml.YAMLToJSON(yamlData)
+	Expect(err).NotTo(HaveOccurred(), "failed to convert nsenter yaml to json")
+
+	err = nsenterDs.UnmarshalJSON(jsonData)
+	Expect(err).NotTo(HaveOccurred(), "failed to unmarshal nsenter json bytes to unstructured")
+
+	nsenterDs.SetNamespace("default")
+
+	err = kubeclient.Create(ctx, &nsenterDs)
+	Expect(err).NotTo(HaveOccurred(), "failed to create daemonset for time sync check")
+
+	var nodes corev1.NodeList
+	kubeclient.List(ctx, &nodes)
+	Expect(err).NotTo(HaveOccurred(), "failed to list nodes for daemonset timesync check")
+	Expect(len(nodes.Items)).Should(BeNumerically(">", 1), "expected to find >= 1 node for timesync check")
+	desired := int32(len(nodes.Items))
+
+	Eventually(func() error {
+		var ds appsv1.DaemonSet
+		if err := kubeclient.Get(ctx, types.NamespacedName{"default", "nsenter"}, &ds); err != nil {
+			Logf("failed to get nsenter ds: %s", err)
+			return err
+		}
+		ready := ds.Status.NumberReady
+		available := ds.Status.NumberAvailable
+		allReadyAndAvailable := desired == ready && desired == available
+		generationOk := ds.ObjectMeta.Generation == ds.Status.ObservedGeneration
+
+		msg := fmt.Sprintf("want %d instances, found %d ready and %d available. generation: %d, observedGeneration: %d", desired, ready, available, ds.ObjectMeta.Generation, ds.Status.ObservedGeneration)
+		Logf(msg)
+		if allReadyAndAvailable && generationOk {
+			return nil
+		}
+		return fmt.Errorf(msg)
+	}, sixty, five).Should(Succeed())
+
+	var podList corev1.PodList
+	err = kubeclient.List(ctx, &podList, client.MatchingLabels(map[string]string{"app": "nsenter"}))
+	Expect(err).NotTo(HaveOccurred(), "failed to list pods for daemonset timesync check")
+
+	Logf("mapping nsenter pods to hostnames for host-by-host execution")
+	podMap := map[string]corev1.Pod{}
+	for _, pod := range podList.Items {
+		podMap[pod.Spec.NodeName] = pod
+	}
+
+	for k, v := range podMap {
+		Logf("found host %s with pod %s", k, v.Name)
+	}
+
+	Eventually(func() error {
+		execInfo, err := getClusterSSHInfo(ctx, input.BootstrapClusterProxy, namespace, clusterName)
+		if err != nil {
+			return err
+		}
+
+		if len(execInfo) <= 0 {
+			return errors.New("execInfo did not contain any machines")
+		}
+
+		nsenterCmd := []string{"nsenter", "--target", "1", "--mount=/proc/1/ns/mnt", "--", "/bin/sh", "-c"}
+		var testFuncs []func() error
+		for key := range execInfo {
+			s := execInfo[key]
+			Byf("checking that time synchronization is healthy on %s", s.Hostname)
+			execToStringFn := func(expected, command string) func() error {
+				// don't assert in this test func, just return errors
+				return func() error {
+					pod, exists := podMap[s.Hostname]
+					if !exists {
+						return fmt.Errorf("failed to find pod matching host %s", s.Hostname)
+					}
+
+					fullCommand := make([]string, 0, len(nsenterCmd)+1)
+					fullCommand = append(fullCommand, nsenterCmd...)
+					fullCommand = append(fullCommand, command)
+					stdout, err := e2e_pod.ExecWithOutput(clientset, config, pod, fullCommand)
+					if err != nil {
+						return fmt.Errorf("failed to nsenter host %s, error: '%s', stdout:  '%s'", s.Hostname, err, stdout.String())
+					}
+
+					if !strings.Contains(stdout.String(), expected) {
+						return fmt.Errorf("expected \"%s\" in command output:\n%s", expected, stdout.String())
+					}
+
+					Byf("time sync OK for host %s", s.Hostname)
+
+					return nil
+				}
+			}
+
+			testFuncs = append(testFuncs,
+				execToStringFn(
+					"chronyd is active",
+					"systemctl is-active chronyd && echo chronyd is active",
+				),
+				execToStringFn(
+					"Reference ID",
+					"chronyc tracking",
+				),
+			)
+		}
+
+		return kinderrors.AggregateConcurrent(testFuncs)
+	}, sixty, five).Should(Succeed())
 }

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -19,6 +19,7 @@ limitations under the License.
 package pod
 
 import (
+	"bytes"
 	"os"
 
 	v1 "k8s.io/api/core/v1"
@@ -55,4 +56,32 @@ func Exec(clientset *kubernetes.Clientset, config *restclient.Config, pod v1.Pod
 	}
 
 	return nil
+}
+
+func ExecWithOutput(clientset *kubernetes.Clientset, config *restclient.Config, pod v1.Pod, command []string) (*bytes.Buffer, error) {
+	req := clientset.CoreV1().RESTClient().Post().Resource("pods").Name(pod.GetName()).
+		Namespace(pod.GetNamespace()).SubResource("exec")
+	option := &v1.PodExecOptions{
+		Command: command,
+		Stdin:   false,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     true,
+	}
+	req.VersionedParams(
+		option,
+		scheme.ParameterCodec,
+	)
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return nil, err
+	}
+	stdout := bytes.NewBuffer(nil)
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: stdout,
+		// needs to be populated or else exec hangs, but we don't need the output. Failures write to stdout when TTY enabled.
+		Stderr: bytes.NewBuffer(nil),
+	})
+
+	return stdout, err
 }

--- a/test/e2e/workloads/nsenter/daemonset.yaml
+++ b/test/e2e/workloads/nsenter/daemonset.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: &name nsenter
+  labels:
+    app: *name
+spec:
+  selector:
+    matchLabels:
+      app: *name
+  template:
+    metadata:
+      labels:
+        app: *name
+    spec:
+      hostPID: true
+      containers:
+      - image: us.gcr.io/k8s-artifacts-prod/busybox:1.27.2
+        name: nsenter
+        command: ["sleep", "100d"] # busybox sleep doesn't support infinity, so use a really long time.
+        resources:
+          requests: {}
+          limits: {}
+        securityContext:
+          privileged: true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Add an implementation of the timesync test which avoids using SSH. useful for private clusters and AKS clusters in which nodes do not have public IPs. 

As part of debugging #1488, I found VMSS List calls across regions have an unexpected lag in returning correct results right now. This also affects AKS e2e resource validation. I worked around the VMSS List issue in the AMMP reconciler. The test validation itself was List VMSS calls which hit the same issue. So instead of simply removing the existing e2e validation, I implemented the existing time sync validation using a daemonset + nsenter rather than SSH (which won't work when nodes all have private IPs). This should also work nicely for private clusters.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
