### PR TITLE
have consistent validation/defaulting for machine and machinetemplate

### DIFF
--- a/api/v1alpha4/azuremachine_default.go
+++ b/api/v1alpha4/azuremachine_default.go
@@ -19,6 +19,7 @@ package v1alpha4
 import (
 	"encoding/base64"
 
+	"github.com/go-logr/logr"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
@@ -26,60 +27,70 @@ import (
 )
 
 // SetDefaultSSHPublicKey sets the default SSHPublicKey for an AzureMachine.
-func (m *AzureMachine) SetDefaultSSHPublicKey() error {
-	sshKeyData := m.Spec.SSHPublicKey
+func (s *AzureMachineSpec) SetDefaultSSHPublicKey() error {
+	sshKeyData := s.SSHPublicKey
 	if sshKeyData == "" {
 		_, publicRsaKey, err := utilSSH.GenerateSSHKey()
 		if err != nil {
 			return err
 		}
 
-		m.Spec.SSHPublicKey = base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey))
+		s.SSHPublicKey = base64.StdEncoding.EncodeToString(ssh.MarshalAuthorizedKey(publicRsaKey))
 	}
 
 	return nil
 }
 
 // SetDefaultCachingType sets the default cache type for an AzureMachine.
-func (m *AzureMachine) SetDefaultCachingType() error {
-	if m.Spec.OSDisk.CachingType == "" {
-		m.Spec.OSDisk.CachingType = "None"
+func (s *AzureMachineSpec) SetDefaultCachingType() {
+	if s.OSDisk.CachingType == "" {
+		s.OSDisk.CachingType = "None"
 	}
-	return nil
 }
 
 // SetDataDisksDefaults sets the data disk defaults for an AzureMachine.
-func (m *AzureMachine) SetDataDisksDefaults() {
+func (s *AzureMachineSpec) SetDataDisksDefaults() {
 	set := make(map[int32]struct{})
 	// populate all the existing values in the set
-	for _, disk := range m.Spec.DataDisks {
+	for _, disk := range s.DataDisks {
 		if disk.Lun != nil {
 			set[*disk.Lun] = struct{}{}
 		}
 	}
 	// Look for unique values for unassigned LUNs
-	for i, disk := range m.Spec.DataDisks {
+	for i, disk := range s.DataDisks {
 		if disk.Lun == nil {
-			for l := range m.Spec.DataDisks {
+			for l := range s.DataDisks {
 				lun := int32(l)
 				if _, ok := set[lun]; !ok {
-					m.Spec.DataDisks[i].Lun = &lun
+					s.DataDisks[i].Lun = &lun
 					set[lun] = struct{}{}
 					break
 				}
 			}
 		}
 		if disk.CachingType == "" {
-			m.Spec.DataDisks[i].CachingType = "ReadWrite"
+			s.DataDisks[i].CachingType = "ReadWrite"
 		}
 	}
 }
 
 // SetIdentityDefaults sets the defaults for VM Identity.
-func (m *AzureMachine) SetIdentityDefaults() {
-	if m.Spec.Identity == VMIdentitySystemAssigned {
-		if m.Spec.RoleAssignmentName == "" {
-			m.Spec.RoleAssignmentName = string(uuid.NewUUID())
+func (s *AzureMachineSpec) SetIdentityDefaults() {
+	if s.Identity == VMIdentitySystemAssigned {
+		if s.RoleAssignmentName == "" {
+			s.RoleAssignmentName = string(uuid.NewUUID())
 		}
 	}
+}
+
+// SetDefaults sets to the defaults for the AzureMachineSpec.
+func (s *AzureMachineSpec) SetDefaults(log logr.Logger) {
+	err := s.SetDefaultSSHPublicKey()
+	if err != nil {
+		log.Error(err, "SetDefaultSshPublicKey failed")
+	}
+	s.SetDefaultCachingType()
+	s.SetDataDisksDefaults()
+	s.SetIdentityDefaults()
 }

--- a/api/v1alpha4/azuremachine_default_test.go
+++ b/api/v1alpha4/azuremachine_default_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestAzureMachine_SetDefaultSSHPublicKey(t *testing.T) {
+func TestAzureMachineSpec_SetDefaultSSHPublicKey(t *testing.T) {
 	g := NewWithT(t)
 
 	type test struct {
@@ -38,16 +38,16 @@ func TestAzureMachine_SetDefaultSSHPublicKey(t *testing.T) {
 	publicKeyExistTest := test{machine: createMachineWithSSHPublicKey(t, existingPublicKey)}
 	publicKeyNotExistTest := test{machine: createMachineWithSSHPublicKey(t, "")}
 
-	err := publicKeyExistTest.machine.SetDefaultSSHPublicKey()
+	err := publicKeyExistTest.machine.Spec.SetDefaultSSHPublicKey()
 	g.Expect(err).To(BeNil())
 	g.Expect(publicKeyExistTest.machine.Spec.SSHPublicKey).To(Equal(existingPublicKey))
 
-	err = publicKeyNotExistTest.machine.SetDefaultSSHPublicKey()
+	err = publicKeyNotExistTest.machine.Spec.SetDefaultSSHPublicKey()
 	g.Expect(err).To(BeNil())
 	g.Expect(publicKeyNotExistTest.machine.Spec.SSHPublicKey).To(Not(BeEmpty()))
 }
 
-func TestAzureMachine_SetIdentityDefaults(t *testing.T) {
+func TestAzureMachineSpec_SetIdentityDefaults(t *testing.T) {
 	g := NewWithT(t)
 
 	type test struct {
@@ -67,19 +67,19 @@ func TestAzureMachine_SetIdentityDefaults(t *testing.T) {
 		Identity: VMIdentityUserAssigned,
 	}}}
 
-	roleAssignmentExistTest.machine.SetIdentityDefaults()
+	roleAssignmentExistTest.machine.Spec.SetIdentityDefaults()
 	g.Expect(roleAssignmentExistTest.machine.Spec.RoleAssignmentName).To(Equal(existingRoleAssignmentName))
 
-	roleAssignmentEmptyTest.machine.SetIdentityDefaults()
+	roleAssignmentEmptyTest.machine.Spec.SetIdentityDefaults()
 	g.Expect(roleAssignmentEmptyTest.machine.Spec.RoleAssignmentName).To(Not(BeEmpty()))
 	_, err := uuid.Parse(roleAssignmentEmptyTest.machine.Spec.RoleAssignmentName)
 	g.Expect(err).To(Not(HaveOccurred()))
 
-	notSystemAssignedTest.machine.SetIdentityDefaults()
+	notSystemAssignedTest.machine.Spec.SetIdentityDefaults()
 	g.Expect(notSystemAssignedTest.machine.Spec.RoleAssignmentName).To(BeEmpty())
 }
 
-func TestAzureMachine_SetDataDisksDefaults(t *testing.T) {
+func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 	cases := []struct {
 		name   string
 		disks  []DataDisk
@@ -240,7 +240,7 @@ func TestAzureMachine_SetDataDisksDefaults(t *testing.T) {
 			t.Parallel()
 			machine := hardcodedAzureMachineWithSSHKey(generateSSHPublicKey(true))
 			machine.Spec.DataDisks = tc.disks
-			machine.SetDataDisksDefaults()
+			machine.Spec.SetDataDisksDefaults()
 			if !reflect.DeepEqual(machine.Spec.DataDisks, tc.output) {
 				expected, _ := json.MarshalIndent(tc.output, "", "\t")
 				actual, _ := json.MarshalIndent(machine.Spec.DataDisks, "", "\t")

--- a/api/v1alpha4/azuremachine_validation.go
+++ b/api/v1alpha4/azuremachine_validation.go
@@ -27,6 +27,37 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+// ValidateAzureMachineSpec check for validation errors of azuremachine.spec.
+func ValidateAzureMachineSpec(spec AzureMachineSpec) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if errs := ValidateImage(spec.Image, field.NewPath("image")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	if errs := ValidateOSDisk(spec.OSDisk, field.NewPath("osDisk")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	if errs := ValidateSSHKey(spec.SSHPublicKey, field.NewPath("sshPublicKey")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	if errs := ValidateSystemAssignedIdentity(spec.Identity, "", spec.RoleAssignmentName, field.NewPath("roleAssignmentName")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	if errs := ValidateUserAssignedIdentity(spec.Identity, spec.UserAssignedIdentities, field.NewPath("userAssignedIdentities")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	if errs := ValidateDataDisks(spec.DataDisks, field.NewPath("dataDisks")); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	return allErrs
+}
+
 // ValidateSSHKey validates an SSHKey.
 func ValidateSSHKey(sshKey string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -54,6 +54,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-azuremachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.azuremachinetemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - azuremachinetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-azuremachinepool
   failurePolicy: Fail
   name: default.azuremachinepool.infrastructure.cluster.x-k8s.io
@@ -154,6 +175,7 @@ webhooks:
     apiVersions:
     - v1alpha4
     operations:
+    - CREATE
     - UPDATE
     resources:
     - azuremachinetemplates


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind other
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
Make the validation and defaulting of `AzureMachine` and `AzureMachineTemplate` consistent with each other. This is to make sure that the controller does not end up in a continuous reconcile loop.

Ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1501#issuecomment-878388206


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Consistent validation for AzureMachineTemplate and AzureMachine
```
