### PR TITLE
Added support for system node pools in managedClusters

### DIFF
--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-02-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -217,7 +217,7 @@ func TestReconcile(t *testing.T) {
 					ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 						Count:               to.Int32Ptr(3),
 						OsDiskSizeGB:        to.Int32Ptr(20),
-						VMSize:              containerservice.VMSizeTypesStandardA1,
+						VMSize:              to.StringPtr(string(containerservice.VMSizeTypesStandardA1)),
 						OrchestratorVersion: to.StringPtr("9.99.9999"),
 						ProvisioningState:   to.StringPtr("Failed"),
 					},
@@ -242,8 +242,8 @@ func TestReconcile(t *testing.T) {
 					ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 						Count:               to.Int32Ptr(2),
 						OsDiskSizeGB:        to.Int32Ptr(100),
-						VMSize:              containerservice.VMSizeTypesStandardD2sV3,
-						OsType:              containerservice.Linux,
+						VMSize:              to.StringPtr(string(containerservice.VMSizeTypesStandardD2sV3)),
+						OsType:              containerservice.OSTypeLinux,
 						OrchestratorVersion: to.StringPtr("9.99.9999"),
 						ProvisioningState:   to.StringPtr("Succeeded"),
 						VnetSubnetID:        to.StringPtr(""),

--- a/azure/services/agentpools/client.go
+++ b/azure/services/agentpools/client.go
@@ -19,7 +19,7 @@ package agentpools
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-02-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/pkg/errors"
 

--- a/azure/services/agentpools/mock_agentpools/agentpools_mock.go
+++ b/azure/services/agentpools/mock_agentpools/agentpools_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	containerservice "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-02-01/containerservice"
+	containerservice "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/azure/services/managedclusters/client.go
+++ b/azure/services/managedclusters/client.go
@@ -19,7 +19,7 @@ package managedclusters
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-02-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/pkg/errors"
 
@@ -66,7 +66,7 @@ func (ac *AzureClient) GetCredentials(ctx context.Context, resourceGroupName, na
 	ctx, span := tele.Tracer().Start(ctx, "managedclusters.AzureClient.GetCredentials")
 	defer span.End()
 
-	credentialList, err := ac.managedclusters.ListClusterAdminCredentials(ctx, resourceGroupName, name)
+	credentialList, err := ac.managedclusters.ListClusterAdminCredentials(ctx, resourceGroupName, name, "")
 	if err != nil {
 		return nil, err
 	}

--- a/azure/services/managedclusters/managedclusters_test.go
+++ b/azure/services/managedclusters/managedclusters_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-02-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	containerservice "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-02-01/containerservice"
+	containerservice "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -64,15 +64,6 @@ spec:
                 - host
                 - port
                 type: object
-              defaultPoolRef:
-                description: DefaultPoolRef is the specification for the default pool,
-                  without which an AKS cluster cannot be created.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
               dnsServiceIP:
                 description: DNSServiceIP is an IP address assigned to the Kubernetes
                   DNS service. It must be within the Kubernetes service address range
@@ -147,7 +138,6 @@ spec:
                 - name
                 type: object
             required:
-            - defaultPoolRef
             - location
             - nodeResourceGroupName
             - resourceGroupName
@@ -216,15 +206,6 @@ spec:
                 required:
                 - host
                 - port
-                type: object
-              defaultPoolRef:
-                description: DefaultPoolRef is the specification for the default pool,
-                  without which an AKS cluster cannot be created.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
                 type: object
               dnsServiceIP:
                 description: DNSServiceIP is an IP address assigned to the Kubernetes
@@ -337,7 +318,6 @@ spec:
                 - name
                 type: object
             required:
-            - defaultPoolRef
             - location
             - resourceGroupName
             - sshPublicKey

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
@@ -42,6 +42,13 @@ spec:
             description: AzureManagedMachinePoolSpec defines the desired state of
               AzureManagedMachinePool.
             properties:
+              mode:
+                description: 'Mode - represents mode of an agent pool. Possible values
+                  include: System, User.'
+                enum:
+                - System
+                - User
+                type: string
               osDiskSizeGB:
                 description: OSDiskSizeGB is the disk size for every machine in this
                   agent pool. If you specify 0, it will apply the default osDisk size
@@ -58,6 +65,7 @@ spec:
                 description: SKU is the size of the VMs in the node pool.
                 type: string
             required:
+            - mode
             - sku
             type: object
           status:
@@ -109,6 +117,13 @@ spec:
             description: AzureManagedMachinePoolSpec defines the desired state of
               AzureManagedMachinePool.
             properties:
+              mode:
+                description: 'Mode - represents mode of an agent pool. Possible values
+                  include: System, User.'
+                enum:
+                - System
+                - User
+                type: string
               osDiskSizeGB:
                 description: OSDiskSizeGB is the disk size for every machine in this
                   agent pool. If you specify 0, it will apply the default osDisk size
@@ -125,6 +140,7 @@ spec:
                 description: SKU is the size of the VMs in the node pool.
                 type: string
             required:
+            - mode
             - sku
             type: object
           status:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -109,6 +109,28 @@ webhooks:
     resources:
     - azuremanagedcontrolplanes
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1alpha4-azuremanagedmachinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.azuremanagedmachinepools.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - azuremanagedmachinepools
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -239,4 +261,26 @@ webhooks:
     - UPDATE
     resources:
     - azuremanagedcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-azuremanagedmachinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.azuremanagedmachinepools.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - azuremanagedmachinepools
   sideEffects: None

--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -12,9 +12,9 @@ custom resources:
 The combination of AzureManagedControlPlane/AzureManagedCluster
 corresponds to provisioning an AKS cluster. AzureManagedMachinePool
 corresponds one-to-one with AKS node pools. This also means that
-creating an AzureManagedControlPlane requires defining the default
-machine pool, since AKS requires at least one system pool at creation
-time.
+creating an AzureManagedControlPlane requires at least one AzureManagedMachinePool
+with `spec.mode` `System`, since AKS expects at least one system pool at creation 
+time. For more documentation on system node pool refer [AKS Docs](https://docs.microsoft.com/en-us/azure/aks/use-system-pools) 
 
 ## Deploy with clusterctl
 
@@ -95,13 +95,11 @@ kind: AzureManagedControlPlane
 metadata:
   name: my-cluster-control-plane
 spec:
-  defaultPoolRef:
-    name: agentpool0
   location: southcentralus
   resourceGroup: foo-bar
   sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   subscriptionID: fae7cc14-bfba-4471-9435-f945b42a16dd # fake uuid
-  version: v1.19.6
+  version: v1.20.5
   networkPolicy: azure # or calico
   networkPlugin: azure # or kubenet
 ---
@@ -127,15 +125,42 @@ spec:
         kind: AzureManagedMachinePool
         name: agentpool0
         namespace: default
-      version: v1.19.6
+      version: v1.20.5
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: AzureManagedMachinePool
 metadata:
   name: agentpool0
 spec:
+  mode: System
   osDiskSizeGB: 512
-  sku: Standard_D8s_v3
+  sku: Standard_D2s_v3
+---
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachinePool
+metadata:
+  name: agentpool1
+spec:
+  clusterName: my-cluster
+  replicas: 2
+  template:
+    spec:
+      clusterName: my-cluster
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: AzureManagedMachinePool
+        name: agentpool1
+        namespace: default
+      version: v1.20.5
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: AzureManagedMachinePool
+metadata:
+  name: agentpool1
+spec:
+  mode: User
+  osDiskSizeGB: 1024
+  sku: Standard_D2s_v4
 ```
 
 The main features for configuration today are
@@ -214,3 +239,83 @@ Current limitations
 - Only supports Standard load balancer (SLB).
   - We will not support Basic load balancer in CAPZ. SLB is generally
     the path forward in Azure.
+
+## Troubleshooting
+
+If a user tries to delete the MachinePool which refers to the last system node pool AzureManagedMachinePool webhook will reject deletion, so time stamp never gets set on the AzureManagedMachinePool. However the timestamp would be set on the MachinePool and would be in deletion state. To recover from this state create a new MachinePool manually referencing the AzureManagedMachinePool, edit the required references and finalizers to link the MachinePool to the AzureManagedMachinePool. In the AzureManagedMachinePool remove the owner reference to the old MachinePool, and set it to the new MachinePool. Once the new MachinePool is pointing to the AzureManagedMachinePool you can delete the old MachinePool. To delete the old MachinePool remove the finalizers in that object.
+
+Here is an Example:
+
+```yaml
+# MachinePool deleted 
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachinePool
+metadata:
+  finalizers:             # remove finalizers once new object is pointing to the AzureManagedMachinePool
+  - machinepool.cluster.x-k8s.io
+  labels:
+    cluster.x-k8s.io/cluster-name: capz-managed-aks
+  name: agentpool0
+  namespace: default
+  ownerReferences:
+  - apiVersion: cluster.x-k8s.io/v1alpha4
+    kind: Cluster
+    name: capz-managed-aks
+    uid: 152ecf45-0a02-4635-987c-1ebb89055fa2
+  uid: ae4a235a-f0fa-4252-928a-0e3b4c61dbea
+spec:
+  clusterName: capz-managed-aks
+  minReadySeconds: 0
+  providerIDList:
+  - azure:///subscriptions/9107f2fb-e486-a434-a948-52e2929b6f18/resourceGroups/MC_rg_capz-managed-aks_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool0-10226072-vmss/virtualMachines/0
+  replicas: 1
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        dataSecretName: ""
+      clusterName: capz-managed-aks
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: AzureManagedMachinePool
+        name: agentpool0
+        namespace: default
+      version: v1.20.5
+
+---
+# New Machinepool
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachinePool
+metadata:
+  finalizers:
+  - machinepool.cluster.x-k8s.io
+  generation: 2
+  labels:
+    cluster.x-k8s.io/cluster-name: capz-managed-aks
+  name: agentpool2    # change the name of the machinepool
+  namespace: default 
+  ownerReferences:
+  - apiVersion: cluster.x-k8s.io/v1alpha4
+    kind: Cluster
+    name: capz-managed-aks
+    uid: 152ecf45-0a02-4635-987c-1ebb89055fa2   
+  # uid: ae4a235a-f0fa-4252-928a-0e3b4c61dbea     # remove the uid set for machinepool
+spec:
+  clusterName: capz-managed-aks
+  minReadySeconds: 0
+  providerIDList:
+  - azure:///subscriptions/9107f2fb-e486-a434-a948-52e2929b6f18/resourceGroups/MC_rg_capz-managed-aks_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool0-10226072-vmss/virtualMachines/0  
+  replicas: 1
+  template:
+    metadata: {}
+    spec:
+      bootstrap:
+        dataSecretName: ""
+      clusterName: capz-managed-aks
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: AzureManagedMachinePool
+        name: agentpool0
+        namespace: default
+      version: v1.20.5
+```

--- a/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
@@ -68,9 +67,6 @@ type AzureManagedControlPlaneSpec struct {
 
 	// SSHPublicKey is a string literal containing an ssh public key base64 encoded.
 	SSHPublicKey string `json:"sshPublicKey"`
-
-	// DefaultPoolRef is the specification for the default pool, without which an AKS cluster cannot be created.
-	DefaultPoolRef corev1.LocalObjectReference `json:"defaultPoolRef"`
 
 	// DNSServiceIP is an IP address assigned to the Kubernetes DNS service.
 	// It must be within the Kubernetes service address range specified in serviceCidr.

--- a/exp/api/v1alpha3/azuremanagedmachinepool_types.go
+++ b/exp/api/v1alpha3/azuremanagedmachinepool_types.go
@@ -23,6 +23,10 @@ import (
 
 // AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.
 type AzureManagedMachinePoolSpec struct {
+	// Mode - represents mode of an agent pool. Possible values include: System, User.
+	// +kubebuilder:validation:Enum=System;User
+	Mode string `json:"mode"`
+
 	// SKU is the size of the VMs in the node pool.
 	SKU string `json:"sku"`
 

--- a/exp/api/v1alpha3/zz_generated.conversion.go
+++ b/exp/api/v1alpha3/zz_generated.conversion.go
@@ -708,7 +708,6 @@ func autoConvert_v1alpha3_AzureManagedControlPlaneSpec_To_v1alpha4_AzureManagedC
 	out.NetworkPlugin = (*string)(unsafe.Pointer(in.NetworkPlugin))
 	out.NetworkPolicy = (*string)(unsafe.Pointer(in.NetworkPolicy))
 	out.SSHPublicKey = in.SSHPublicKey
-	out.DefaultPoolRef = in.DefaultPoolRef
 	out.DNSServiceIP = (*string)(unsafe.Pointer(in.DNSServiceIP))
 	out.LoadBalancerSKU = (*string)(unsafe.Pointer(in.LoadBalancerSKU))
 	return nil
@@ -735,7 +734,6 @@ func autoConvert_v1alpha4_AzureManagedControlPlaneSpec_To_v1alpha3_AzureManagedC
 	out.NetworkPlugin = (*string)(unsafe.Pointer(in.NetworkPlugin))
 	out.NetworkPolicy = (*string)(unsafe.Pointer(in.NetworkPolicy))
 	out.SSHPublicKey = in.SSHPublicKey
-	out.DefaultPoolRef = in.DefaultPoolRef
 	out.DNSServiceIP = (*string)(unsafe.Pointer(in.DNSServiceIP))
 	out.LoadBalancerSKU = (*string)(unsafe.Pointer(in.LoadBalancerSKU))
 	// WARNING: in.IdentityRef requires manual conversion: does not exist in peer-type
@@ -819,6 +817,7 @@ func Convert_v1alpha4_AzureManagedMachinePoolList_To_v1alpha3_AzureManagedMachin
 }
 
 func autoConvert_v1alpha3_AzureManagedMachinePoolSpec_To_v1alpha4_AzureManagedMachinePoolSpec(in *AzureManagedMachinePoolSpec, out *v1alpha4.AzureManagedMachinePoolSpec, s conversion.Scope) error {
+	out.Mode = in.Mode
 	out.SKU = in.SKU
 	out.OSDiskSizeGB = (*int32)(unsafe.Pointer(in.OSDiskSizeGB))
 	out.ProviderIDList = *(*[]string)(unsafe.Pointer(&in.ProviderIDList))
@@ -831,6 +830,7 @@ func Convert_v1alpha3_AzureManagedMachinePoolSpec_To_v1alpha4_AzureManagedMachin
 }
 
 func autoConvert_v1alpha4_AzureManagedMachinePoolSpec_To_v1alpha3_AzureManagedMachinePoolSpec(in *v1alpha4.AzureManagedMachinePoolSpec, out *AzureManagedMachinePoolSpec, s conversion.Scope) error {
+	out.Mode = in.Mode
 	out.SKU = in.SKU
 	out.OSDiskSizeGB = (*int32)(unsafe.Pointer(in.OSDiskSizeGB))
 	out.ProviderIDList = *(*[]string)(unsafe.Pointer(&in.ProviderIDList))

--- a/exp/api/v1alpha3/zz_generated.deepcopy.go
+++ b/exp/api/v1alpha3/zz_generated.deepcopy.go
@@ -411,7 +411,6 @@ func (in *AzureManagedControlPlaneSpec) DeepCopyInto(out *AzureManagedControlPla
 		*out = new(string)
 		**out = **in
 	}
-	out.DefaultPoolRef = in.DefaultPoolRef
 	if in.DNSServiceIP != nil {
 		in, out := &in.DNSServiceIP, &out.DNSServiceIP
 		*out = new(string)

--- a/exp/api/v1alpha4/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1alpha4/azuremanagedcontrolplane_types.go
@@ -70,9 +70,6 @@ type AzureManagedControlPlaneSpec struct {
 	// SSHPublicKey is a string literal containing an ssh public key base64 encoded.
 	SSHPublicKey string `json:"sshPublicKey"`
 
-	// DefaultPoolRef is the specification for the default pool, without which an AKS cluster cannot be created.
-	DefaultPoolRef corev1.LocalObjectReference `json:"defaultPoolRef"`
-
 	// DNSServiceIP is an IP address assigned to the Kubernetes DNS service.
 	// It must be within the Kubernetes service address range specified in serviceCidr.
 	// +optional

--- a/exp/api/v1alpha4/azuremanagedcontrolplane_webhook.go
+++ b/exp/api/v1alpha4/azuremanagedcontrolplane_webhook.go
@@ -217,16 +217,6 @@ func (r *AzureManagedControlPlane) ValidateUpdate(oldRaw runtime.Object) error {
 		}
 	}
 
-	if old.Spec.DefaultPoolRef.Name != "" {
-		if r.Spec.DefaultPoolRef.Name != old.Spec.DefaultPoolRef.Name {
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "DefaultPoolRef", "Name"),
-					r.Spec.DefaultPoolRef.Name,
-					"field is immutable"))
-		}
-	}
-
 	if len(allErrs) == 0 {
 		return r.Validate()
 	}

--- a/exp/api/v1alpha4/azuremanagedcontrolplane_webhook_test.go
+++ b/exp/api/v1alpha4/azuremanagedcontrolplane_webhook_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -468,28 +467,6 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: to.StringPtr("192.168.0.0"),
-					Version:      "v1.18.0",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "AzureManagedControlPlane DefaultPoolRef.Name is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					DefaultPoolRef: v1.LocalObjectReference{
-						Name: "pool-1",
-					},
-					DNSServiceIP: to.StringPtr("192.168.0.0"),
-					Version:      "v1.18.0",
-				},
-			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					DefaultPoolRef: v1.LocalObjectReference{
-						Name: "pool-2",
-					},
 					DNSServiceIP: to.StringPtr("192.168.0.0"),
 					Version:      "v1.18.0",
 				},

--- a/exp/api/v1alpha4/azuremanagedmachinepool_types.go
+++ b/exp/api/v1alpha4/azuremanagedmachinepool_types.go
@@ -21,8 +21,27 @@ import (
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
+const (
+	// LabelAgentPoolMode represents mode of an agent pool. Possible values include: System, User.
+	LabelAgentPoolMode = "azuremanagedmachinepool.infrastructure.cluster.x-k8s.io/agentpoolmode"
+
+	// NodePoolModeSystem represents mode system for azuremachinepool.
+	NodePoolModeSystem NodePoolMode = "System"
+
+	// NodePoolModeUser represents mode user for azuremachinepool.
+	NodePoolModeUser NodePoolMode = "User"
+)
+
+// NodePoolMode enumerates the values for agent pool mode.
+type NodePoolMode string
+
 // AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.
 type AzureManagedMachinePoolSpec struct {
+
+	// Mode - represents mode of an agent pool. Possible values include: System, User.
+	// +kubebuilder:validation:Enum=System;User
+	Mode string `json:"mode"`
+
 	// SKU is the size of the VMs in the node pool.
 	SKU string `json:"sku"`
 

--- a/exp/api/v1alpha4/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1alpha4/azuremanagedmachinepool_webhook.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// log is for logging in this package.
+var azuremanagedmachinepoollog = logf.Log.WithName("azuremanagedmachinepool-resource")
+
+//+kubebuilder:webhook:path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha4-azuremanagedmachinepool,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=azuremanagedmachinepools,verbs=create;update,versions=v1alpha4,name=default.azuremanagedmachinepools.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
+func (r *AzureManagedMachinePool) Default(client client.Client) {
+	azuremanagedmachinepoollog.Info("default", "name", r.Name)
+
+	if r.Labels == nil {
+		r.Labels = make(map[string]string)
+	}
+	r.Labels[LabelAgentPoolMode] = r.Spec.Mode
+}
+
+//+kubebuilder:webhook:verbs=update;delete,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-azuremanagedmachinepool,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=azuremanagedmachinepools,versions=v1alpha4,name=validation.azuremanagedmachinepools.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedMachinePool) ValidateCreate(client client.Client) error {
+	azuremanagedmachinepoollog.Info("validate create", "name", r.Name)
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client client.Client) error {
+	old := oldRaw.(*AzureManagedMachinePool)
+	var allErrs field.ErrorList
+
+	if r.Spec.SKU != old.Spec.SKU {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("Spec", "SKU"),
+				r.Spec.SKU,
+				"field is immutable"))
+	}
+
+	if old.Spec.OSDiskSizeGB != nil {
+		// Prevent OSDiskSizeGB modification if it was already set to some value
+		if r.Spec.OSDiskSizeGB == nil {
+			// unsetting the field is not allowed
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("Spec", "OSDiskSizeGB"),
+					r.Spec.OSDiskSizeGB,
+					"field is immutable, unsetting is not allowed"))
+		} else if *r.Spec.OSDiskSizeGB != *old.Spec.OSDiskSizeGB {
+			// changing the field is not allowed
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("Spec", "OSDiskSizeGB"),
+					*r.Spec.OSDiskSizeGB,
+					"field is immutable"))
+		}
+	}
+
+	if r.Spec.Mode != string(NodePoolModeSystem) && old.Spec.Mode == string(NodePoolModeSystem) {
+		// validate for last system node pool
+		if err := r.validateLastSystemNodePool(client); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("Spec", "Mode"),
+				r.Spec.Mode,
+				"Last system node pool cannot be mutated to user node pool"))
+		}
+	}
+
+	if len(allErrs) != 0 {
+		return apierrors.NewInvalid(GroupVersion.WithKind("AzureManagedMachinePool").GroupKind(), r.Name, allErrs)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedMachinePool) ValidateDelete(client client.Client) error {
+	azuremanagedmachinepoollog.Info("validate delete", "name", r.Name)
+
+	if r.Spec.Mode != string(NodePoolModeSystem) {
+		return nil
+	}
+
+	return errors.Wrapf(r.validateLastSystemNodePool(client), "if the delete is triggered via owner MachinePool please refer to trouble shooting section in https://capz.sigs.k8s.io/topics/managedcluster.html")
+}
+
+// validateLastSystemNodePool is used to check if the existing system node pool is the last system node pool.
+// If it is a last system node pool it cannot be deleted or mutated to user node pool as AKS expects min 1 system node pool.
+func (r *AzureManagedMachinePool) validateLastSystemNodePool(cli client.Client) error {
+	ctx := context.Background()
+
+	// Fetch the Cluster.
+	clusterName, ok := r.Labels[clusterv1.ClusterLabelName]
+	if !ok {
+		return nil
+	}
+
+	ownerCluster := &clusterv1.Cluster{}
+	key := client.ObjectKey{
+		Namespace: r.Namespace,
+		Name:      clusterName,
+	}
+
+	if err := cli.Get(ctx, key, ownerCluster); err != nil {
+		if azure.ResourceNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if !ownerCluster.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	opt1 := client.InNamespace(r.Namespace)
+	opt2 := client.MatchingLabels(map[string]string{
+		clusterv1.ClusterLabelName: clusterName,
+		LabelAgentPoolMode:         string(NodePoolModeSystem),
+	})
+
+	ammpList := &AzureManagedMachinePoolList{}
+	if err := cli.List(ctx, ammpList, opt1, opt2); err != nil {
+		return err
+	}
+
+	if len(ammpList.Items) <= 1 {
+		return errors.New("AKS Cluster must have at least one system pool")
+	}
+	return nil
+}

--- a/exp/api/v1alpha4/azuremanagedmachinepool_webhook_test.go
+++ b/exp/api/v1alpha4/azuremanagedmachinepool_webhook_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Logf("Testing ammp defaulting webhook with mode system")
+	ammp := &AzureManagedMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fooName",
+		},
+		Spec: AzureManagedMachinePoolSpec{
+			Mode:         "System",
+			SKU:          "StandardD2S_V3",
+			OSDiskSizeGB: to.Int32Ptr(512),
+		},
+	}
+	var client client.Client
+	ammp.Default(client)
+	g.Expect(ammp.Labels).ToNot(BeNil())
+	val, ok := ammp.Labels[LabelAgentPoolMode]
+	g.Expect(ok).To(BeTrue())
+	g.Expect(val).To(Equal("System"))
+}
+
+func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Logf("Testing ammp updating webhook with mode system")
+
+	tests := []struct {
+		name    string
+		new     *AzureManagedMachinePool
+		old     *AzureManagedMachinePool
+		wantErr bool
+	}{
+		{
+			name: "Cannot change SKU of the agentpool",
+			new: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Mode:         "System",
+					SKU:          "StandardD2S_V3",
+					OSDiskSizeGB: to.Int32Ptr(512),
+				},
+			},
+			old: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Mode:         "System",
+					SKU:          "StandardD2S_V4",
+					OSDiskSizeGB: to.Int32Ptr(512),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Cannot change OSDiskSizeGB of the agentpool",
+			new: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Mode:         "System",
+					SKU:          "StandardD2S_V3",
+					OSDiskSizeGB: to.Int32Ptr(512),
+				},
+			},
+			old: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Mode:         "System",
+					SKU:          "StandardD2S_V3",
+					OSDiskSizeGB: to.Int32Ptr(1024),
+				},
+			},
+			wantErr: true,
+		},
+	}
+	var client client.Client
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.new.ValidateUpdate(tc.old, client)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}

--- a/exp/api/v1alpha4/zz_generated.deepcopy.go
+++ b/exp/api/v1alpha4/zz_generated.deepcopy.go
@@ -566,7 +566,6 @@ func (in *AzureManagedControlPlaneSpec) DeepCopyInto(out *AzureManagedControlPla
 		*out = new(string)
 		**out = **in
 	}
-	out.DefaultPoolRef = in.DefaultPoolRef
 	if in.DNSServiceIP != nil {
 		in, out := &in.DNSServiceIP, &out.DNSServiceIP
 		*out = new(string)

--- a/exp/controllers/azuremanagedmachinepool_controller.go
+++ b/exp/controllers/azuremanagedmachinepool_controller.go
@@ -185,7 +185,7 @@ func (r *AzureManagedMachinePoolReconciler) Reconcile(ctx context.Context, req c
 	// For non-system node pools, we wait for the control plane to be
 	// initialized, otherwise Azure API will return an error for node pool
 	// CreateOrUpdate request.
-	if infraPool.Name != controlPlane.Spec.DefaultPoolRef.Name && !controlPlane.Status.Initialized {
+	if infraPool.Spec.Mode != string(infrav1exp.NodePoolModeSystem) && !controlPlane.Status.Initialized {
 		log.Info("AzureManagedControlPlane is not initialized")
 		return reconcile.Result{}, nil
 	}

--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -117,6 +117,7 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context, scope *s
 			scope.ControlPlane.Spec.VirtualNetwork.Name,
 			scope.ControlPlane.Spec.VirtualNetwork.Subnet.Name,
 		),
+		Mode: scope.InfraMachinePool.Spec.Mode,
 	}
 
 	if scope.InfraMachinePool.Spec.OSDiskSizeGB != nil {

--- a/exp/controllers/azuremangedcontrolplane_reconciler.go
+++ b/exp/controllers/azuremangedcontrolplane_reconciler.go
@@ -23,7 +23,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-02-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/managedclusters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/subnets"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/virtualnetworks"
+	infracontroller "sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -209,27 +210,63 @@ func (r *azureManagedControlPlaneReconciler) reconcileManagedCluster(ctx context
 	}
 
 	// We are creating this cluster for the first time.
-	// Configure the default pool, rest will be handled by machinepool controller
+	// Configure the system pool, rest will be handled by machinepool controller
 	// We do this here because AKS will only let us mutate agent pools via managed
 	// clusters API at create time, not update.
 	if azure.ResourceNotFound(err) {
-		defaultPoolSpec := managedclusters.PoolSpec{
-			Name:         scope.InfraMachinePool.Name,
-			SKU:          scope.InfraMachinePool.Spec.SKU,
-			Replicas:     1,
-			OSDiskSizeGB: 0,
+		opt1 := client.InNamespace(scope.ControlPlane.Namespace)
+		opt2 := client.MatchingLabels(map[string]string{
+			infrav1exp.LabelAgentPoolMode: string(infrav1exp.NodePoolModeSystem),
+			clusterv1.ClusterLabelName:    scope.Cluster.Name,
+		})
+
+		ammpList := &infrav1exp.AzureManagedMachinePoolList{}
+
+		if err := r.kubeclient.List(ctx, ammpList, opt1, opt2); err != nil {
+			return err
 		}
 
-		// Set optional values
-		if scope.InfraMachinePool.Spec.OSDiskSizeGB != nil {
-			defaultPoolSpec.OSDiskSizeGB = *scope.InfraMachinePool.Spec.OSDiskSizeGB
+		if ammpList == nil || len(ammpList.Items) == 0 {
+			return errors.New("failed to fetch azuremanagedMachine pool with mode:System, require at least 1 system node pool")
 		}
-		if scope.MachinePool.Spec.Replicas != nil {
-			defaultPoolSpec.Replicas = *scope.MachinePool.Spec.Replicas
-		}
+		ammps := []managedclusters.PoolSpec{}
 
+		for _, pool := range ammpList.Items {
+			// Fetch the owning MachinePool.
+			ownerPool, err := infracontroller.GetOwnerMachinePool(ctx, r.kubeclient, pool.ObjectMeta)
+			if err != nil {
+				scope.Logger.Error(err, "failed to fetch owner ref for system pool: %s", pool.Name)
+				continue
+			}
+			if ownerPool == nil {
+				scope.Logger.Info("failed to fetch owner ref for system pool")
+				continue
+			}
+
+			ammp := managedclusters.PoolSpec{
+				Name:         pool.Name,
+				SKU:          pool.Spec.SKU,
+				Replicas:     1,
+				OSDiskSizeGB: 0,
+			}
+
+			// Set optional values
+			if pool.Spec.OSDiskSizeGB != nil {
+				ammp.OSDiskSizeGB = *pool.Spec.OSDiskSizeGB
+			}
+
+			if ownerPool.Spec.Replicas != nil {
+				ammp.Replicas = *ownerPool.Spec.Replicas
+			}
+
+			ammps = append(ammps, ammp)
+		}
+		if len(ammps) == 0 {
+			scope.Logger.Info("owner ref for system machine pools not ready")
+			return nil
+		}
 		// Add to cluster spec
-		managedClusterSpec.AgentPools = []managedclusters.PoolSpec{defaultPoolSpec}
+		managedClusterSpec.AgentPools = ammps
 	}
 
 	// Send to Azure for create/update.

--- a/templates/cluster-template-aks-multi-tenancy.yaml
+++ b/templates/cluster-template-aks-multi-tenancy.yaml
@@ -23,8 +23,6 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
-  defaultPoolRef:
-    name: agentpool0
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
     kind: AzureClusterIdentity
@@ -68,6 +66,7 @@ metadata:
   name: agentpool0
   namespace: default
 spec:
+  mode: System
   osDiskSizeGB: 512
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---
@@ -97,6 +96,7 @@ metadata:
   name: agentpool1
   namespace: default
 spec:
+  mode: User
   osDiskSizeGB: 1024
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---

--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -23,8 +23,6 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
-  defaultPoolRef:
-    name: agentpool0
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
     kind: AzureClusterIdentity
@@ -67,6 +65,7 @@ metadata:
   name: agentpool0
   namespace: default
 spec:
+  mode: System
   osDiskSizeGB: 512
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---
@@ -96,6 +95,7 @@ metadata:
   name: agentpool1
   namespace: default
 spec:
+  mode: User
   osDiskSizeGB: 1024
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---

--- a/templates/flavors/aks-multi-tenancy/cluster-template.yaml
+++ b/templates/flavors/aks-multi-tenancy/cluster-template.yaml
@@ -31,8 +31,6 @@ spec:
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
   resourceGroupName: "${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}"
   location: "${AZURE_LOCATION}"
-  defaultPoolRef:
-    name: "agentpool0"
   sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   version: "${KUBERNETES_VERSION}"
 ---
@@ -73,6 +71,7 @@ kind: AzureManagedMachinePool
 metadata:
   name: "agentpool0"
 spec:
+  mode: System
   osDiskSizeGB: 512
   sku: "${AZURE_NODE_MACHINE_TYPE}"
 ---
@@ -102,5 +101,6 @@ kind: AzureManagedMachinePool
 metadata:
   name: "agentpool1"
 spec:
+  mode: User
   osDiskSizeGB: 1024
   sku: "${AZURE_NODE_MACHINE_TYPE}"

--- a/templates/flavors/aks/cluster-template.yaml
+++ b/templates/flavors/aks/cluster-template.yaml
@@ -31,8 +31,6 @@ spec:
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
   resourceGroupName: "${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}"
   location: "${AZURE_LOCATION}"
-  defaultPoolRef:
-    name: "agentpool0"
   sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   version: "${KUBERNETES_VERSION}"
 ---
@@ -73,6 +71,7 @@ kind: AzureManagedMachinePool
 metadata:
   name: "agentpool0"
 spec:
+  mode: System
   osDiskSizeGB: 512
   sku: "${AZURE_NODE_MACHINE_TYPE}"
 ---
@@ -102,5 +101,6 @@ kind: AzureManagedMachinePool
 metadata:
   name: "agentpool1"
 spec:
+  mode: User
   osDiskSizeGB: 1024
   sku: "${AZURE_NODE_MACHINE_TYPE}"

--- a/templates/test/ci/cluster-template-prow-aks-multi-tenancy.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-multi-tenancy.yaml
@@ -27,8 +27,6 @@ spec:
     buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
-  defaultPoolRef:
-    name: agentpool0
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
     kind: AzureClusterIdentity
@@ -72,6 +70,7 @@ metadata:
   name: agentpool0
   namespace: default
 spec:
+  mode: System
   osDiskSizeGB: 512
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---
@@ -101,6 +100,7 @@ metadata:
   name: agentpool1
   namespace: default
 spec:
+  mode: User
   osDiskSizeGB: 1024
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---

--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	infraexpv1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha4"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha4"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -83,6 +84,7 @@ func DiscoverAndWaitForControlPlaneInitialized(ctx context.Context, input Discov
 
 	Logf("Waiting for the first control plane machine managed by %s/%s to be provisioned", controlPlane.Namespace, controlPlane.Name)
 	WaitForAtLeastOneControlPlaneAndMachineToExist(ctx, WaitForControlPlaneAndMachinesReadyInput{
+		Lister:       input.Lister,
 		Getter:       input.Getter,
 		ControlPlane: controlPlane,
 		ClusterName:  input.Cluster.Name,
@@ -106,6 +108,7 @@ func DiscoverAndWaitForControlPlaneReady(ctx context.Context, input DiscoverAndW
 
 	Logf("Waiting for the first control plane machine managed by %s/%s to be provisioned", controlPlane.Namespace, controlPlane.Name)
 	WaitForAllControlPlaneAndMachinesToExist(ctx, WaitForControlPlaneAndMachinesReadyInput{
+		Lister:       input.Lister,
 		Getter:       input.Getter,
 		ControlPlane: controlPlane,
 		ClusterName:  input.Cluster.Name,
@@ -135,6 +138,7 @@ func GetAzureManagedControlPlaneByCluster(ctx context.Context, input GetAzureMan
 
 // WaitForControlPlaneAndMachinesReadyInput contains the fields required for checking the status of azure managed control plane machines.
 type WaitForControlPlaneAndMachinesReadyInput struct {
+	Lister       framework.Lister
 	Getter       framework.Getter
 	ControlPlane *infraexpv1.AzureManagedControlPlane
 	ClusterName  string
@@ -175,13 +179,40 @@ func (r controlPlaneReplicas) value(mp *clusterv1exp.MachinePool) int {
 // WaitForControlPlaneMachinesToExist waits for a certain number of control plane machines to be provisioned represented.
 func WaitForControlPlaneMachinesToExist(ctx context.Context, input WaitForControlPlaneAndMachinesReadyInput, minReplicas controlPlaneReplicas, intervals ...interface{}) {
 	Eventually(func() (bool, error) {
-		controlPlaneMachinePool := &clusterv1exp.MachinePool{}
-		if err := input.Getter.Get(ctx, types.NamespacedName{Namespace: input.Namespace, Name: input.ControlPlane.Spec.DefaultPoolRef.Name},
-			controlPlaneMachinePool); err != nil {
+
+		opt1 := client.InNamespace(input.Namespace)
+		opt2 := client.MatchingLabels(map[string]string{
+			infrav1exp.LabelAgentPoolMode: string(infrav1exp.NodePoolModeSystem),
+			clusterv1.ClusterLabelName:    input.ClusterName,
+		})
+
+		ammpList := &infrav1exp.AzureManagedMachinePoolList{}
+
+		if err := input.Lister.List(ctx, ammpList, opt1, opt2); err != nil {
 			Logf("Failed to get machinePool: %+v", err)
 			return false, err
 		}
-		return len(controlPlaneMachinePool.Status.NodeRefs) >= minReplicas.value(controlPlaneMachinePool), nil
+
+		for _, pool := range ammpList.Items {
+			// Fetch the owning MachinePool.
+			for _, ref := range pool.OwnerReferences {
+				if ref.Kind != "MachinePool" {
+					continue
+				}
+
+				ownerMachinePool := &clusterv1exp.MachinePool{}
+				if err := input.Getter.Get(ctx, types.NamespacedName{Namespace: input.Namespace, Name: ref.Name},
+					ownerMachinePool); err != nil {
+					Logf("Failed to get machinePool: %+v", err)
+					return false, err
+				}
+				if len(ownerMachinePool.Status.NodeRefs) >= minReplicas.value(ownerMachinePool) {
+					return true, nil
+				}
+			}
+		}
+
+		return false, errors.New("system machine pools not ready")
 
 	}, intervals...).Should(Equal(true))
 }

--- a/util/webhook/mutator.go
+++ b/util/webhook/mutator.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Defaulter defines functions for setting defaults on resources.
+type Defaulter interface {
+	runtime.Object
+	Default(client client.Client)
+}
+
+// NewMutatingWebhook creates a new Webhook for Defaulting the provided type.
+func NewMutatingWebhook(defaulter Defaulter, client client.Client) *admission.Webhook {
+	return &admission.Webhook{
+		Handler: &mutatingHandler{
+			defaulter: defaulter,
+			Client:    client,
+		},
+	}
+}
+
+type mutatingHandler struct {
+	defaulter Defaulter
+	Client    client.Client
+	decoder   *admission.Decoder
+}
+
+var _ admission.DecoderInjector = &mutatingHandler{}
+
+// InjectDecoder injects the decoder into a mutatingHandler.
+func (h *mutatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *mutatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if h.defaulter == nil {
+		panic("defaulter should never be nil")
+	}
+
+	// Get the object in the request
+	obj := h.defaulter.DeepCopyObject().(Defaulter)
+	if err := h.decoder.Decode(req, obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Default the object
+	obj.Default(h.Client)
+	marshalled, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// Create the patch
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshalled)
+}

--- a/util/webhook/validator.go
+++ b/util/webhook/validator.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"net/http"
+
+	"errors"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Validator defines functions for validating an operation.
+type Validator interface {
+	runtime.Object
+	ValidateCreate(client client.Client) error
+	ValidateUpdate(old runtime.Object, client client.Client) error
+	ValidateDelete(client client.Client) error
+}
+
+// NewValidatingWebhook creates a new Webhook for validating the provided type.
+func NewValidatingWebhook(validator Validator, client client.Client) *admission.Webhook {
+	return &admission.Webhook{
+		Handler: &validatingHandler{
+			validator: validator,
+			Client:    client,
+		},
+	}
+}
+
+type validatingHandler struct {
+	validator Validator
+	Client    client.Client
+	decoder   *admission.Decoder
+}
+
+var _ admission.DecoderInjector = &validatingHandler{}
+
+// InjectDecoder injects the decoder into a validatingHandler.
+func (h *validatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *validatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if h.validator == nil {
+		panic("validator should never be nil")
+	}
+
+	// Get the object in the request
+	obj := h.validator.DeepCopyObject().(Validator)
+	if req.Operation == v1.Create {
+		err := h.decoder.Decode(req, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		err = obj.ValidateCreate(h.Client)
+		if err != nil {
+			var apiStatus apierrors.APIStatus
+			if errors.As(err, &apiStatus) {
+				return validationResponseFromStatus(false, apiStatus.Status())
+			}
+			return admission.Denied(err.Error())
+		}
+	}
+
+	if req.Operation == v1.Update {
+		oldObj := obj.DeepCopyObject()
+
+		err := h.decoder.DecodeRaw(req.Object, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		err = h.decoder.DecodeRaw(req.OldObject, oldObj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		err = obj.ValidateUpdate(oldObj, h.Client)
+		if err != nil {
+			var apiStatus apierrors.APIStatus
+			if errors.As(err, &apiStatus) {
+				return validationResponseFromStatus(false, apiStatus.Status())
+			}
+			return admission.Denied(err.Error())
+		}
+	}
+
+	if req.Operation == v1.Delete {
+		// In reference to PR: https://github.com/kubernetes/kubernetes/pull/76346
+		// OldObject contains the object being deleted
+		err := h.decoder.DecodeRaw(req.OldObject, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		err = obj.ValidateDelete(h.Client)
+		if err != nil {
+			var apiStatus apierrors.APIStatus
+			if errors.As(err, &apiStatus) {
+				return validationResponseFromStatus(false, apiStatus.Status())
+			}
+			return admission.Denied(err.Error())
+		}
+	}
+
+	return admission.Allowed("")
+}
+
+func validationResponseFromStatus(allowed bool, status metav1.Status) admission.Response {
+	return admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			Allowed: allowed,
+			Result:  &status,
+		},
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
/area managedclusters

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
system node pool will be of type system and not user.
added mode in the azuremannagedmachinepool api to set the mode of azure agent pools
removed defaultPoolRef from azuremanagedcontrolplane api. (provides more flexibility to manage system node pools.)
validation for deletion of last system node pool is handled in the webhook.
bumped up the containerservice sdk from 2020-02-01 to 2021-05-01
updated the aks docs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes  #1376 #1418 #1536

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Mode spec in the AzureManagedMachinePool is used to specify the mode of an agentPool i.e System or User.
Removed defaultPoolRef from AzureManagedControlPlane. 
```
