### PR TITLE
Set Service Principal in azurejson secret when AzureCluster has IdentityRef but not using Managed Identity

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "aks_kubernetes_version": "v1.20.5"
 }
 
-keys = ["AZURE_SUBSCRIPTION_ID_B64", "AZURE_TENANT_ID_B64", "AZURE_CLIENT_SECRET_B64", "AZURE_CLIENT_ID_B64"]
+keys = ["AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID", "AZURE_CLIENT_SECRET", "AZURE_CLIENT_ID"]
 
 # global settings
 settings.update(read_json(
@@ -178,9 +178,10 @@ def create_identity_secret():
     os.putenv('CLUSTER_IDENTITY_NAME', 'cluster-identity')
 
     substitutions = settings.get("kustomize_substitutions", {})
-    os.putenv('AZURE_CLIENT_SECRET_B64', substitutions.get("AZURE_CLIENT_SECRET_B64"))
+    os.putenv('AZURE_CLIENT_SECRET_B64', base64_encode(substitutions.get("AZURE_CLIENT_SECRET")))
 
     local("cat templates/azure-cluster-identity/secret.yaml | " + envsubst_cmd + " | kubectl apply -f -", quiet=True)
+    os.unsetenv('AZURE_CLIENT_SECRET_B64')
 
 def create_crs():
     # create config maps

--- a/azure/scope/clients.go
+++ b/azure/scope/clients.go
@@ -120,6 +120,14 @@ func (c *AzureClients) setCredentialsWithProvider(ctx context.Context, subscript
 	c.ResourceManagerEndpoint = settings.Environment.ResourceManagerEndpoint
 	c.ResourceManagerVMDNSSuffix = settings.Environment.ResourceManagerVMDNSSuffix
 	c.Values[auth.SubscriptionID] = strings.TrimSuffix(subscriptionID, "\n")
+	c.Values[auth.TenantID] = strings.TrimSuffix(credentialsProvider.GetTenantID(), "\n")
+	c.Values[auth.ClientID] = strings.TrimSuffix(credentialsProvider.GetClientID(), "\n")
+
+	clientSecret, err := credentialsProvider.GetClientSecret(ctx)
+	if err != nil {
+		return err
+	}
+	c.Values[auth.ClientSecret] = strings.TrimSuffix(clientSecret, "\n")
 
 	c.Authorizer, err = credentialsProvider.GetAuthorizer(ctx, c.ResourceManagerEndpoint)
 	return err

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -67,11 +67,11 @@ func NewClusterScope(ctx context.Context, params ClusterScopeParams) (*ClusterSc
 			return nil, errors.Wrap(err, "failed to configure azure settings and credentials from environment")
 		}
 	} else {
-		credentailsProvider, err := NewAzureClusterCredentialsProvider(ctx, params.Client, params.AzureCluster)
+		credentialsProvider, err := NewAzureClusterCredentialsProvider(ctx, params.Client, params.AzureCluster)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to init credentials provider")
 		}
-		err = params.AzureClients.setCredentialsWithProvider(ctx, params.AzureCluster.Spec.SubscriptionID, params.AzureCluster.Spec.AzureEnvironment, credentailsProvider)
+		err = params.AzureClients.setCredentialsWithProvider(ctx, params.AzureCluster.Spec.SubscriptionID, params.AzureCluster.Spec.AzureEnvironment, credentialsProvider)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to configure azure settings and credentials for Identity")
 		}

--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/pkg/errors"
@@ -38,9 +40,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const azureSecretKey = "clientSecret"
+
 // CredentialsProvider defines the behavior for azure identity based credential providers.
 type CredentialsProvider interface {
 	GetAuthorizer(ctx context.Context, resourceManagerEndpoint string) (autorest.Authorizer, error)
+	GetClientID() string
+	GetClientSecret(ctx context.Context) (string, error)
+	GetTenantID() string
 }
 
 // AzureCredentialsProvider represents a credential provider with azure cluster identity.
@@ -217,6 +224,33 @@ func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, resourceMa
 	}
 
 	return autorest.NewBearerAuthorizer(spt), nil
+}
+
+// GetClientID returns the Client ID associated with the AzureCredentialsProvider's Identity.
+func (p *AzureCredentialsProvider) GetClientID() string {
+	return p.Identity.Spec.ClientID
+}
+
+// GetClientSecret returns the Client Secret associated with the AzureCredentialsProvider's Identity.
+// NOTE: this only works if the Identity references a Service Principal Client Secret.
+// If using another type of credentials, such a Certificate, we return an empty string.
+func (p *AzureCredentialsProvider) GetClientSecret(ctx context.Context) (string, error) {
+	secretRef := p.Identity.Spec.ClientSecret
+	key := types.NamespacedName{
+		Namespace: secretRef.Namespace,
+		Name:      secretRef.Name,
+	}
+	secret := &corev1.Secret{}
+	err := p.Client.Get(ctx, key, secret)
+	if err != nil {
+		return "", errors.Wrap(err, "Unable to fetch ClientSecret")
+	}
+	return string(secret.Data[azureSecretKey]), nil
+}
+
+// GetTenantID returns the Tenant ID associated with the AzureCredentialsProvider's Identity.
+func (p *AzureCredentialsProvider) GetTenantID() string {
+	return p.Identity.Spec.TenantID
 }
 
 func getAzureIdentityType(identity *infrav1.AzureClusterIdentity) (aadpodv1.IdentityType, error) {

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -162,11 +162,8 @@ func (r *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return reconcile.Result{}, errors.New("AzureClusterIdentity list of allowed namespaces doesn't include current cluster namespace")
 		}
 	} else {
-		warningMessage := ("You're using deprecated functionality: ")
-		warningMessage += ("Using Azure credentials from the manager environment is deprecated and will be removed in future releases. ")
-		warningMessage += ("Please specify an AzureClusterIdentity for the AzureCluster instead, see: https://capz.sigs.k8s.io/topics/multitenancy.html ")
-		log.Info(fmt.Sprintf("WARNING, %s", warningMessage))
-		r.Recorder.Eventf(azureCluster, corev1.EventTypeWarning, "AzureClusterIdentity", warningMessage)
+		log.Info(fmt.Sprintf("WARNING, %s", deprecatedManagerCredsWarning))
+		r.Recorder.Eventf(azureCluster, corev1.EventTypeWarning, "AzureClusterIdentity", deprecatedManagerCredsWarning)
 	}
 
 	// Create the scope.

--- a/controllers/azurejson_machine_controller.go
+++ b/controllers/azurejson_machine_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -180,6 +181,11 @@ func (r *AzureJSONMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	userAssignedIdentityIfExists := ""
 	if len(azureMachine.Spec.UserAssignedIdentities) > 0 {
 		userAssignedIdentityIfExists = azureMachine.Spec.UserAssignedIdentities[0].ProviderID
+	}
+
+	if azureMachine.Spec.Identity == infrav1.VMIdentityNone {
+		log.Info(fmt.Sprintf("WARNING, %s", spIdentityWarning))
+		r.Recorder.Eventf(azureMachine, corev1.EventTypeWarning, "VMIdentityNone", spIdentityWarning)
 	}
 
 	newSecret, err := GetCloudProviderSecret(

--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -141,6 +142,11 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl
 		Kind:       kind,
 		Name:       azureMachinePool.GetName(),
 		UID:        azureMachinePool.GetUID(),
+	}
+
+	if azureMachinePool.Spec.Identity == infrav1.VMIdentityNone {
+		log.Info(fmt.Sprintf("WARNING, %s", spIdentityWarning))
+		r.Recorder.Eventf(azureMachinePool, corev1.EventTypeWarning, "VMIdentityNone", spIdentityWarning)
 	}
 
 	newSecret, err := GetCloudProviderSecret(

--- a/controllers/azurejson_machinetemplate_controller.go
+++ b/controllers/azurejson_machinetemplate_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -143,6 +144,11 @@ func (r *AzureJSONTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	userAssignedIdentityIfExists := ""
 	if len(azureMachineTemplate.Spec.Template.Spec.UserAssignedIdentities) > 0 {
 		userAssignedIdentityIfExists = azureMachineTemplate.Spec.Template.Spec.UserAssignedIdentities[0].ProviderID
+	}
+
+	if azureMachineTemplate.Spec.Template.Spec.Identity == infrav1.VMIdentityNone {
+		log.Info(fmt.Sprintf("WARNING, %s", spIdentityWarning))
+		r.Recorder.Eventf(azureMachineTemplate, corev1.EventTypeWarning, "VMIdentityNone", spIdentityWarning)
 	}
 
 	newSecret, err := GetCloudProviderSecret(

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -49,6 +49,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
+const (
+	spIdentityWarning = "You are using Service Principal authentication for Cloud Provider Azure which is less secure than Managed Identity. " +
+		"Your Service Principal credentials will be written to a file on the disk of each VM in order to be accessible by Cloud Provider. " +
+		"To learn more, see https://capz.sigs.k8s.io/topics/identities-use-cases.html#azure-host-identity "
+	deprecatedManagerCredsWarning = "You're using deprecated functionality: " +
+		"Using Azure credentials from the manager environment is deprecated and will be removed in future releases. " +
+		"Please specify an AzureClusterIdentity for the AzureCluster instead, see: https://capz.sigs.k8s.io/topics/multitenancy.html "
+)
+
 type (
 	// Options are controller options extended.
 	Options struct {

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -70,12 +70,6 @@ defaultTag=$(date -u '+%Y%m%d%H%M%S')
 export TAG="${defaultTag:-dev}"
 export GINKGO_NODES=1
 
-AZURE_SUBSCRIPTION_ID_B64="$(echo -n "$AZURE_SUBSCRIPTION_ID" | base64 | tr -d '\n')"
-AZURE_TENANT_ID_B64="$(echo -n "$AZURE_TENANT_ID" | base64 | tr -d '\n')"
-AZURE_CLIENT_ID_B64="$(echo -n "$AZURE_CLIENT_ID" | base64 | tr -d '\n')"
-AZURE_CLIENT_SECRET_B64="$(echo -n "$AZURE_CLIENT_SECRET" | base64 | tr -d '\n')"
-export AZURE_SUBSCRIPTION_ID_B64 AZURE_TENANT_ID_B64 AZURE_CLIENT_ID_B64 AZURE_CLIENT_SECRET_B64
-
 export AZURE_LOCATION="${AZURE_LOCATION:-$(get_random_region)}"
 export AZURE_CONTROL_PLANE_MACHINE_TYPE="${AZURE_CONTROL_PLANE_MACHINE_TYPE:-"Standard_D2s_v3"}"
 export AZURE_NODE_MACHINE_TYPE="${AZURE_NODE_MACHINE_TYPE:-"Standard_D2s_v3"}"

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -68,6 +68,7 @@ defaultTag=$(date -u '+%Y%m%d%H%M%S')
 export TAG="${defaultTag:-dev}"
 export GINKGO_NODES=3
 
+# TODO: remove these variables once Calico 3.20 fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1448
 AZURE_SUBSCRIPTION_ID_B64="$(echo -n "$AZURE_SUBSCRIPTION_ID" | base64 | tr -d '\n')"
 AZURE_TENANT_ID_B64="$(echo -n "$AZURE_TENANT_ID" | base64 | tr -d '\n')"
 AZURE_CLIENT_ID_B64="$(echo -n "$AZURE_CLIENT_ID" | base64 | tr -d '\n')"

--- a/templates/flavors/README.md
+++ b/templates/flavors/README.md
@@ -29,10 +29,10 @@ Please note your tilt-settings.json must contain at minimum the following fields
 ```json
 {
     "kustomize_substitutions": {
-        "AZURE_SUBSCRIPTION_ID_B64": "******",
-        "AZURE_TENANT_ID_B64": "******",
-        "AZURE_CLIENT_SECRET_B64": "******",
-        "AZURE_CLIENT_ID_B64": "******"
+        "AZURE_SUBSCRIPTION_ID": "******",
+        "AZURE_TENANT_ID": "******",
+        "AZURE_CLIENT_SECRET": "******",
+        "AZURE_CLIENT_ID": "******"
     }
 }
 ```
@@ -48,10 +48,10 @@ If you wish to override the default variables for flavor workers, you can specif
 ```json
 {
     "kustomize_substitutions": {
-        "AZURE_SUBSCRIPTION_ID_B64": "****",
-        "AZURE_TENANT_ID_B64": "****",
-        "AZURE_CLIENT_SECRET_B64": "****",
-        "AZURE_CLIENT_ID_B64": "****",
+        "AZURE_SUBSCRIPTION_ID": "****",
+        "AZURE_TENANT_ID": "****",
+        "AZURE_CLIENT_SECRET": "****",
+        "AZURE_CLIENT_ID": "****"
     },
     "worker-templates": {
         "flavors": {
@@ -84,10 +84,10 @@ N-series node type just for the `nvidia-gpu` flavor in `tilt-settings.json` to o
 ```json
 {
     "kustomize_substitutions": {
-        "AZURE_SUBSCRIPTION_ID_B64": "****",
-        "AZURE_TENANT_ID_B64": "****",
-        "AZURE_CLIENT_SECRET_B64": "****",
-        "AZURE_CLIENT_ID_B64": "****",
+        "AZURE_SUBSCRIPTION_ID": "****",
+        "AZURE_TENANT_ID": "****",
+        "AZURE_CLIENT_SECRET": "****",
+        "AZURE_CLIENT_ID": "****"
     },
     "worker-templates": {
         "flavors": {

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -29,6 +29,10 @@ spec:
     buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
@@ -396,6 +400,22 @@ spec:
   - kind: ConfigMap
     name: cni-${CLUSTER_NAME}-calico
   strategy: ApplyOnce
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: AzureClusterIdentity
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: ${CLUSTER_IDENTITY_NAME}
+  namespace: default
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+  tenantID: ${AZURE_TENANT_ID}
+  type: ServicePrincipal
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -29,6 +29,10 @@ spec:
     buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
@@ -230,6 +234,22 @@ spec:
   - kind: ConfigMap
     name: cni-${CLUSTER_NAME}-calico
   strategy: ApplyOnce
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: AzureClusterIdentity
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: ${CLUSTER_IDENTITY_NAME}
+  namespace: default
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+  tenantID: ${AZURE_TENANT_ID}
+  type: ServicePrincipal
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/prow/kustomization.yaml
+++ b/templates/test/ci/prow/kustomization.yaml
@@ -6,11 +6,13 @@ resources:
   - ../../../flavors/default/machine-deployment.yaml
   - mhc.yaml
   - cni-resource-set.yaml
+  - ../../../azure-cluster-identity
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/mhc.yaml
   - ../patches/cluster-cni.yaml
   - ../patches/controller-manager.yaml
+  - ../../../azure-cluster-identity/azurecluster-identity-ref.yaml
 configMapGenerator:
   - name: cni-${CLUSTER_NAME}-calico
     files:

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -29,6 +29,10 @@ spec:
     buildProvenance: ${BUILD_PROVENANCE}
     creationTimestamp: ${TIMESTAMP}
     jobName: ${JOB_NAME}
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
   location: ${AZURE_LOCATION}
   networkSpec:
     vnet:
@@ -322,6 +326,22 @@ spec:
   - kind: ConfigMap
     name: cni-${CLUSTER_NAME}-calico
   strategy: ApplyOnce
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: AzureClusterIdentity
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: ${CLUSTER_IDENTITY_NAME}
+  namespace: default
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID}
+  clientSecret:
+    name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+  tenantID: ${AZURE_TENANT_ID}
+  type: ServicePrincipal
 ---
 apiVersion: v1
 data:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: The azure.json controller didn't have access to the Client secret/id/tenant ID when using AzureClusterIdentity and the manager creds were not set. This caused the azurejson secrets to be generated without aadClientID and aadClientSecret set, when not using managed identity, which causes cloud provider to fail (kube-controller-manager goes into crashloop).

Also adds a warning when not using Managed Identity since it is less secure and requires writing creds to disk.

To ensure the integrity of these changes, the tilt, e2e and conformance scripts have been modified to not set base64 encoded variables so that the manager credentials are no longer set (this is what prevented us from catching this bug in the first place). Intentionally left ci-entrypoint untouched, will follow up on that one later.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1517

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Get Cloud Provider config Service Principal credentials from AzureClusterIdentity when not using Managed Identity 
```
