### PR TITLE
Add e2e spec name as cluster name suffix

### DIFF
--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -119,7 +119,7 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 	//*************
 
 	By("Creating a private workload cluster")
-	clusterName = fmt.Sprintf("capz-e2e-%s", util.RandomString(6))
+	clusterName = fmt.Sprintf("capz-e2e-%s-%s", util.RandomString(6), "private")
 	Expect(os.Setenv(AzureInternalLBIP, "10.128.0.100")).NotTo(HaveOccurred())
 	result := &clusterctl.ApplyClusterTemplateAndWaitResult{}
 	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{

--- a/test/e2e/azure_selfhosted.go
+++ b/test/e2e/azure_selfhosted.go
@@ -75,6 +75,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		var err error
 		namespace, cancelWatches, err = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		Expect(err).ToNot(HaveOccurred())
 		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
 
 		spClientSecret := os.Getenv(AzureClientSecret)

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -303,6 +303,20 @@ func logCheckpoint(specTimes map[string]time.Time) {
 	}
 }
 
+// getClusterName gets the cluster name for the test cluster
+// and sets the environment variables that depend on it.
+func getClusterName(prefix, specName string) string {
+	clusterName := os.Getenv("CLUSTER_NAME")
+	if clusterName == "" {
+		clusterName = fmt.Sprintf("%s-%s", prefix, specName)
+	}
+	fmt.Fprintf(GinkgoWriter, "INFO: Cluster name is %s\n", clusterName)
+
+	Expect(os.Setenv(AzureResourceGroup, clusterName)).NotTo(HaveOccurred())
+	Expect(os.Setenv(AzureVNetName, fmt.Sprintf("%s-vnet", clusterName))).NotTo(HaveOccurred())
+	return clusterName
+}
+
 // nodeSSHInfo provides information to establish an SSH connection to a VM or VMSS instance.
 type nodeSSHInfo struct {
 	Endpoint string // Endpoint is the control plane hostname or IP address for initial connection.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: Improve debugging experience by including the cluster type in the cluster name so we can easily find the right log folder, etc. instead of having to remember a random 6 char string.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
