### PR TITLE
add SetIdentityDefaults to azuremachinepool_webhook.go

### DIFF
--- a/exp/api/v1alpha4/azuremachinepool_webhook.go
+++ b/exp/api/v1alpha4/azuremachinepool_webhook.go
@@ -54,6 +54,7 @@ func (amp *AzureMachinePool) Default() {
 	if err != nil {
 		azuremachinepoollog.Error(err, "SetDefaultSshPublicKey failed")
 	}
+	amp.SetIdentityDefaults()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-azuremachinepool,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=azuremachinepools,versions=v1alpha4,name=validation.azuremachinepool.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1


### PR DESCRIPTION
**What type of PR is this?**
add SetIdentityDefaults to azuremachinepool_webhook.go


/kind bug



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1526


- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

```release-note
Set role assignment name default for AzureMachinePools
```