### PR TITLE
azurejson machinepool controller drops user assigned identity

### DIFF
--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -125,6 +125,12 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl
 		return reconcile.Result{}, err
 	}
 
+	// Construct secret for this machine
+	userAssignedIdentityIfExists := ""
+	if len(azureMachinePool.Spec.UserAssignedIdentities) > 0 {
+		userAssignedIdentityIfExists = azureMachinePool.Spec.UserAssignedIdentities[0].ProviderID
+	}
+
 	// Create the scope.
 	clusterScope, err := scope.NewClusterScope(ctx, scope.ClusterScopeParams{
 		Client:       r.Client,
@@ -155,7 +161,7 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl
 		azureMachinePool.Name,
 		owner,
 		azureMachinePool.Spec.Identity,
-		"",
+		userAssignedIdentityIfExists,
 	)
 
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1522


**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests


```release-note
add user assigned identity to azurejson machinepool secret
```