### PR TITLE
🐛 wrong mapper used for MP -> AMMP

### DIFF
--- a/exp/controllers/azuremachinepool_controller_unit_test.go
+++ b/exp/controllers/azuremachinepool_controller_unit_test.go
@@ -123,6 +123,17 @@ func newMachinePoolWithInfrastructureRef(clusterName, poolName string) *clusterv
 	return m
 }
 
+func newManagedMachinePoolWithInfrastructureRef(clusterName, poolName string) *clusterv1exp.MachinePool {
+	m := newMachinePool(clusterName, poolName)
+	m.Spec.Template.Spec.InfrastructureRef = v1.ObjectReference{
+		Kind:       "AzureManagedMachinePool",
+		Namespace:  m.Namespace,
+		Name:       "azure" + poolName,
+		APIVersion: infrav1exp.GroupVersion.String(),
+	}
+	return m
+}
+
 func newAzureCluster(clusterName string) *infrav1.AzureCluster {
 	return &infrav1.AzureCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/exp/controllers/azuremanagedmachinepool_controller.go
+++ b/exp/controllers/azuremanagedmachinepool_controller.go
@@ -91,7 +91,7 @@ func (r *AzureManagedMachinePoolReconciler) SetupWithManager(ctx context.Context
 		// watch for changes in CAPI MachinePool resources
 		Watches(
 			&source.Kind{Type: &clusterv1exp.MachinePool{}},
-			handler.EnqueueRequestsFromMapFunc(util.MachineToInfrastructureMapFunc(infrav1exp.GroupVersion.WithKind("AzureManagedMachinePool"))),
+			handler.EnqueueRequestsFromMapFunc(MachinePoolToInfrastructureMapFunc(clusterv1exp.GroupVersion.WithKind("AzureManagedMachinePool"), ctrl.LoggerFrom(ctx))),
 		).
 		// watch for changes in AzureManagedControlPlanes
 		Watches(


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake

**What this PR does / why we need it**:

Fixes mapper from MachinePools to AzureManagedMachinePools. We were using a machine to infrastructure mapper which doesn't work for machine pools. 

Another slice from https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1488/files#diff-714daa93f2eede09b5665786a53bcddf09a13a8d0a19cd17fc61e3bc017f4b8aR98

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes an issue with AzureManagedMachinePools not re-reconciling on updates to the corresponding MachinePool resources.
```
