### PR TITLE
Remove AzureClusterIdentity Owner Ref on upgrade from v1alpha3 to v1alpha4

### DIFF
--- a/api/v1alpha3/azureclusteridentity_conversion.go
+++ b/api/v1alpha3/azureclusteridentity_conversion.go
@@ -17,10 +17,15 @@ limitations under the License.
 package v1alpha3
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
 	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+const (
+	AzureClusterKind = "AzureCluster"
 )
 
 // ConvertTo converts this AzureCluster to the Hub version (v1alpha4).
@@ -43,6 +48,15 @@ func (src *AzureClusterIdentity) ConvertTo(dstRaw conversion.Hub) error { // nol
 		}
 		dst.Spec.AllowedNamespaces.Selector = restored.Spec.AllowedNamespaces.Selector
 	}
+
+	// removing ownerReference for AzureCluster as ownerReference is not required from v1alpha4 onwards.
+	var restoredOwnerReferences []v1.OwnerReference
+	for _, ownerRef :=  range dst.OwnerReferences {
+		if ownerRef.Kind != AzureClusterKind {
+			restoredOwnerReferences = append(restoredOwnerReferences, ownerRef)
+		}
+	}
+	dst.OwnerReferences = restoredOwnerReferences
 
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR automatically removes the owner reference of AzureCluster in AzureClusterIdentity when a v1alpha3 cluster is upgraded to v1alpha4 cluster

**Which issue(s) this PR fixes** :
Fixes #1529 

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Remove AzureClusterIdentity OwnerReference for AzureCluster on upgrade from v1alpha3 to v1alpha4
```
