### PR TITLE
Use dl.k8s.io instead of hardcoded GCS URIs

### DIFF
--- a/hack/terraform-gcr-init/user_project.tf
+++ b/hack/terraform-gcr-init/user_project.tf
@@ -42,7 +42,7 @@ resource "google_storage_bucket_acl" "acl" {
   ]
 
   provisioner "local-exec" {
-    command = "gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.${google_project.project.project_id}.appspot.com"
+    command = "gsutil -m acl ch -r -u AllUsers:READ dl.k8s.io/artifacts.${google_project.project.project_id}.appspot.com"
   }
 
   depends_on = ["null_resource.gcr"]

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -123,7 +123,7 @@ spec:
           echo "* testing CI version $$CI_VERSION"
           # Check for semver
           if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            CI_URL="gs://kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
+            CI_URL="dl.k8s.io/kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
             VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
             DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
             curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -137,9 +137,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
+            CI_URL="dl.k8s.io/k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
+              CI_URL="dl.k8s.io/k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
@@ -311,7 +311,7 @@ spec:
             echo "* testing CI version $$CI_VERSION"
             # Check for semver
             if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              CI_URL="gs://kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
+              CI_URL="dl.k8s.io/kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
               VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
               DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
               curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -325,9 +325,9 @@ spec:
                 DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
               done
             else
-              CI_URL="gs://k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
+              CI_URL="dl.k8s.io/k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
               if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-                CI_URL="gs://k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
+                CI_URL="dl.k8s.io/k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
               fi
               for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
                 echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -123,7 +123,7 @@ spec:
           echo "* testing CI version $$CI_VERSION"
           # Check for semver
           if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            CI_URL="gs://kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
+            CI_URL="dl.k8s.io/kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
             VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
             DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
             curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -137,9 +137,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
+            CI_URL="dl.k8s.io/k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
+              CI_URL="dl.k8s.io/k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
@@ -313,7 +313,7 @@ spec:
         echo "* testing CI version $$CI_VERSION"
         # Check for semver
         if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          CI_URL="gs://kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
+          CI_URL="dl.k8s.io/kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
           VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
           DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
           curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -327,9 +327,9 @@ spec:
             DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
           done
         else
-          CI_URL="gs://k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
+          CI_URL="dl.k8s.io/k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
           if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-            CI_URL="gs://k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
+            CI_URL="dl.k8s.io/k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
           fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"

--- a/templates/test/ci/patches/control-plane-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-ci-version.yaml
@@ -44,7 +44,7 @@ spec:
           echo "* testing CI version $$CI_VERSION"
           # Check for semver
           if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            CI_URL="gs://kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
+            CI_URL="dl.k8s.io/kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
             VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
             DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
             curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -58,9 +58,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
+            CI_URL="dl.k8s.io/k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
+              CI_URL="dl.k8s.io/k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -42,7 +42,7 @@ spec:
               echo "* testing CI version $$CI_VERSION"
               # Check for semver
               if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                CI_URL="gs://kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
+                CI_URL="dl.k8s.io/kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
                 VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
                 DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
                 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -56,9 +56,9 @@ spec:
                   DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
                 done
               else
-                CI_URL="gs://k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
+                CI_URL="dl.k8s.io/k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
                 if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-                  CI_URL="gs://k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
+                  CI_URL="dl.k8s.io/k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
                 fi
                 for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
                   echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -40,7 +40,7 @@ spec:
           echo "* testing CI version $$CI_VERSION"
           # Check for semver
           if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            CI_URL="gs://kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
+            CI_URL="dl.k8s.io/kubernetes-release/release/$$CI_VERSION/bin/linux/amd64"
             VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
             DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
             curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -54,9 +54,9 @@ spec:
               DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
             done
           else
-            CI_URL="gs://k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
+            CI_URL="dl.k8s.io/k8s-release-dev/ci-periodic/$$CI_VERSION/bin/linux/amd64"
             if ! $${GSUTIL} ls "$${CI_URL}" > /dev/null; then
-              CI_URL="gs://k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
+              CI_URL="dl.k8s.io/k8s-release-dev/ci/$$CI_VERSION/bin/linux/amd64"
             fi
             for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind api-change
/kind deprecation
-->

**What this PR does / why we need it**:
Replaces all hardcoded usages of ```sh gs:// ``` with dl.k8s.io. dl.k8s.io is much nicer for a project, since we can transparently change where that redirects to without having to change code everywhere


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1551 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
```sh None ```