### PR TITLE
fix: update go for github actions coverage test

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - run: "make test-cover"
+    - run: "bash hack/install-go.sh"
+    - run: "PATH=/usr/local/go/bin:$PATH make test-cover"
     - uses: codecov/codecov-action@v1
       with:
         file: ./coverage.out

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "installing apt dependencies"
+sudo apt update && sudo apt install -y curl apt-transport-https
+
+echo "setting up work dir"
+WORKDIR="$(mktemp -d)"
+pushd "$WORKDIR"
+
+trap 'rm -rf ${WORKDIR}' EXIT
+
+GOLANG_VERSION="$(curl -sS https://golang.org/VERSION?m=text)"
+echo "Downloading ${GOLANG_VERSION}"
+curl -O "https://dl.google.com/go/${GOLANG_VERSION}.linux-amd64.tar.gz"
+
+echo "unpacking go"
+sudo mkdir -p /usr/local/go
+sudo chown -R "$(whoami):$(whoami)" /usr/local/go 
+tar -xvf "${GOLANG_VERSION}.linux-amd64.tar.gz" -C /usr/local
+
+echo "Successfully installed go"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

master is failing coverage tests due to what seems to me to be a compilation failure due to old go version (has happened to me a few times). trying to update it here and manually trigger a test run. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
