### PR TITLE
Adding correlation ID in reconcile loop loggers

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -212,8 +212,8 @@ func (m MachinePoolScope) MaxSurge() (int, error) {
 // updateReplicasAndProviderIDs ties the Azure VMSS instance data and the Node status data together to build and update
 // the AzureMachinePool replica count and providerIDList.
 func (m *MachinePoolScope) updateReplicasAndProviderIDs(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolScope.UpdateInstanceStatuses")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scope.MachinePoolScope.UpdateInstanceStatuses")
+	defer done()
 
 	machines, err := m.getMachinePoolMachines(ctx)
 	if err != nil {
@@ -235,8 +235,11 @@ func (m *MachinePoolScope) updateReplicasAndProviderIDs(ctx context.Context) err
 }
 
 func (m *MachinePoolScope) getMachinePoolMachines(ctx context.Context) ([]infrav1exp.AzureMachinePoolMachine, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolScope.getMachinePoolMachines")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolScope.getMachinePoolMachines",
+	)
+	defer done()
 
 	labels := map[string]string{
 		clusterv1.ClusterLabelName:      m.ClusterName(),
@@ -251,8 +254,11 @@ func (m *MachinePoolScope) getMachinePoolMachines(ctx context.Context) ([]infrav
 }
 
 func (m *MachinePoolScope) applyAzureMachinePoolMachines(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolScope.applyAzureMachinePoolMachines")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolScope.applyAzureMachinePoolMachines",
+	)
+	defer done()
 
 	if m.vmssState == nil {
 		m.Info("vmssState is nil")
@@ -493,16 +499,19 @@ func (m *MachinePoolScope) SetAnnotation(key, value string) {
 
 // PatchObject persists the machine spec and status.
 func (m *MachinePoolScope) PatchObject(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolScope.PatchObject")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolScope.PatchObject",
+	)
+	defer done()
 
 	return m.patchHelper.Patch(ctx, m.AzureMachinePool)
 }
 
 // Close the MachineScope by updating the machine spec, machine status.
 func (m *MachinePoolScope) Close(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolScope.Close")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scope.MachinePoolScope.Close")
+	defer done()
 
 	if m.vmssState != nil {
 		if err := m.applyAzureMachinePoolMachines(ctx); err != nil {
@@ -521,8 +530,11 @@ func (m *MachinePoolScope) Close(ctx context.Context) error {
 
 // GetBootstrapData returns the bootstrap data from the secret in the Machine's bootstrap.dataSecretName.
 func (m *MachinePoolScope) GetBootstrapData(ctx context.Context) (string, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolScope.GetBootstrapData")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolScope.GetBootstrapData",
+	)
+	defer done()
 
 	dataSecretName := m.MachinePool.Spec.Template.Spec.Bootstrap.DataSecretName
 	if dataSecretName == nil {

--- a/azure/scope/machinepoolmachine.go
+++ b/azure/scope/machinepoolmachine.go
@@ -268,8 +268,11 @@ func (s *MachinePoolMachineScope) ProviderID() string {
 
 // Close updates the state of MachinePoolMachine.
 func (s *MachinePoolMachineScope) Close(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolMachineScope.Close")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolMachineScope.Close",
+	)
+	defer done()
 
 	return s.patchHelper.Patch(ctx, s.AzureMachinePoolMachine)
 }
@@ -277,8 +280,11 @@ func (s *MachinePoolMachineScope) Close(ctx context.Context) error {
 // UpdateStatus updates the node reference for the machine and other status fields. This func should be called at the
 // end of a reconcile request and after updating the scope with the most recent Azure data.
 func (s *MachinePoolMachineScope) UpdateStatus(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolMachineScope.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolMachineScope.Get",
+	)
+	defer done()
 
 	var (
 		nodeRef = s.AzureMachinePoolMachine.Status.NodeRef
@@ -323,8 +329,11 @@ func (s *MachinePoolMachineScope) UpdateStatus(ctx context.Context) error {
 
 // CordonAndDrain will cordon and drain the Kubernetes node associated with this AzureMachinePoolMachine.
 func (s *MachinePoolMachineScope) CordonAndDrain(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolMachineScope.CordonAndDrain")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolMachineScope.CordonAndDrain",
+	)
+	defer done()
 
 	var (
 		nodeRef = s.AzureMachinePoolMachine.Status.NodeRef
@@ -386,8 +395,11 @@ func (s *MachinePoolMachineScope) CordonAndDrain(ctx context.Context) error {
 }
 
 func (s *MachinePoolMachineScope) drainNode(ctx context.Context, node *corev1.Node) error {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolMachineScope.drainNode")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolMachineScope.drainNode",
+	)
+	defer done()
 
 	restConfig, err := remote.RESTConfig(ctx, MachinePoolMachineScopeName, s.client, client.ObjectKey{
 		Name:      s.ClusterName(),
@@ -523,8 +535,11 @@ func (np *workloadClusterProxy) GetNodeByObjectReference(ctx context.Context, no
 
 // GetNodeByProviderID will fetch a node from the workload cluster by it's providerID.
 func (np *workloadClusterProxy) GetNodeByProviderID(ctx context.Context, providerID string) (*corev1.Node, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolMachineScope.getNode")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolMachineScope.getNode",
+	)
+	defer done()
 
 	workloadClient, err := getWorkloadClient(ctx, np.Client, np.Cluster)
 	if err != nil {
@@ -535,8 +550,11 @@ func (np *workloadClusterProxy) GetNodeByProviderID(ctx context.Context, provide
 }
 
 func getNodeByProviderID(ctx context.Context, workloadClient client.Client, providerID string) (*corev1.Node, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolMachineScope.getNodeRefForProviderID")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolMachineScope.getNodeRefForProviderID",
+	)
+	defer done()
 
 	nodeList := corev1.NodeList{}
 	for {
@@ -559,8 +577,11 @@ func getNodeByProviderID(ctx context.Context, workloadClient client.Client, prov
 }
 
 func getWorkloadClient(ctx context.Context, c client.Client, cluster client.ObjectKey) (client.Client, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scope.MachinePoolMachineScope.getWorkloadClient")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"scope.MachinePoolMachineScope.getWorkloadClient",
+	)
+	defer done()
 
 	return remote.NewClusterClient(ctx, MachinePoolMachineScopeName, c, cluster)
 }

--- a/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
+++ b/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
@@ -105,8 +105,11 @@ func (rollingUpdateStrategy *rollingUpdateStrategy) maxUnavailable(desiredReplic
 // SelectMachinesToDelete selects the machines to delete based on the machine state, desired replica count, and
 // the DeletePolicy.
 func (rollingUpdateStrategy rollingUpdateStrategy) SelectMachinesToDelete(ctx context.Context, desiredReplicaCount int32, machinesByProviderID map[string]infrav1exp.AzureMachinePoolMachine) ([]infrav1exp.AzureMachinePoolMachine, error) {
-	ctx, span := tele.Tracer().Start(ctx, "strategies.rollingUpdateStrategy.SelectMachinesToDelete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"strategies.rollingUpdateStrategy.SelectMachinesToDelete",
+	)
+	defer done()
 
 	maxUnavailable, err := rollingUpdateStrategy.maxUnavailable(int(desiredReplicaCount))
 	if err != nil {

--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -59,8 +59,11 @@ func New(scope ManagedMachinePoolScope) *Service {
 
 // Reconcile idempotently creates or updates a agent pool, if possible.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "agentpools.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"agentpools.Service.Reconcile",
+	)
+	defer done()
 
 	agentPoolSpec := s.scope.AgentPoolSpec()
 
@@ -135,8 +138,11 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the virtual network with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "agentpools.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"agentpools.Service.Delete",
+	)
+	defer done()
 
 	agentPoolSpec := s.scope.AgentPoolSpec()
 

--- a/azure/services/agentpools/client.go
+++ b/azure/services/agentpools/client.go
@@ -56,16 +56,16 @@ func newAgentPoolsClient(subscriptionID string, baseURI string, authorizer autor
 
 // Get gets an agent pool.
 func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, cluster, name string) (containerservice.AgentPool, error) {
-	ctx, span := tele.Tracer().Start(ctx, "agentpools.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "agentpools.AzureClient.Get")
+	defer done()
 
 	return ac.agentpools.Get(ctx, resourceGroupName, cluster, name)
 }
 
 // CreateOrUpdate creates or updates an agent pool.
 func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, cluster, name string, properties containerservice.AgentPool) error {
-	ctx, span := tele.Tracer().Start(ctx, "agentpools.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "agentpools.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.agentpools.CreateOrUpdate(ctx, resourceGroupName, cluster, name, properties)
 	if err != nil {
@@ -80,8 +80,8 @@ func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, cl
 
 // Delete deletes an agent pool.
 func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, cluster, name string) error {
-	ctx, span := tele.Tracer().Start(ctx, "agentpools.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "agentpools.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.agentpools.Delete(ctx, resourceGroupName, cluster, name)
 	if err != nil {

--- a/azure/services/availabilitysets/availabilitysets.go
+++ b/azure/services/availabilitysets/availabilitysets.go
@@ -57,8 +57,11 @@ func New(scope AvailabilitySetScope, skuCache *resourceskus.Cache) *Service {
 
 // Reconcile creates or updates availability sets.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "availabilitysets.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"availabilitysets.Service.Reconcile",
+	)
+	defer done()
 
 	availabilitySetName, ok := s.Scope.AvailabilitySet()
 	if !ok {
@@ -111,8 +114,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes availability sets.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "availabilitysets.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "availabilitysets.Service.Delete")
+	defer done()
 
 	availabilitySetName, ok := s.Scope.AvailabilitySet()
 	if !ok {

--- a/azure/services/availabilitysets/client.go
+++ b/azure/services/availabilitysets/client.go
@@ -55,8 +55,8 @@ func newAvailabilitySetsClient(subscriptionID string, baseURI string, authorizer
 
 // Get gets an availability set.
 func (a *AzureClient) Get(ctx context.Context, resourceGroup, availabilitySetsName string) (compute.AvailabilitySet, error) {
-	ctx, span := tele.Tracer().Start(ctx, "availabilitysets.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "availabilitysets.AzureClient.Get")
+	defer done()
 
 	return a.availabilitySets.Get(ctx, resourceGroup, availabilitySetsName)
 }
@@ -64,16 +64,16 @@ func (a *AzureClient) Get(ctx context.Context, resourceGroup, availabilitySetsNa
 // CreateOrUpdate creates or updates an availability set.
 func (a *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroup string, availabilitySetsName string,
 	params compute.AvailabilitySet) (compute.AvailabilitySet, error) {
-	ctx, span := tele.Tracer().Start(ctx, "availabilitysets.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "availabilitysets.AzureClient.CreateOrUpdate")
+	defer done()
 
 	return a.availabilitySets.CreateOrUpdate(ctx, resourceGroup, availabilitySetsName, params)
 }
 
 // Delete deletes an availability set.
 func (a *AzureClient) Delete(ctx context.Context, resourceGroup, availabilitySetsName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "availabilitysets.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "availabilitysets.AzureClient.Delete")
+	defer done()
 	_, err := a.availabilitySets.Delete(ctx, resourceGroup, availabilitySetsName)
 	return err
 }

--- a/azure/services/bastionhosts/bastionhosts.go
+++ b/azure/services/bastionhosts/bastionhosts.go
@@ -57,8 +57,11 @@ func New(scope BastionScope) *Service {
 
 // Reconcile gets/creates/updates a bastion host.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "bastionhosts.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"bastionhosts.Service.Reconcile",
+	)
+	defer done()
 
 	azureBastionSpec := s.Scope.BastionSpec().AzureBastion
 	if azureBastionSpec != nil {
@@ -73,8 +76,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the bastion host with the provided scope.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "bastionhosts.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "bastionhosts.Service.Delete")
+	defer done()
 
 	azureBastionSpec := s.Scope.BastionSpec().AzureBastion
 	if azureBastionSpec != nil {

--- a/azure/services/bastionhosts/client.go
+++ b/azure/services/bastionhosts/client.go
@@ -55,16 +55,16 @@ func newBastionHostsClient(subscriptionID string, baseURI string, authorizer aut
 
 // Get gets information about the specified bastion host.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, bastionName string) (network.BastionHost, error) {
-	ctx, span := tele.Tracer().Start(ctx, "bastionhosts.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "bastionhosts.AzureClient.Get")
+	defer done()
 
 	return ac.interfaces.Get(ctx, resourceGroupName, bastionName)
 }
 
 // CreateOrUpdate creates or updates a bastion host.
 func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, bastionName string, bastionHost network.BastionHost) error {
-	ctx, span := tele.Tracer().Start(ctx, "bastionhosts.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "bastionhosts.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.interfaces.CreateOrUpdate(ctx, resourceGroupName, bastionName, bastionHost)
 	if err != nil {
@@ -80,8 +80,8 @@ func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName str
 
 // Delete deletes the specified network interface.
 func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, bastionName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "bastionhosts.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "bastionhosts.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.interfaces.Delete(ctx, resourceGroupName, bastionName)
 	if err != nil {

--- a/azure/services/disks/client.go
+++ b/azure/services/disks/client.go
@@ -52,8 +52,8 @@ func newDisksClient(subscriptionID string, baseURI string, authorizer autorest.A
 
 // Delete removes the disk client.
 func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, name string) error {
-	ctx, span := tele.Tracer().Start(ctx, "disks.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "disks.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.disks.Delete(ctx, resourceGroupName, name)
 	if err != nil {

--- a/azure/services/disks/disks.go
+++ b/azure/services/disks/disks.go
@@ -49,16 +49,16 @@ func New(scope DiskScope) *Service {
 
 // Reconcile on disk is currently no-op. OS disks should only be deleted and will create with the VM automatically.
 func (s *Service) Reconcile(ctx context.Context) error {
-	_, span := tele.Tracer().Start(ctx, "disks.Service.Reconcile")
-	defer span.End()
+	_, _, done := tele.StartSpanWithLogger(ctx, "disks.Service.Reconcile")
+	defer done()
 
 	return nil
 }
 
 // Delete deletes the disk associated with a VM.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "disks.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "disks.Service.Delete")
+	defer done()
 
 	for _, diskSpec := range s.Scope.DiskSpecs() {
 		s.Scope.V(2).Info("deleting disk", "disk", diskSpec.Name)

--- a/azure/services/groups/client.go
+++ b/azure/services/groups/client.go
@@ -61,8 +61,8 @@ func newGroupsClient(subscriptionID string, baseURI string, authorizer autorest.
 
 // Get gets a resource group.
 func (ac *azureClient) Get(ctx context.Context, name string) (resources.Group, error) {
-	ctx, span := tele.Tracer().Start(ctx, "groups.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.AzureClient.Get")
+	defer done()
 
 	return ac.groups.Get(ctx, name)
 }
@@ -70,8 +70,8 @@ func (ac *azureClient) Get(ctx context.Context, name string) (resources.Group, e
 // CreateOrUpdateAsync creates or updates a resource group.
 // Creating a resource group is not a long running operation, so we don't ever return a future.
 func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter) (azureautorest.FutureAPI, error) {
-	ctx, span := tele.Tracer().Start(ctx, "groups.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.AzureClient.CreateOrUpdate")
+	defer done()
 
 	group, err := ac.resourceGroupParams(ctx, spec)
 	if err != nil {
@@ -91,8 +91,8 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 //
 // NOTE: When you delete a resource group, all of its resources are also deleted.
 func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (azureautorest.FutureAPI, error) {
-	ctx, span := tele.Tracer().Start(ctx, "groups.AzureClient.DeleteAsync")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.groups.Delete(ctx, spec.ResourceName())
 	if err != nil {
@@ -115,21 +115,21 @@ func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecG
 
 // IsDone returns true if the long-running operation has completed.
 func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (bool, error) {
-	ctx, span := tele.Tracer().Start(ctx, "groups.AzureClient.IsDone")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.AzureClient.IsDone")
+	defer done()
 
-	done, err := future.DoneWithContext(ctx, ac.groups)
+	isDone, err := future.DoneWithContext(ctx, ac.groups)
 	if err != nil {
 		return false, errors.Wrap(err, "failed checking if the operation was complete")
 	}
 
-	return done, nil
+	return isDone, nil
 }
 
 // resourceGroupParams returns the desired resource group parameters from the given spec.
 func (ac *azureClient) resourceGroupParams(ctx context.Context, spec azure.ResourceSpecGetter) (*resources.Group, error) {
-	ctx, span := tele.Tracer().Start(ctx, "groups.AzureClient.resourceGroupParams")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.AzureClient.resourceGroupParams")
+	defer done()
 
 	var params interface{}
 

--- a/azure/services/groups/groups.go
+++ b/azure/services/groups/groups.go
@@ -57,8 +57,8 @@ func New(scope GroupScope) *Service {
 
 // Reconcile gets/creates/updates a resource group.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "groups.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.Service.Reconcile")
+	defer done()
 
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
@@ -72,8 +72,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the resource group if it is managed by capz.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "groups.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.Service.Delete")
+	defer done()
 
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
@@ -104,8 +104,8 @@ func (s *Service) Delete(ctx context.Context) error {
 // IsGroupManaged returns true if the resource group has an owned tag with the cluster name as value,
 // meaning that the resource group's lifecycle is managed.
 func (s *Service) IsGroupManaged(ctx context.Context) (bool, error) {
-	ctx, span := tele.Tracer().Start(ctx, "groups.Service.IsGroupManaged")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "groups.Service.IsGroupManaged")
+	defer done()
 
 	groupSpec := s.Scope.GroupSpec()
 	group, err := s.client.Get(ctx, groupSpec.ResourceName())

--- a/azure/services/inboundnatrules/client.go
+++ b/azure/services/inboundnatrules/client.go
@@ -55,16 +55,16 @@ func newInboundNatRulesClient(subscriptionID string, baseURI string, authorizer 
 
 // Get gets the specified inbound NAT rules.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, lbName, inboundNatRuleName string) (network.InboundNatRule, error) {
-	ctx, span := tele.Tracer().Start(ctx, "inboundnatrules.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.AzureClient.Get")
+	defer done()
 
 	return ac.inboundnatrules.Get(ctx, resourceGroupName, lbName, inboundNatRuleName, "")
 }
 
 // CreateOrUpdate creates or updates a inbound NAT rules.
 func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, lbName string, inboundNatRuleName string, inboundNatRuleParameters network.InboundNatRule) error {
-	ctx, span := tele.Tracer().Start(ctx, "inboundnatrules.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.inboundnatrules.CreateOrUpdate(ctx, resourceGroupName, lbName, inboundNatRuleName, inboundNatRuleParameters)
 	if err != nil {
@@ -80,8 +80,8 @@ func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName str
 
 // Delete deletes the specified inbound NAT rules.
 func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, lbName, inboundNatRuleName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "inboundnatrules.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.inboundnatrules.Delete(ctx, resourceGroupName, lbName, inboundNatRuleName)
 	if err != nil {

--- a/azure/services/inboundnatrules/inboundnatrules.go
+++ b/azure/services/inboundnatrules/inboundnatrules.go
@@ -54,8 +54,8 @@ func New(scope InboundNatScope) *Service {
 
 // Reconcile gets/creates/updates an inbound NAT rule.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "inboundnatrules.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.Service.Reconcile")
+	defer done()
 
 	for _, inboundNatSpec := range s.Scope.InboundNatSpecs() {
 		s.Scope.V(2).Info("creating inbound NAT rule", "NAT rule", inboundNatSpec.Name)
@@ -107,8 +107,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the inbound NAT rule with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "inboundnatrules.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.Service.Delete")
+	defer done()
 
 	for _, inboundNatSpec := range s.Scope.InboundNatSpecs() {
 		s.Scope.V(2).Info("deleting inbound NAT rule", "NAT rule", inboundNatSpec.Name)

--- a/azure/services/loadbalancers/client.go
+++ b/azure/services/loadbalancers/client.go
@@ -55,16 +55,16 @@ func newLoadBalancersClient(subscriptionID string, baseURI string, authorizer au
 
 // Get gets the specified load balancer.
 func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, lbName string) (network.LoadBalancer, error) {
-	ctx, span := tele.Tracer().Start(ctx, "loadbalancers.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "loadbalancers.AzureClient.Get")
+	defer done()
 
 	return ac.loadbalancers.Get(ctx, resourceGroupName, lbName, "")
 }
 
 // CreateOrUpdate creates or updates a load balancer.
 func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, lbName string, lb network.LoadBalancer) error {
-	ctx, span := tele.Tracer().Start(ctx, "loadbalancers.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "loadbalancers.AzureClient.CreateOrUpdate")
+	defer done()
 
 	var etag string
 	if lb.Etag != nil {
@@ -98,8 +98,8 @@ func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName str
 
 // Delete deletes the specified load balancer.
 func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, lbName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "loadbalancers.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "loadbalancers.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.loadbalancers.Delete(ctx, resourceGroupName, lbName)
 	if err != nil {

--- a/azure/services/loadbalancers/loadbalancers.go
+++ b/azure/services/loadbalancers/loadbalancers.go
@@ -63,8 +63,8 @@ func New(scope LBScope) *Service {
 
 // Reconcile gets/creates/updates a load balancer.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "loadbalancers.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "loadbalancers.Service.Reconcile")
+	defer done()
 
 	for _, lbSpec := range s.Scope.LBSpecs() {
 		var (
@@ -176,8 +176,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the public load balancer with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "loadbalancers.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "loadbalancers.Service.Delete")
+	defer done()
 
 	for _, lbSpec := range s.Scope.LBSpecs() {
 		s.Scope.V(2).Info("deleting load balancer", "load balancer", lbSpec.Name)

--- a/azure/services/managedclusters/client.go
+++ b/azure/services/managedclusters/client.go
@@ -63,8 +63,8 @@ func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, name string) 
 
 // GetCredentials fetches the admin kubeconfig for a managed cluster.
 func (ac *AzureClient) GetCredentials(ctx context.Context, resourceGroupName, name string) ([]byte, error) {
-	ctx, span := tele.Tracer().Start(ctx, "managedclusters.AzureClient.GetCredentials")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "managedclusters.AzureClient.GetCredentials")
+	defer done()
 
 	credentialList, err := ac.managedclusters.ListClusterAdminCredentials(ctx, resourceGroupName, name, "")
 	if err != nil {
@@ -80,8 +80,8 @@ func (ac *AzureClient) GetCredentials(ctx context.Context, resourceGroupName, na
 
 // CreateOrUpdate creates or updates a managed cluster.
 func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, name string, cluster containerservice.ManagedCluster) (containerservice.ManagedCluster, error) {
-	ctx, span := tele.Tracer().Start(ctx, "managedclusters.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "managedclusters.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.managedclusters.CreateOrUpdate(ctx, resourceGroupName, name, cluster)
 	if err != nil {
@@ -96,8 +96,8 @@ func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, na
 
 // Delete deletes a managed cluster.
 func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, name string) error {
-	ctx, span := tele.Tracer().Start(ctx, "managedclusters.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "managedclusters.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.managedclusters.Delete(ctx, resourceGroupName, name)
 	if err != nil {

--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -135,8 +135,8 @@ func New(scope ManagedClusterScope) *Service {
 
 // Reconcile idempotently creates or updates a managed cluster, if possible.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "managedclusters.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "managedclusters.Service.Reconcile")
+	defer done()
 
 	managedClusterSpec, err := s.Scope.ManagedClusterSpec()
 	if err != nil {
@@ -314,8 +314,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the virtual network with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "managedclusters.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "managedclusters.Service.Delete")
+	defer done()
 
 	klog.V(2).Infof("Deleting managed cluster  %s ", s.Scope.ClusterName())
 	err := s.Client.Delete(ctx, s.Scope.ResourceGroup(), s.Scope.ClusterName())

--- a/azure/services/natgateways/client.go
+++ b/azure/services/natgateways/client.go
@@ -55,16 +55,16 @@ func netNatGatewaysClient(subscriptionID string, baseURI string, authorizer auto
 
 // Get gets the specified nat gateway.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, natGatewayName string) (network.NatGateway, error) {
-	ctx, span := tele.Tracer().Start(ctx, "natgateways.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "natgateways.AzureClient.Get")
+	defer done()
 
 	return ac.natgateways.Get(ctx, resourceGroupName, natGatewayName, "")
 }
 
 // CreateOrUpdate create or updates a nat gateway in a specified resource group.
 func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, natGatewayName string, natGateway network.NatGateway) error {
-	ctx, span := tele.Tracer().Start(ctx, "natgateways.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "natgateways.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.natgateways.CreateOrUpdate(ctx, resourceGroupName, natGatewayName, natGateway)
 	if err != nil {
@@ -80,8 +80,8 @@ func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName str
 
 // Delete deletes the specified nat gateway.
 func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, natGatewayName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "natgateways.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "natgateways.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.natgateways.Delete(ctx, resourceGroupName, natGatewayName)
 	if err != nil {

--- a/azure/services/natgateways/natgateways.go
+++ b/azure/services/natgateways/natgateways.go
@@ -55,8 +55,8 @@ func New(scope NatGatewayScope) *Service {
 // Reconcile gets/creates/updates a nat gateway.
 // Only when the Nat Gateway 'Name' property is defined we create the Nat Gateway: it's opt-in.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "natgateways.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "natgateways.Service.Reconcile")
+	defer done()
 
 	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping nat gateways reconcile in custom vnet mode")
@@ -149,8 +149,8 @@ func (s *Service) getExisting(ctx context.Context, spec azure.NatGatewaySpec) (*
 
 // Delete deletes the nat gateway with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "natgateways.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "natgateways.Service.Delete")
+	defer done()
 
 	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping nat gateway deletion in custom vnet mode")

--- a/azure/services/networkinterfaces/client.go
+++ b/azure/services/networkinterfaces/client.go
@@ -55,16 +55,16 @@ func newInterfacesClient(subscriptionID string, baseURI string, authorizer autor
 
 // Get gets information about the specified network interface.
 func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, nicName string) (network.Interface, error) {
-	ctx, span := tele.Tracer().Start(ctx, "networkinterfaces.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.Get")
+	defer done()
 
 	return ac.interfaces.Get(ctx, resourceGroupName, nicName, "")
 }
 
 // CreateOrUpdate creates or updates a network interface.
 func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, nicName string, nic network.Interface) error {
-	ctx, span := tele.Tracer().Start(ctx, "networkinterfaces.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.interfaces.CreateOrUpdate(ctx, resourceGroupName, nicName, nic)
 	if err != nil {
@@ -80,8 +80,8 @@ func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName str
 
 // Delete deletes the specified network interface.
 func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, nicName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "networkinterfaces.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.interfaces.Delete(ctx, resourceGroupName, nicName)
 	if err != nil {

--- a/azure/services/networkinterfaces/networkinterfaces.go
+++ b/azure/services/networkinterfaces/networkinterfaces.go
@@ -54,8 +54,8 @@ func New(scope NICScope, skuCache *resourceskus.Cache) *Service {
 
 // Reconcile gets/creates/updates a network interface.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "networkinterfaces.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.Service.Reconcile")
+	defer done()
 
 	for _, nicSpec := range s.Scope.NICSpecs() {
 		_, err := s.Client.Get(ctx, s.Scope.ResourceGroup(), nicSpec.Name)
@@ -163,8 +163,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the network interface with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "networkinterfaces.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.Service.Delete")
+	defer done()
 
 	for _, nicSpec := range s.Scope.NICSpecs() {
 		s.Scope.V(2).Info("deleting network interface %s", "network interface", nicSpec.Name)

--- a/azure/services/privatedns/client.go
+++ b/azure/services/privatedns/client.go
@@ -76,8 +76,8 @@ func newRecordSetsClient(subscriptionID string, baseURI string, authorizer autor
 
 // CreateOrUpdateZone creates or updates a private zone.
 func (ac *azureClient) CreateOrUpdateZone(ctx context.Context, resourceGroupName string, zoneName string, zone privatedns.PrivateZone) error {
-	ctx, span := tele.Tracer().Start(ctx, "privatedns.AzureClient.CreateOrUpdateZone")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.AzureClient.CreateOrUpdateZone")
+	defer done()
 
 	future, err := ac.privatezones.CreateOrUpdate(ctx, resourceGroupName, zoneName, zone, "", "")
 	if err != nil {
@@ -93,8 +93,8 @@ func (ac *azureClient) CreateOrUpdateZone(ctx context.Context, resourceGroupName
 
 // DeleteZone deletes the private zone.
 func (ac *azureClient) DeleteZone(ctx context.Context, resourceGroupName, name string) error {
-	ctx, span := tele.Tracer().Start(ctx, "privatedns.AzureClient.DeleteZone")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.AzureClient.DeleteZone")
+	defer done()
 
 	future, err := ac.privatezones.Delete(ctx, resourceGroupName, name, "")
 	if err != nil {
@@ -110,8 +110,8 @@ func (ac *azureClient) DeleteZone(ctx context.Context, resourceGroupName, name s
 
 // CreateOrUpdateLink creates or updates a virtual network link to the specified Private DNS zone.
 func (ac *azureClient) CreateOrUpdateLink(ctx context.Context, resourceGroupName, privateZoneName, name string, link privatedns.VirtualNetworkLink) error {
-	ctx, span := tele.Tracer().Start(ctx, "privatedns.AzureClient.CreateOrUpdateLink")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.AzureClient.CreateOrUpdateLink")
+	defer done()
 
 	future, err := ac.vnetlinks.CreateOrUpdate(ctx, resourceGroupName, privateZoneName, name, link, "", "")
 	if err != nil {
@@ -127,8 +127,8 @@ func (ac *azureClient) CreateOrUpdateLink(ctx context.Context, resourceGroupName
 
 // DeleteLink deletes a virtual network link to the specified Private DNS zone.
 func (ac *azureClient) DeleteLink(ctx context.Context, resourceGroupName, privateZoneName, name string) error {
-	ctx, span := tele.Tracer().Start(ctx, "privatedns.AzureClient.DeleteLink")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.AzureClient.DeleteLink")
+	defer done()
 
 	future, err := ac.vnetlinks.Delete(ctx, resourceGroupName, privateZoneName, name, "")
 	if err != nil {
@@ -144,8 +144,8 @@ func (ac *azureClient) DeleteLink(ctx context.Context, resourceGroupName, privat
 
 // CreateOrUpdateRecordSet creates or updates a record set within the specified Private DNS zone.
 func (ac *azureClient) CreateOrUpdateRecordSet(ctx context.Context, resourceGroupName string, privateZoneName string, recordType privatedns.RecordType, name string, set privatedns.RecordSet) error {
-	ctx, span := tele.Tracer().Start(ctx, "privatedns.AzureClient.CreateOrUpdateRecordSet")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.AzureClient.CreateOrUpdateRecordSet")
+	defer done()
 
 	_, err := ac.recordsets.CreateOrUpdate(ctx, resourceGroupName, privateZoneName, recordType, name, set, "", "")
 	return err
@@ -153,8 +153,8 @@ func (ac *azureClient) CreateOrUpdateRecordSet(ctx context.Context, resourceGrou
 
 // DeleteRecordSet deletes a record set within the specified Private DNS zone.
 func (ac *azureClient) DeleteRecordSet(ctx context.Context, resourceGroupName string, privateZoneName string, recordType privatedns.RecordType, name string) error {
-	ctx, span := tele.Tracer().Start(ctx, "privatedns.AzureClient.DeleteRecordSet")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.AzureClient.DeleteRecordSet")
+	defer done()
 
 	_, err := ac.recordsets.Delete(ctx, resourceGroupName, privateZoneName, recordType, name, "")
 	return err

--- a/azure/services/privatedns/privatedns.go
+++ b/azure/services/privatedns/privatedns.go
@@ -52,8 +52,8 @@ func New(scope Scope) *Service {
 
 // Reconcile creates or updates the private zone, links it to the vnet, and creates DNS records.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "privatedns.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.Service.Reconcile")
+	defer done()
 
 	zoneSpec := s.Scope.PrivateDNSSpec()
 	if zoneSpec != nil {
@@ -112,8 +112,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the private zone.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "privatedns.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.Service.Delete")
+	defer done()
 
 	zoneSpec := s.Scope.PrivateDNSSpec()
 	if zoneSpec != nil {

--- a/azure/services/publicips/client.go
+++ b/azure/services/publicips/client.go
@@ -55,16 +55,16 @@ func newPublicIPAddressesClient(subscriptionID string, baseURI string, authorize
 
 // Get gets the specified public IP address in a specified resource group.
 func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, ipName string) (network.PublicIPAddress, error) {
-	ctx, span := tele.Tracer().Start(ctx, "publicips.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "publicips.AzureClient.Get")
+	defer done()
 
 	return ac.publicips.Get(ctx, resourceGroupName, ipName, "")
 }
 
 // CreateOrUpdate creates or updates a static or dynamic public IP address.
 func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, ipName string, ip network.PublicIPAddress) error {
-	ctx, span := tele.Tracer().Start(ctx, "publicips.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "publicips.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.publicips.CreateOrUpdate(ctx, resourceGroupName, ipName, ip)
 	if err != nil {
@@ -80,8 +80,8 @@ func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName str
 
 // Delete deletes the specified public IP address.
 func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, ipName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "publicips.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "publicips.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.publicips.Delete(ctx, resourceGroupName, ipName)
 	if err != nil {

--- a/azure/services/publicips/publicips.go
+++ b/azure/services/publicips/publicips.go
@@ -54,8 +54,8 @@ func New(scope PublicIPScope) *Service {
 
 // Reconcile gets/creates/updates a public ip.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "publicips.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "publicips.Service.Reconcile")
+	defer done()
 
 	for _, ip := range s.Scope.PublicIPSpecs() {
 		s.Scope.V(2).Info("creating public IP", "public ip", ip.Name)
@@ -109,8 +109,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the public IP with the provided scope.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "publicips.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "publicips.Service.Delete")
+	defer done()
 
 	for _, ip := range s.Scope.PublicIPSpecs() {
 		managed, err := s.isIPManaged(ctx, ip.Name)

--- a/azure/services/resourceskus/cache.go
+++ b/azure/services/resourceskus/cache.go
@@ -102,8 +102,8 @@ func NewStaticCache(data []compute.ResourceSku, location string) *Cache {
 }
 
 func (c *Cache) refresh(ctx context.Context, location string) error {
-	ctx, span := tele.Tracer().Start(ctx, "resourceskus.Cache.refresh")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "resourceskus.Cache.refresh")
+	defer done()
 
 	data, err := c.client.List(ctx, fmt.Sprintf("location eq '%s'", location))
 	if err != nil {
@@ -121,8 +121,8 @@ func (c *Cache) refresh(ctx context.Context, location string) error {
 // supported in region), which is why it returns an error and not a
 // boolean.
 func (c *Cache) Get(ctx context.Context, name string, kind ResourceType) (SKU, error) {
-	ctx, span := tele.Tracer().Start(ctx, "resourceskus.Cache.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "resourceskus.Cache.Get")
+	defer done()
 
 	if c.data == nil {
 		if err := c.refresh(ctx, c.location); err != nil {
@@ -140,8 +140,8 @@ func (c *Cache) Get(ctx context.Context, name string, kind ResourceType) (SKU, e
 
 // Map invokes a function over all cached values.
 func (c *Cache) Map(ctx context.Context, mapFn func(sku SKU)) error {
-	ctx, span := tele.Tracer().Start(ctx, "resourceskus.Cache.Map")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "resourceskus.Cache.Map")
+	defer done()
 
 	if c.data == nil {
 		if err := c.refresh(ctx, c.location); err != nil {
@@ -161,8 +161,8 @@ func (c *Cache) Map(ctx context.Context, mapFn func(sku SKU)) error {
 // set of zones into which some machine size may deploy. It removes
 // restricted virtual machine sizes and duplicates.
 func (c *Cache) GetZones(ctx context.Context, location string) ([]string, error) {
-	ctx, span := tele.Tracer().Start(ctx, "resourceskus.Cache.GetZones")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "resourceskus.Cache.GetZones")
+	defer done()
 
 	var allZones = make(map[string]bool)
 	mapFn := func(sku SKU) {
@@ -223,8 +223,8 @@ func (c *Cache) GetZones(ctx context.Context, location string) ([]string, error)
 
 // GetZonesWithVMSize returns available zones for a virtual machine size in the given location.
 func (c *Cache) GetZonesWithVMSize(ctx context.Context, size, location string) ([]string, error) {
-	ctx, span := tele.Tracer().Start(ctx, "resourceskus.Cache.GetZonesWithVMSize")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "resourceskus.Cache.GetZonesWithVMSize")
+	defer done()
 
 	var allZones = make(map[string]bool)
 	mapFn := func(sku SKU) {

--- a/azure/services/resourceskus/client.go
+++ b/azure/services/resourceskus/client.go
@@ -55,8 +55,8 @@ func newResourceSkusClient(subscriptionID string, baseURI string, authorizer aut
 
 // List returns all Resource SKUs available to the subscription.
 func (ac *AzureClient) List(ctx context.Context, filter string) ([]compute.ResourceSku, error) {
-	ctx, span := tele.Tracer().Start(ctx, "resourceskus.AzureClient.List")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "resourceskus.AzureClient.List")
+	defer done()
 
 	iter, err := ac.skus.ListComplete(ctx, filter)
 	if err != nil {

--- a/azure/services/roleassignments/client.go
+++ b/azure/services/roleassignments/client.go
@@ -61,8 +61,8 @@ func newRoleAssignmentClient(subscriptionID string, baseURI string, authorizer a
 // roleAssignmentName - the name of the role assignment to create. It can be any valid GUID.
 // parameters - parameters for the role assignment.
 func (ac *azureClient) Create(ctx context.Context, scope string, roleAssignmentName string, parameters authorization.RoleAssignmentCreateParameters) (authorization.RoleAssignment, error) {
-	ctx, span := tele.Tracer().Start(ctx, "roleassignments.AzureClient.Create")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.AzureClient.Create")
+	defer done()
 
 	return ac.roleassignments.Create(ctx, scope, roleAssignmentName, parameters)
 }

--- a/azure/services/roleassignments/roleassignments.go
+++ b/azure/services/roleassignments/roleassignments.go
@@ -60,8 +60,8 @@ func New(scope RoleAssignmentScope) *Service {
 
 // Reconcile creates a role assignment.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "roleassignments.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.Service.Reconcile")
+	defer done()
 
 	for _, roleSpec := range s.Scope.RoleAssignmentSpecs() {
 		switch roleSpec.ResourceType {
@@ -78,8 +78,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 }
 
 func (s *Service) reconcileVM(ctx context.Context, roleSpec azure.RoleAssignmentSpec) error {
-	ctx, span := tele.Tracer().Start(ctx, "roleassignments.Service.reconcileVM")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.Service.reconcileVM")
+	defer done()
 
 	resultVM, err := s.virtualMachinesClient.Get(ctx, s.Scope.ResourceGroup(), roleSpec.MachineName)
 	if err != nil {
@@ -97,8 +97,8 @@ func (s *Service) reconcileVM(ctx context.Context, roleSpec azure.RoleAssignment
 }
 
 func (s *Service) reconcileVMSS(ctx context.Context, roleSpec azure.RoleAssignmentSpec) error {
-	ctx, span := tele.Tracer().Start(ctx, "roleassignments.Service.reconcileVMSS")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.Service.reconcileVMSS")
+	defer done()
 
 	resultVMSS, err := s.virtualMachineScaleSetClient.Get(ctx, s.Scope.ResourceGroup(), roleSpec.MachineName)
 	if err != nil {
@@ -116,8 +116,8 @@ func (s *Service) reconcileVMSS(ctx context.Context, roleSpec azure.RoleAssignme
 }
 
 func (s *Service) assignRole(ctx context.Context, roleAssignmentName string, principalID *string) error {
-	ctx, span := tele.Tracer().Start(ctx, "roleassignments.Service.assignRole")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.Service.assignRole")
+	defer done()
 
 	scope := fmt.Sprintf("/subscriptions/%s/", s.Scope.SubscriptionID())
 	// Azure built-in roles https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
@@ -134,8 +134,8 @@ func (s *Service) assignRole(ctx context.Context, roleAssignmentName string, pri
 
 // Delete is a no-op as the role assignments get deleted as part of VM deletion.
 func (s *Service) Delete(ctx context.Context) error {
-	_, span := tele.Tracer().Start(ctx, "roleassignments.Service.Delete")
-	defer span.End()
+	_, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.Service.Delete")
+	defer done()
 
 	return nil
 }

--- a/azure/services/routetables/client.go
+++ b/azure/services/routetables/client.go
@@ -55,16 +55,16 @@ func newRouteTablesClient(subscriptionID string, baseURI string, authorizer auto
 
 // Get gets the specified route table.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, rtName string) (network.RouteTable, error) {
-	ctx, span := tele.Tracer().Start(ctx, "routetables.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.AzureClient.Get")
+	defer done()
 
 	return ac.routetables.Get(ctx, resourceGroupName, rtName, "")
 }
 
 // CreateOrUpdate create or updates a route table in a specified resource group.
 func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, rtName string, rt network.RouteTable) error {
-	ctx, span := tele.Tracer().Start(ctx, "routetables.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.routetables.CreateOrUpdate(ctx, resourceGroupName, rtName, rt)
 	if err != nil {
@@ -80,8 +80,8 @@ func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName str
 
 // Delete deletes the specified route table.
 func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, rtName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "routetables.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.routetables.Delete(ctx, resourceGroupName, rtName)
 	if err != nil {

--- a/azure/services/routetables/routetables.go
+++ b/azure/services/routetables/routetables.go
@@ -53,8 +53,8 @@ func New(scope *scope.ClusterScope) *Service {
 
 // Reconcile gets/creates/updates a route table.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "routetables.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.Service.Reconcile")
+	defer done()
 
 	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping route tables reconcile in custom vnet mode")
@@ -97,8 +97,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the route table with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "routetables.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.Service.Delete")
+	defer done()
 
 	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping route table deletion in custom vnet mode")

--- a/azure/services/scalesets/client.go
+++ b/azure/services/scalesets/client.go
@@ -97,8 +97,8 @@ func newVirtualMachineScaleSetsClient(subscriptionID string, baseURI string, aut
 
 // ListInstances retrieves information about the model views of a virtual machine scale set.
 func (ac *AzureClient) ListInstances(ctx context.Context, resourceGroupName, vmssName string) ([]compute.VirtualMachineScaleSetVM, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.ListInstances")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.ListInstances")
+	defer done()
 
 	itr, err := ac.scalesetvms.ListComplete(ctx, resourceGroupName, vmssName, "", "", "")
 	if err != nil {
@@ -118,8 +118,8 @@ func (ac *AzureClient) ListInstances(ctx context.Context, resourceGroupName, vms
 
 // List returns all scale sets in a resource group.
 func (ac *AzureClient) List(ctx context.Context, resourceGroupName string) ([]compute.VirtualMachineScaleSet, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.List")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.List")
+	defer done()
 
 	itr, err := ac.scalesets.ListComplete(ctx, resourceGroupName)
 	if err != nil {
@@ -139,8 +139,8 @@ func (ac *AzureClient) List(ctx context.Context, resourceGroupName string) ([]co
 
 // Get retrieves information about the model view of a virtual machine scale set.
 func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, vmssName string) (compute.VirtualMachineScaleSet, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.Get")
+	defer done()
 
 	return ac.scalesets.Get(ctx, resourceGroupName, vmssName, "")
 }
@@ -148,8 +148,8 @@ func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, vmssName stri
 // CreateOrUpdateAsync the operation to create or update a virtual machine scale set without waiting for the operation
 // to complete.
 func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, resourceGroupName, vmssName string, vmss compute.VirtualMachineScaleSet) (*infrav1.Future, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.CreateOrUpdateAsync")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.CreateOrUpdateAsync")
+	defer done()
 
 	future, err := ac.scalesets.CreateOrUpdate(ctx, resourceGroupName, vmssName, vmss)
 	if err != nil {
@@ -181,8 +181,8 @@ func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, resourceGroupNam
 //   resourceGroupName - the name of the resource group.
 //   vmssName - the name of the VM scale set to create or update. parameters - the scale set object.
 func (ac *AzureClient) UpdateAsync(ctx context.Context, resourceGroupName, vmssName string, parameters compute.VirtualMachineScaleSetUpdate) (*infrav1.Future, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.UpdateAsync")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.UpdateAsync")
+	defer done()
 
 	future, err := ac.scalesets.Update(ctx, resourceGroupName, vmssName, parameters)
 	if err != nil {
@@ -266,8 +266,8 @@ func (ac *AzureClient) GetResultIfDone(ctx context.Context, future *infrav1.Futu
 
 // UpdateInstances update instances of a VM scale set.
 func (ac *AzureClient) UpdateInstances(ctx context.Context, resourceGroupName, vmssName string, instanceIDs []string) error {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.UpdateInstances")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.UpdateInstances")
+	defer done()
 
 	params := compute.VirtualMachineScaleSetVMInstanceRequiredIDs{
 		InstanceIds: &instanceIDs,
@@ -292,8 +292,8 @@ func (ac *AzureClient) UpdateInstances(ctx context.Context, resourceGroupName, v
 //   resourceGroupName - the name of the resource group.
 //   vmssName - the name of the VM scale set to create or update. parameters - the scale set object.
 func (ac *AzureClient) DeleteAsync(ctx context.Context, resourceGroupName, vmssName string) (*infrav1.Future, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.DeleteAsync")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.DeleteAsync")
+	defer done()
 
 	future, err := ac.scalesets.Delete(ctx, resourceGroupName, vmssName, to.BoolPtr(false))
 	if err != nil {

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -74,8 +74,8 @@ func NewService(scope ScaleSetScope, skuCache *resourceskus.Cache) *Service {
 
 // Reconcile idempotently gets, creates, and updates a scale set.
 func (s *Service) Reconcile(ctx context.Context) (retErr error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.Service.Reconcile")
+	defer done()
 
 	if err := s.validateSpec(ctx); err != nil {
 		// do as much early validation as possible to limit calls to Azure
@@ -150,8 +150,8 @@ func (s *Service) Reconcile(ctx context.Context) (retErr error) {
 // Delete deletes a scale set asynchronously. Delete sends a DELETE request to Azure and if accepted without error,
 // the VMSS will be considered deleted. The actual delete in Azure may take longer, but should eventually complete.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.Service.Delete")
+	defer done()
 
 	var err error
 
@@ -208,8 +208,8 @@ func (s *Service) Delete(ctx context.Context) error {
 }
 
 func (s *Service) createVMSS(ctx context.Context) (*infrav1.Future, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.createVMSS")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.Service.createVMSS")
+	defer done()
 
 	spec := s.Scope.ScaleSetSpec()
 
@@ -229,8 +229,8 @@ func (s *Service) createVMSS(ctx context.Context) (*infrav1.Future, error) {
 }
 
 func (s *Service) patchVMSSIfNeeded(ctx context.Context, infraVMSS *azure.VMSS) (*infrav1.Future, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.patchVMSSIfNeeded")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.Service.patchVMSSIfNeeded")
+	defer done()
 
 	spec := s.Scope.ScaleSetSpec()
 
@@ -284,8 +284,8 @@ func hasModelModifyingDifferences(infraVMSS *azure.VMSS, vmss compute.VirtualMac
 }
 
 func (s *Service) validateSpec(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.validateSpec")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.Service.validateSpec")
+	defer done()
 
 	spec := s.Scope.ScaleSetSpec()
 
@@ -354,8 +354,8 @@ func (s *Service) validateSpec(ctx context.Context) error {
 }
 
 func (s *Service) buildVMSSFromSpec(ctx context.Context, vmssSpec azure.ScaleSetSpec) (compute.VirtualMachineScaleSet, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.buildVMSSFromSpec")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.Service.buildVMSSFromSpec")
+	defer done()
 
 	sku, err := s.resourceSKUCache.Get(ctx, vmssSpec.Size, resourceskus.VirtualMachines)
 	if err != nil {
@@ -507,8 +507,8 @@ func (s *Service) buildVMSSFromSpec(ctx context.Context, vmssSpec azure.ScaleSet
 
 // getVirtualMachineScaleSet provides information about a Virtual Machine Scale Set and its instances.
 func (s *Service) getVirtualMachineScaleSet(ctx context.Context, vmssName string) (*azure.VMSS, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.getVirtualMachineScaleSet")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.Service.getVirtualMachineScaleSet")
+	defer done()
 
 	vmss, err := s.Client.Get(ctx, s.Scope.ResourceGroup(), vmssName)
 	if err != nil {
@@ -525,8 +525,8 @@ func (s *Service) getVirtualMachineScaleSet(ctx context.Context, vmssName string
 
 // getVirtualMachineScaleSetIfDone gets a Virtual Machine Scale Set and its instances from Azure if the future is completed.
 func (s *Service) getVirtualMachineScaleSetIfDone(ctx context.Context, future *infrav1.Future) (*azure.VMSS, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesets.Service.getVirtualMachineScaleSetIfDone")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesets.Service.getVirtualMachineScaleSetIfDone")
+	defer done()
 
 	vmss, err := s.GetResultIfDone(ctx, future)
 	if err != nil {

--- a/azure/services/scalesetvms/client.go
+++ b/azure/services/scalesetvms/client.go
@@ -76,16 +76,16 @@ func newVirtualMachineScaleSetVMsClient(subscriptionID string, baseURI string, a
 
 // Get retrieves the Virtual Machine Scale Set Virtual Machine.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmssName, instanceID string) (compute.VirtualMachineScaleSetVM, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesetvms.azureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.azureClient.Get")
+	defer done()
 
 	return ac.scalesetvms.Get(ctx, resourceGroupName, vmssName, instanceID, "")
 }
 
 // GetResultIfDone fetches the result of a long-running operation future if it is done.
 func (ac *azureClient) GetResultIfDone(ctx context.Context, future *infrav1.Future) (compute.VirtualMachineScaleSetVM, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesetvms.azureClient.GetResultIfDone")
-	defer span.End()
+	ctx, _, spanDone := tele.StartSpanWithLogger(ctx, "scalesetvms.azureClient.GetResultIfDone")
+	defer spanDone()
 
 	var genericFuture genericScaleSetVMFuture
 	futureData, err := base64.URLEncoding.DecodeString(future.Data)
@@ -133,8 +133,8 @@ func (ac *azureClient) GetResultIfDone(ctx context.Context, future *infrav1.Futu
 //   vmssName - the name of the VM scale set to create or update. parameters - the scale set object.
 //   instanceID - the ID of the VM scale set VM.
 func (ac *azureClient) DeleteAsync(ctx context.Context, resourceGroupName, vmssName, instanceID string) (*infrav1.Future, error) {
-	ctx, span := tele.Tracer().Start(ctx, "scalesetvms.azureClient.DeleteAsync")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.azureClient.DeleteAsync")
+	defer done()
 
 	future, err := ac.scalesetvms.Delete(ctx, resourceGroupName, vmssName, instanceID, to.BoolPtr(false))
 	if err != nil {

--- a/azure/services/scalesetvms/scalesetvms.go
+++ b/azure/services/scalesetvms/scalesetvms.go
@@ -59,8 +59,8 @@ func NewService(scope ScaleSetVMScope) *Service {
 
 // Reconcile idempotently gets, creates, and updates a scale set.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scalesetvms.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.Service.Reconcile")
+	defer done()
 
 	var (
 		resourceGroup = s.Scope.ResourceGroup()
@@ -83,8 +83,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes a scaleset instance asynchronously returning a future which encapsulates the long-running operation.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "scalesetvms.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.Service.Delete")
+	defer done()
 
 	var (
 		resourceGroup = s.Scope.ResourceGroup()

--- a/azure/services/securitygroups/client.go
+++ b/azure/services/securitygroups/client.go
@@ -55,16 +55,16 @@ func newSecurityGroupsClient(subscriptionID string, baseURI string, authorizer a
 
 // Get gets the specified network security group.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, sgName string) (network.SecurityGroup, error) {
-	ctx, span := tele.Tracer().Start(ctx, "securitygroups.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "securitygroups.AzureClient.Get")
+	defer done()
 
 	return ac.securitygroups.Get(ctx, resourceGroupName, sgName, "")
 }
 
 // CreateOrUpdate creates or updates a network security group in the specified resource group.
 func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, sgName string, sg network.SecurityGroup) error {
-	ctx, span := tele.Tracer().Start(ctx, "securitygroups.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "securitygroups.AzureClient.CreateOrUpdate")
+	defer done()
 
 	var etag string
 	if sg.Etag != nil {
@@ -95,8 +95,8 @@ func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName str
 
 // Delete deletes the specified network security group.
 func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, sgName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "securitygroups.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "securitygroups.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.securitygroups.Delete(ctx, resourceGroupName, sgName)
 	if err != nil {

--- a/azure/services/securitygroups/securitygroups.go
+++ b/azure/services/securitygroups/securitygroups.go
@@ -54,8 +54,8 @@ func New(scope NSGScope) *Service {
 
 // Reconcile gets/creates/updates a network security group.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "securitygroups.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "securitygroups.Service.Reconcile")
+	defer done()
 
 	if !s.Scope.IsVnetManaged() {
 		s.Scope.V(4).Info("Skipping network security group reconcile in custom VNet mode")
@@ -137,8 +137,8 @@ func ruleExists(rules []network.SecurityRule, rule network.SecurityRule) bool {
 
 // Delete deletes the network security group with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "securitygroups.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "securitygroups.Service.Delete")
+	defer done()
 
 	if !s.Scope.IsVnetManaged() {
 		s.Scope.V(4).Info("Skipping network security group delete in custom VNet mode")

--- a/azure/services/subnets/client.go
+++ b/azure/services/subnets/client.go
@@ -55,16 +55,16 @@ func newSubnetsClient(subscriptionID string, baseURI string, authorizer autorest
 
 // Get gets the specified subnet by virtual network and resource group.
 func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, vnetName, snName string) (network.Subnet, error) {
-	ctx, span := tele.Tracer().Start(ctx, "subnets.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "subnets.AzureClient.Get")
+	defer done()
 
 	return ac.subnets.Get(ctx, resourceGroupName, vnetName, snName, "")
 }
 
 // CreateOrUpdate creates or updates a subnet in the specified virtual network.
 func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vnetName, snName string, sn network.Subnet) error {
-	ctx, span := tele.Tracer().Start(ctx, "subnets.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "subnets.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.subnets.CreateOrUpdate(ctx, resourceGroupName, vnetName, snName, sn)
 	if err != nil {
@@ -80,8 +80,8 @@ func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vn
 
 // Delete deletes the specified subnet.
 func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, vnetName, snName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "subnets.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "subnets.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.subnets.Delete(ctx, resourceGroupName, vnetName, snName)
 	if err != nil {

--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -53,8 +53,8 @@ func New(scope SubnetScope) *Service {
 
 // Reconcile gets/creates/updates a subnet.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "subnets.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "subnets.Service.Reconcile")
+	defer done()
 
 	for _, subnetSpec := range s.Scope.SubnetSpecs() {
 		existingSubnet, err := s.getExisting(ctx, s.Scope.Vnet().ResourceGroup, subnetSpec)
@@ -122,8 +122,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the subnet with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "subnets.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "subnets.Service.Delete")
+	defer done()
 
 	for _, subnetSpec := range s.Scope.SubnetSpecs() {
 		if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
@@ -147,8 +147,8 @@ func (s *Service) Delete(ctx context.Context) error {
 
 // getExisting provides information about an existing subnet.
 func (s *Service) getExisting(ctx context.Context, rgName string, spec azure.SubnetSpec) (*infrav1.SubnetSpec, error) {
-	ctx, span := tele.Tracer().Start(ctx, "subnets.Service.getExisting")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "subnets.Service.getExisting")
+	defer done()
 
 	subnet, err := s.Client.Get(ctx, rgName, spec.VNetName, spec.Name)
 	if err != nil {

--- a/azure/services/tags/client.go
+++ b/azure/services/tags/client.go
@@ -54,16 +54,16 @@ func newTagsClient(subscriptionID string, baseURI string, authorizer autorest.Au
 
 // GetAtScope sends the get at scope request.
 func (ac *azureClient) GetAtScope(ctx context.Context, scope string) (resources.TagsResource, error) {
-	ctx, span := tele.Tracer().Start(ctx, "tags.AzureClient.GetAtScope")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "tags.AzureClient.GetAtScope")
+	defer done()
 
 	return ac.tags.GetAtScope(ctx, scope)
 }
 
 // CreateOrUpdateAtScope allows adding or replacing the entire set of tags on the specified resource or subscription.
 func (ac *azureClient) CreateOrUpdateAtScope(ctx context.Context, scope string, parameters resources.TagsResource) (resources.TagsResource, error) {
-	ctx, span := tele.Tracer().Start(ctx, "tags.AzureClient.CreateOrUpdateAtScope")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "tags.AzureClient.CreateOrUpdateAtScope")
+	defer done()
 
 	return ac.tags.CreateOrUpdateAtScope(ctx, scope, parameters)
 }

--- a/azure/services/tags/tags.go
+++ b/azure/services/tags/tags.go
@@ -53,8 +53,8 @@ func New(scope TagScope) *Service {
 
 // Reconcile ensures tags are correct.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "tags.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "tags.Service.Reconcile")
+	defer done()
 
 	for _, tagsSpec := range s.Scope.TagsSpecs() {
 		annotation, err := s.Scope.AnnotationJSON(tagsSpec.Annotation)
@@ -96,8 +96,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete is a no-op as the tags get deleted as part of VM deletion.
 func (s *Service) Delete(ctx context.Context) error {
-	_, span := tele.Tracer().Start(ctx, "tags.Service.Delete")
-	defer span.End()
+	_, _, done := tele.StartSpanWithLogger(ctx, "tags.Service.Delete")
+	defer done()
 
 	return nil
 }

--- a/azure/services/virtualmachines/client.go
+++ b/azure/services/virtualmachines/client.go
@@ -56,16 +56,16 @@ func newVirtualMachinesClient(subscriptionID string, baseURI string, authorizer 
 
 // Get retrieves information about the model view or the instance view of a virtual machine.
 func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, vmName string) (compute.VirtualMachine, error) {
-	ctx, span := tele.Tracer().Start(ctx, "virtualmachines.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.Get")
+	defer done()
 
 	return ac.virtualmachines.Get(ctx, resourceGroupName, vmName, "")
 }
 
 // CreateOrUpdate the operation to create or update a virtual machine.
 func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vmName string, vm compute.VirtualMachine) error {
-	ctx, span := tele.Tracer().Start(ctx, "virtualmachines.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.virtualmachines.CreateOrUpdate(ctx, resourceGroupName, vmName, vm)
 	if err != nil {
@@ -81,8 +81,8 @@ func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vm
 
 // Delete the operation to delete a virtual machine.
 func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, vmName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "virtualmachines.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.Delete")
+	defer done()
 
 	// TODO: pass variable to force the deletion or not
 	// now we are not forcing.

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -79,8 +79,8 @@ func New(scope VMScope, skuCache *resourceskus.Cache) *Service {
 
 // Reconcile gets/creates/updates a virtual machine.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "virtualmachines.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.Service.Reconcile")
+	defer done()
 
 	vmSpec := s.Scope.VMSpec()
 	existingVM, err := s.getExisting(ctx, vmSpec.Name)
@@ -213,8 +213,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the virtual machine with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "virtualmachines.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.Service.Delete")
+	defer done()
 
 	vmSpec := s.Scope.VMSpec()
 	s.Scope.V(2).Info("deleting VM", "vm", vmSpec.Name)
@@ -233,8 +233,8 @@ func (s *Service) Delete(ctx context.Context) error {
 
 // getExisting provides information about a virtual machine.
 func (s *Service) getExisting(ctx context.Context, name string) (*infrav1.VM, error) {
-	ctx, span := tele.Tracer().Start(ctx, "virtualmachines.Service.getExisting")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.Service.getExisting")
+	defer done()
 
 	vm, err := s.Client.Get(ctx, s.Scope.ResourceGroup(), name)
 	if err != nil {
@@ -287,8 +287,8 @@ func (s *Service) generateImagePlan() *compute.Plan {
 }
 
 func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine) ([]corev1.NodeAddress, error) {
-	ctx, span := tele.Tracer().Start(ctx, "virtualmachines.Service.getAddresses")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.Service.getAddresses")
+	defer done()
 
 	addresses := []corev1.NodeAddress{}
 
@@ -342,8 +342,8 @@ func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine) (
 
 // getPublicIPAddress will fetch a public ip address resource by name and return a nodeaddresss representation.
 func (s *Service) getPublicIPAddress(ctx context.Context, publicIPAddressName string) (corev1.NodeAddress, error) {
-	ctx, span := tele.Tracer().Start(ctx, "virtualmachines.Service.getPublicIPAddress")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.Service.getPublicIPAddress")
+	defer done()
 
 	retAddress := corev1.NodeAddress{}
 	publicIP, err := s.publicIPsClient.Get(ctx, s.Scope.ResourceGroup(), publicIPAddressName)
@@ -358,8 +358,8 @@ func (s *Service) getPublicIPAddress(ctx context.Context, publicIPAddressName st
 
 // generateStorageProfile generates a pointer to a compute.StorageProfile which can utilized for VM creation.
 func (s *Service) generateStorageProfile(ctx context.Context, vmSpec azure.VMSpec, sku resourceskus.SKU) (*compute.StorageProfile, error) {
-	_, span := tele.Tracer().Start(ctx, "virtualmachines.Service.generateStorageProfile")
-	defer span.End()
+	_, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.Service.generateStorageProfile")
+	defer done()
 
 	storageProfile := &compute.StorageProfile{
 		OsDisk: &compute.OSDisk{

--- a/azure/services/virtualnetworks/client.go
+++ b/azure/services/virtualnetworks/client.go
@@ -58,16 +58,16 @@ func newVirtualNetworksClient(subscriptionID string, baseURI string, authorizer 
 
 // Get gets the specified virtual network by resource group.
 func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, vnetName string) (network.VirtualNetwork, error) {
-	ctx, span := tele.Tracer().Start(ctx, "virtualnetworks.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.AzureClient.Get")
+	defer done()
 
 	return ac.virtualnetworks.Get(ctx, resourceGroupName, vnetName, "")
 }
 
 // CreateOrUpdate creates or updates a virtual network in the specified resource group.
 func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vnetName string, vn network.VirtualNetwork) error {
-	ctx, span := tele.Tracer().Start(ctx, "virtualnetworks.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.AzureClient.CreateOrUpdate")
+	defer done()
 
 	future, err := ac.virtualnetworks.CreateOrUpdate(ctx, resourceGroupName, vnetName, vn)
 	if err != nil {
@@ -83,8 +83,8 @@ func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vn
 
 // Delete deletes the specified virtual network.
 func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, vnetName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "virtualnetworks.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.virtualnetworks.Delete(ctx, resourceGroupName, vnetName)
 	if err != nil {
@@ -100,8 +100,8 @@ func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, vnetName s
 
 // CheckIPAddressAvailability checks whether a private IP address is available for use.
 func (ac *AzureClient) CheckIPAddressAvailability(ctx context.Context, resourceGroupName, vnetName, ip string) (network.IPAddressAvailabilityResult, error) {
-	ctx, span := tele.Tracer().Start(ctx, "virtualnetworks.AzureClient.CheckIPAddressAvailability")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.AzureClient.CheckIPAddressAvailability")
+	defer done()
 
 	return ac.virtualnetworks.CheckIPAddressAvailability(ctx, resourceGroupName, vnetName, ip)
 }

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -54,8 +54,8 @@ func New(scope VNetScope) *Service {
 
 // Reconcile gets/creates/updates a virtual network.
 func (s *Service) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "virtualnetworks.Service.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.Service.Reconcile")
+	defer done()
 
 	// Following should be created upstream and provided as an input to NewService
 	// A VNet has following dependencies
@@ -109,8 +109,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 // Delete deletes the virtual network with the provided name.
 func (s *Service) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "virtualnetworks.Service.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.Service.Delete")
+	defer done()
 
 	vnetSpec := s.Scope.VNetSpec()
 	existingVnet, err := s.getExisting(ctx, vnetSpec)
@@ -141,8 +141,8 @@ func (s *Service) Delete(ctx context.Context) error {
 
 // getExisting provides information about an existing virtual network.
 func (s *Service) getExisting(ctx context.Context, spec azure.VNetSpec) (*infrav1.VnetSpec, error) {
-	ctx, span := tele.Tracer().Start(ctx, "virtualnetworks.Service.getExisting")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualnetworks.Service.getExisting")
+	defer done()
 
 	vnet, err := s.Client.Get(ctx, spec.ResourceGroup, spec.Name)
 	if err != nil {

--- a/azure/services/vmextensions/client.go
+++ b/azure/services/vmextensions/client.go
@@ -54,16 +54,16 @@ func newVirtualMachineExtensionsClient(subscriptionID string, baseURI string, au
 
 // Get the virtual machine extension.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmName, name string) (compute.VirtualMachineExtension, error) {
-	ctx, span := tele.Tracer().Start(ctx, "vmextensions.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "vmextensions.AzureClient.Get")
+	defer done()
 
 	return ac.vmextensions.Get(ctx, resourceGroupName, vmName, name, "")
 }
 
 // CreateOrUpdateAsync creates or updates the virtual machine extension.
 func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, resourceGroupName, vmName, name string, parameters compute.VirtualMachineExtension) error {
-	ctx, span := tele.Tracer().Start(ctx, "vmextensions.AzureClient.CreateOrUpdate")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "vmextensions.AzureClient.CreateOrUpdate")
+	defer done()
 
 	_, err := ac.vmextensions.CreateOrUpdate(ctx, resourceGroupName, vmName, name, parameters)
 	return err
@@ -71,8 +71,8 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, resourceGroupNam
 
 // Delete removes the virtual machine extension.
 func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, vmName, name string) error {
-	ctx, span := tele.Tracer().Start(ctx, "vmextensions.AzureClient.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "vmextensions.AzureClient.Delete")
+	defer done()
 
 	future, err := ac.vmextensions.Delete(ctx, resourceGroupName, vmName, name)
 	if err != nil {

--- a/azure/services/vmextensions/vmextensions.go
+++ b/azure/services/vmextensions/vmextensions.go
@@ -51,8 +51,8 @@ func New(scope VMExtensionScope) *Service {
 
 // Reconcile creates or updates the VM extension.
 func (s *Service) Reconcile(ctx context.Context) error {
-	_, span := tele.Tracer().Start(ctx, "vmextensions.Service.Reconcile")
-	defer span.End()
+	_, _, done := tele.StartSpanWithLogger(ctx, "vmextensions.Service.Reconcile")
+	defer done()
 
 	for _, extensionSpec := range s.Scope.VMExtensionSpecs() {
 		if existing, err := s.client.Get(ctx, s.Scope.ResourceGroup(), extensionSpec.VMName, extensionSpec.Name); err == nil {

--- a/azure/services/vmssextensions/client.go
+++ b/azure/services/vmssextensions/client.go
@@ -52,8 +52,8 @@ func newVirtualMachineScaleSetExtensionsClient(subscriptionID string, baseURI st
 
 // Get creates or updates the virtual machine scale set extension.
 func (ac *azureClient) Get(ctx context.Context, resourceGroupName, vmssName, name string) (compute.VirtualMachineScaleSetExtension, error) {
-	ctx, span := tele.Tracer().Start(ctx, "vmssextensions.AzureClient.Get")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "vmssextensions.AzureClient.Get")
+	defer done()
 
 	return ac.vmssextensions.Get(ctx, resourceGroupName, vmssName, name, "")
 }

--- a/azure/services/vmssextensions/vmssextensions.go
+++ b/azure/services/vmssextensions/vmssextensions.go
@@ -50,8 +50,8 @@ func New(scope VMSSExtensionScope) *Service {
 
 // Reconcile creates or updates the VMSS extension.
 func (s *Service) Reconcile(ctx context.Context) error {
-	_, span := tele.Tracer().Start(ctx, "vmssextensions.Service.Reconcile")
-	defer span.End()
+	_, _, done := tele.StartSpanWithLogger(ctx, "vmssextensions.Service.Reconcile")
+	defer done()
 
 	for _, extensionSpec := range s.Scope.VMSSExtensionSpecs() {
 		if existing, err := s.client.Get(ctx, s.Scope.ResourceGroup(), extensionSpec.VMName, extensionSpec.Name); err == nil {

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/go-logr/logr"
@@ -77,8 +75,8 @@ func NewAzureClusterReconciler(client client.Client, log logr.Logger, recorder r
 
 // SetupWithManager initializes this controller with a manager.
 func (acr *AzureClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options Options) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureClusterReconciler.SetupWithManager")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureClusterReconciler.SetupWithManager")
+	defer done()
 
 	log := acr.Log.WithValues("controller", "AzureCluster")
 	var r reconcile.Reconciler = acr
@@ -121,13 +119,14 @@ func (acr *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	defer cancel()
 	log := acr.Log.WithValues("namespace", req.Namespace, "azureCluster", req.Name)
 
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureClusterReconciler.Reconcile",
-		trace.WithAttributes(
-			attribute.String("namespace", req.Namespace),
-			attribute.String("name", req.Name),
-			attribute.String("kind", "AzureCluster"),
-		))
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(
+		ctx,
+		"controllers.AzureClusterReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", "AzureCluster"),
+	)
+	defer done()
 
 	// Fetch the AzureCluster instance
 	azureCluster := &infrav1.AzureCluster{}
@@ -205,8 +204,8 @@ func (acr *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func (acr *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureClusterReconciler.reconcileNormal")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureClusterReconciler.reconcileNormal")
+	defer done()
 
 	clusterScope.Info("Reconciling AzureCluster")
 	azureCluster := clusterScope.AzureCluster
@@ -243,8 +242,8 @@ func (acr *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 }
 
 func (acr *AzureClusterReconciler) reconcileDelete(ctx context.Context, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureClusterReconciler.reconcileDelete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureClusterReconciler.reconcileDelete")
+	defer done()
 
 	clusterScope.Info("Reconciling AzureCluster delete")
 

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -81,8 +81,8 @@ var _ azure.Reconciler = (*azureClusterService)(nil)
 
 // Reconcile reconciles all the services in a predetermined order.
 func (s *azureClusterService) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureClusterService.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureClusterService.Reconcile")
+	defer done()
 
 	if err := s.setFailureDomainsForLocation(ctx); err != nil {
 		return errors.Wrap(err, "failed to get availability zones")
@@ -136,8 +136,8 @@ func (s *azureClusterService) Reconcile(ctx context.Context) error {
 
 // Delete reconciles all the services in a predetermined order.
 func (s *azureClusterService) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureClusterService.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureClusterService.Delete")
+	defer done()
 
 	if err := s.groupsSvc.Delete(ctx); err != nil {
 		if errors.Is(err, azure.ErrNotOwned) {

--- a/controllers/azureidentity_controller.go
+++ b/controllers/azureidentity_controller.go
@@ -27,8 +27,6 @@ import (
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
@@ -103,13 +101,12 @@ func (r *AzureIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	defer cancel()
 	log := r.Log.WithValues("namespace", req.Namespace, "identityOwner", req.Name)
 
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureIdentityReconciler.Reconcile",
-		trace.WithAttributes(
-			attribute.String("namespace", req.Namespace),
-			attribute.String("name", req.Name),
-			attribute.String("kind", "AzureCluster"),
-		))
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureIdentityReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", "AzureCluster"),
+	)
+	defer done()
 
 	// identityOwner is the resource that created the identity. This could be either an AzureCluster or AzureManagedControlPlane (if AKS is enabled).
 	// check for AzureCluster first and if it is not found, check for AzureManagedControlPlane.

--- a/controllers/azurejson_machine_controller.go
+++ b/controllers/azurejson_machine_controller.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,15 +100,17 @@ func (f filterUnclonedMachinesPredicate) Generic(e event.GenericEvent) bool {
 func (r *AzureJSONMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()
-	log := r.Log.WithValues("namespace", req.Namespace, "azureMachine", req.Name)
 
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureJSONMachineReconciler.Reconcile",
-		trace.WithAttributes(
-			attribute.String("namespace", req.Namespace),
-			attribute.String("name", req.Name),
-			attribute.String("kind", "AzureMachine"),
-		))
-	defer span.End()
+	ctx, log, done := tele.StartSpanWithLogger(
+		ctx,
+		"controllers.AzureJSONMachineReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", "AzureMachine"),
+	)
+	defer done()
+
+	log = log.WithValues("namespace", req.Namespace, "azureMachine", req.Name)
 
 	// Fetch the AzureMachine instance
 	azureMachine := &infrav1.AzureMachine{}

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -77,8 +77,8 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 
 // Reconcile reconciles all the services in a predetermined order.
 func (s *azureMachineService) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureMachineService.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureMachineService.Reconcile")
+	defer done()
 
 	if err := s.scope.SetSubnetName(); err != nil {
 		return errors.Wrap(err, "failed defaulting subnet name")
@@ -121,8 +121,8 @@ func (s *azureMachineService) Reconcile(ctx context.Context) error {
 
 // Delete deletes all the services in a predetermined order.
 func (s *azureMachineService) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureMachineService.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureMachineService.Delete")
+	defer done()
 
 	if err := s.virtualMachinesSvc.Delete(ctx); err != nil {
 		return errors.Wrap(err, "failed to delete machine")

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -433,8 +433,8 @@ func toCloudProviderBackOffConfig(source infrav1.BackOffConfig) BackOffConfig {
 }
 
 func reconcileAzureSecret(ctx context.Context, log logr.Logger, kubeclient client.Client, owner metav1.OwnerReference, new *corev1.Secret, clusterName string) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.reconcileAzureSecret")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.reconcileAzureSecret")
+	defer done()
 
 	// Fetch previous secret, if it exists
 	key := types.NamespacedName{
@@ -498,8 +498,8 @@ func reconcileAzureSecret(ctx context.Context, log logr.Logger, kubeclient clien
 
 // GetOwnerMachinePool returns the MachinePool object owning the current resource.
 func GetOwnerMachinePool(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*capiv1exp.MachinePool, error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.GetOwnerMachinePool")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.GetOwnerMachinePool")
+	defer done()
 
 	for _, ref := range obj.OwnerReferences {
 		if ref.Kind != "MachinePool" {
@@ -519,8 +519,8 @@ func GetOwnerMachinePool(ctx context.Context, c client.Client, obj metav1.Object
 
 // GetOwnerAzureMachinePool returns the AzureMachinePool object owning the current resource.
 func GetOwnerAzureMachinePool(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*infrav1exp.AzureMachinePool, error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.GetOwnerAzureMachinePool")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.GetOwnerAzureMachinePool")
+	defer done()
 
 	for _, ref := range obj.OwnerReferences {
 		if ref.Kind != "AzureMachinePool" {
@@ -541,8 +541,8 @@ func GetOwnerAzureMachinePool(ctx context.Context, c client.Client, obj metav1.O
 
 // GetMachinePoolByName finds and return a MachinePool object using the specified params.
 func GetMachinePoolByName(ctx context.Context, c client.Client, namespace, name string) (*capiv1exp.MachinePool, error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.GetMachinePoolByName")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.GetMachinePoolByName")
+	defer done()
 
 	m := &capiv1exp.MachinePool{}
 	key := client.ObjectKey{Name: name, Namespace: namespace}
@@ -554,8 +554,8 @@ func GetMachinePoolByName(ctx context.Context, c client.Client, namespace, name 
 
 // GetAzureMachinePoolByName finds and return an AzureMachinePool object using the specified params.
 func GetAzureMachinePoolByName(ctx context.Context, c client.Client, namespace, name string) (*infrav1exp.AzureMachinePool, error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.GetAzureMachinePoolByName")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.GetAzureMachinePoolByName")
+	defer done()
 
 	m := &infrav1exp.AzureMachinePool{}
 	key := client.ObjectKey{Name: name, Namespace: namespace}
@@ -568,8 +568,8 @@ func GetAzureMachinePoolByName(ctx context.Context, c client.Client, namespace, 
 // ShouldDeleteIndividualResources returns false if the resource group is managed and the whole cluster is being deleted
 // meaning that we can rely on a single resource group delete operation as opposed to deleting every individual VM resource.
 func ShouldDeleteIndividualResources(ctx context.Context, clusterScope *scope.ClusterScope) bool {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.ShouldDeleteIndividualResources")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.ShouldDeleteIndividualResources")
+	defer done()
 
 	if clusterScope.Cluster.DeletionTimestamp.IsZero() {
 		return true

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,8 +86,8 @@ func NewAzureMachinePoolReconciler(client client.Client, log logr.Logger, record
 
 // SetupWithManager initializes this controller with a manager.
 func (ampr *AzureMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options infracontroller.Options) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureMachinePoolReconciler.SetupWithManager")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureMachinePoolReconciler.SetupWithManager")
+	defer done()
 
 	log := ampr.Log.WithValues("controller", "AzureMachinePool")
 	var r reconcile.Reconciler = ampr
@@ -160,19 +158,18 @@ func (ampr *AzureMachinePoolReconciler) SetupWithManager(ctx context.Context, mg
 
 // Reconcile idempotently gets, creates, and updates a machine pool.
 func (ampr *AzureMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	ctx, logger, done := tele.StartSpanWithLogger(
+		ctx,
+		"controllers.AzureMachinePoolReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", "AzureMachinePool"),
+	)
+	defer done()
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(ampr.ReconcileTimeout))
 	defer cancel()
 
-	logger := ampr.Log.WithValues("namespace", req.Namespace, "azureMachinePool", req.Name)
-
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureMachinePoolReconciler.Reconcile",
-		trace.WithAttributes(
-			attribute.String("namespace", req.Namespace),
-			attribute.String("name", req.Name),
-			attribute.String("kind", "AzureMachinePool"),
-		),
-	)
-	defer span.End()
+	logger = logger.WithValues("namespace", req.Namespace, "azureMachinePool", req.Name)
 
 	azMachinePool := &infrav1exp.AzureMachinePool{}
 	err := ampr.Get(ctx, req.NamespacedName, azMachinePool)
@@ -262,8 +259,8 @@ func (ampr *AzureMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.
 }
 
 func (ampr *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, machinePoolScope *scope.MachinePoolScope, clusterScope *scope.ClusterScope) (_ reconcile.Result, reterr error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureMachinePoolReconciler.reconcileNormal")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureMachinePoolReconciler.reconcileNormal")
+	defer done()
 
 	machinePoolScope.Info("Reconciling AzureMachinePool")
 	// If the AzureMachine is in an error state, return early.
@@ -340,8 +337,8 @@ func (ampr *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, mac
 }
 
 func (ampr *AzureMachinePoolReconciler) reconcileDelete(ctx context.Context, machinePoolScope *scope.MachinePoolScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureMachinePoolReconciler.reconcileDelete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureMachinePoolReconciler.reconcileDelete")
+	defer done()
 
 	machinePoolScope.V(2).Info("handling deleted AzureMachinePool")
 

--- a/exp/controllers/azuremachinepool_reconciler.go
+++ b/exp/controllers/azuremachinepool_reconciler.go
@@ -59,8 +59,8 @@ func newAzureMachinePoolService(machinePoolScope *scope.MachinePoolScope) (*azur
 
 // Reconcile reconciles all the services in pre determined order.
 func (s *azureMachinePoolService) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureMachinePoolService.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureMachinePoolService.Reconcile")
+	defer done()
 
 	if err := s.scope.SetSubnetName(); err != nil {
 		return errors.Wrap(err, "failed defaulting subnet name")
@@ -83,8 +83,8 @@ func (s *azureMachinePoolService) Reconcile(ctx context.Context) error {
 
 // Delete reconciles all the services in pre determined order.
 func (s *azureMachinePoolService) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureMachinePoolService.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureMachinePoolService.Delete")
+	defer done()
 
 	if err := s.virtualMachinesScaleSetSvc.Delete(ctx); err != nil {
 		return errors.Wrap(err, "failed to delete scale set")

--- a/exp/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/exp/controllers/azuremanagedcontrolplane_reconciler.go
@@ -57,8 +57,8 @@ func newAzureManagedControlPlaneReconciler(scope *scope.ManagedControlPlaneScope
 
 // Reconcile reconciles all the services in a predetermined order.
 func (r *azureManagedControlPlaneService) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureManagedControlPlaneService.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedControlPlaneService.Reconcile")
+	defer done()
 
 	if err := r.groupsSvc.Reconcile(ctx); err != nil {
 		return errors.Wrap(err, "failed to reconcile managed cluster resource group")
@@ -86,8 +86,8 @@ func (r *azureManagedControlPlaneService) Reconcile(ctx context.Context) error {
 
 // Delete reconciles all the services in a predetermined order.
 func (r *azureManagedControlPlaneService) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureManagedControlPlaneService.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedControlPlaneService.Delete")
+	defer done()
 
 	if err := r.managedClustersSvc.Delete(ctx); err != nil {
 		return errors.Wrapf(err, "failed to delete managed cluster")
@@ -105,8 +105,8 @@ func (r *azureManagedControlPlaneService) Delete(ctx context.Context) error {
 }
 
 func (r *azureManagedControlPlaneService) reconcileKubeconfig(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureManagedControlPlaneService.reconcileKubeconfig")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedControlPlaneService.reconcileKubeconfig")
+	defer done()
 
 	kubeConfigData := r.scope.GetKubeConfigData()
 	if kubeConfigData == nil {

--- a/exp/controllers/azuremanagedmachinepool_controller.go
+++ b/exp/controllers/azuremanagedmachinepool_controller.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
@@ -76,8 +74,8 @@ func NewAzureManagedMachinePoolReconciler(client client.Client, log logr.Logger,
 
 // SetupWithManager initializes this controller with a manager.
 func (ammpr *AzureManagedMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options infracontroller.Options) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureManagedMachinePoolReconciler.SetupWithManager")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureManagedMachinePoolReconciler.SetupWithManager")
+	defer done()
 
 	log := ammpr.Log.WithValues("controller", "AzureManagedMachinePool")
 	var r reconcile.Reconciler = ammpr
@@ -135,13 +133,12 @@ func (ammpr *AzureManagedMachinePoolReconciler) Reconcile(ctx context.Context, r
 	defer cancel()
 	log := ammpr.Log.WithValues("namespace", req.Namespace, "azureManagedMachinePool", req.Name)
 
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureManagedMachinePoolReconciler.Reconcile",
-		trace.WithAttributes(
-			attribute.String("namespace", req.Namespace),
-			attribute.String("name", req.Name),
-			attribute.String("kind", "AzureManagedMachinePool"),
-		))
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureManagedMachinePoolReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", "AzureManagedMachinePool"),
+	)
+	defer done()
 
 	// Fetch the AzureManagedMachinePool instance
 	infraPool := &infrav1exp.AzureManagedMachinePool{}
@@ -230,8 +227,8 @@ func (ammpr *AzureManagedMachinePoolReconciler) Reconcile(ctx context.Context, r
 }
 
 func (ammpr *AzureManagedMachinePoolReconciler) reconcileNormal(ctx context.Context, scope *scope.ManagedControlPlaneScope) (reconcile.Result, error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureManagedMachinePoolReconciler.reconcileNormal")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureManagedMachinePoolReconciler.reconcileNormal")
+	defer done()
 
 	scope.Logger.Info("Reconciling AzureManagedMachinePool")
 
@@ -259,8 +256,8 @@ func (ammpr *AzureManagedMachinePoolReconciler) reconcileNormal(ctx context.Cont
 }
 
 func (ammpr *AzureManagedMachinePoolReconciler) reconcileDelete(ctx context.Context, scope *scope.ManagedControlPlaneScope) (reconcile.Result, error) {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.AzureManagedMachinePoolReconciler.reconcileDelete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.AzureManagedMachinePoolReconciler.reconcileDelete")
+	defer done()
 
 	scope.Logger.Info("Reconciling AzureManagedMachinePool delete")
 

--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -87,8 +87,8 @@ func newAzureManagedMachinePoolService(scope *scope.ManagedControlPlaneScope) *a
 
 // Reconcile reconciles all the services in a predetermined order.
 func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureManagedMachinePoolService.Reconcile")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedMachinePoolService.Reconcile")
+	defer done()
 
 	s.scope.Info("reconciling machine pool")
 	agentPoolName := s.scope.AgentPoolSpec().Name
@@ -136,8 +136,8 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context) error {
 
 // Delete reconciles all the services in a predetermined order.
 func (s *azureManagedMachinePoolService) Delete(ctx context.Context) error {
-	ctx, span := tele.Tracer().Start(ctx, "controllers.azureManagedMachinePoolService.Delete")
-	defer span.End()
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureManagedMachinePoolService.Delete")
+	defer done()
 
 	if err := s.agentPoolsSvc.Delete(ctx); err != nil {
 		return errors.Wrapf(err, "failed to delete machine pool %s", s.scope.AgentPoolSpec().Name)

--- a/util/tele/composite_logger.go
+++ b/util/tele/composite_logger.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tele
+
+import (
+	"github.com/go-logr/logr"
+)
+
+type compositeLogger struct {
+	loggers []logr.Logger
+}
+
+func (c *compositeLogger) Enabled() bool {
+	for _, l := range c.loggers {
+		if !l.Enabled() {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *compositeLogger) iter(fn func(l logr.Logger)) {
+	for _, l := range c.loggers {
+		fn(l)
+	}
+}
+
+func (c *compositeLogger) Info(msg string, keysAndValues ...interface{}) {
+	c.iter(func(l logr.Logger) {
+		l.Info(msg, keysAndValues...)
+	})
+}
+
+func (c *compositeLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	c.iter(func(l logr.Logger) {
+		l.Error(err, msg, keysAndValues...)
+	})
+}
+
+func (c *compositeLogger) V(level int) logr.Logger {
+	return c
+}
+
+func (c *compositeLogger) WithValues(keysAndValues ...interface{}) logr.Logger {
+	for i, l := range c.loggers {
+		c.loggers[i] = l.WithValues(keysAndValues...)
+	}
+	return c
+}
+
+func (c *compositeLogger) WithName(name string) logr.Logger {
+	for i, l := range c.loggers {
+		c.loggers[i] = l.WithName(name)
+	}
+	return c
+}

--- a/util/tele/corr_id.go
+++ b/util/tele/corr_id.go
@@ -19,6 +19,7 @@ package tele
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 )
 
@@ -79,4 +80,16 @@ func CorrIDFromCtx(ctx context.Context) (CorrID, bool) {
 	}
 
 	return CorrID(""), false
+}
+
+// corrIDLogger attempts to fetch the correlation ID from the
+// given ctx using CorrIDFromCtx. If it finds one, this function
+// uses lggr.WithValues to return a new logr.Logger with the
+// correlation ID in it.
+func corrIDLogger(ctx context.Context, lggr logr.Logger) logr.Logger {
+	corrID, ok := CorrIDFromCtx(ctx)
+	if ok {
+		lggr = lggr.WithValues(string(CorrIDKeyVal), string(corrID))
+	}
+	return lggr
 }

--- a/util/tele/span_logger.go
+++ b/util/tele/span_logger.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tele
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// spanLogger is a logr.Logger implementation that writes log
+// data to a span.
+type spanLogger struct {
+	trace.Span
+	name string
+	vals []interface{}
+}
+
+func (s *spanLogger) End(opts ...trace.SpanEndOption) {
+	s.Span.End(opts...)
+}
+
+func (s *spanLogger) Enabled() bool {
+	return true
+}
+
+func (s *spanLogger) kvsToAttrs(keysAndValues ...interface{}) []attribute.KeyValue {
+	ret := []attribute.KeyValue{}
+	for i := 0; i < len(keysAndValues); i += 2 {
+		kv1 := fmt.Sprintf("%s", keysAndValues[i])
+		kv2 := fmt.Sprintf("%s", keysAndValues[i+1])
+		ret = append(ret, attribute.String(kv1, kv2))
+	}
+	for i := 0; i < len(s.vals); i += 2 {
+		kv1 := fmt.Sprintf("%s", s.vals[i])
+		kv2 := fmt.Sprintf("%s", s.vals[i+1])
+		ret = append(ret, attribute.String(kv1, kv2))
+	}
+	return ret
+}
+
+func (s *spanLogger) evtStr(evtType, msg string) string {
+	return fmt.Sprintf(
+		"[%s | %s] %s",
+		evtType,
+		s.name,
+		msg,
+	)
+}
+
+func (s *spanLogger) Info(msg string, keysAndValues ...interface{}) {
+	attrs := s.kvsToAttrs(keysAndValues...)
+	s.AddEvent(
+		s.evtStr("INFO", msg),
+		trace.WithTimestamp(time.Now()),
+		trace.WithAttributes(attrs...),
+	)
+}
+
+func (s *spanLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	attrs := s.kvsToAttrs(keysAndValues...)
+	s.AddEvent(
+		s.evtStr("ERROR", fmt.Sprintf("%s (%s)", msg, err)),
+		trace.WithTimestamp(time.Now()),
+		trace.WithAttributes(attrs...),
+	)
+}
+
+func (s *spanLogger) V(level int) logr.Logger {
+	return s
+}
+
+func (s *spanLogger) WithValues(keysAndValues ...interface{}) logr.Logger {
+	s.vals = append(s.vals, keysAndValues...)
+	return s
+}
+
+func (s *spanLogger) WithName(name string) logr.Logger {
+	s.name = name
+	return s
+}
+
+// Config holds optional, arbitrary configuration information
+// to be added to logs and telemetry data. Instances of
+// Config get passed to StartSpanWithLogger via the KVP function.
+type Config struct {
+	KVPs map[string]string
+}
+
+func (c Config) teleKeyValues() []attribute.KeyValue {
+	ret := make([]attribute.KeyValue, len(c.KVPs))
+	i := 0
+	for k, v := range c.KVPs {
+		ret[i] = attribute.String(k, v)
+		i++
+	}
+	return ret
+}
+
+// Option is the modifier function used to configure
+// StartSpanWithLogger. Generally speaking, you should
+// not create your own option function. Instead, use
+// built-in functions (like KVP) that create them.
+type Option func(*Config)
+
+// KVP returns a new Option function that adds a the given
+// key-value pair.
+func KVP(key, value string) Option {
+	return func(cfg *Config) {
+		cfg.KVPs[key] = value
+	}
+}
+
+// StartSpanWithLogger starts a new span with the global
+// tracer returned from Tracer(), then returns a new logger
+// implementation that composes both the logger from the
+// given ctx and a logger that logs to the newly created span.
+//
+// Callers should make sure to call the function in the 3rd return
+// value to ensure that the span is ended properly. In many cases,
+// that can be done with a defer:
+//
+//	ctx, lggr, done := StartSpanWithLogger(ctx, "my-span")
+//	defer done()
+func StartSpanWithLogger(
+	ctx context.Context,
+	spanName string,
+	opts ...Option,
+) (context.Context, logr.Logger, func()) {
+	cfg := &Config{KVPs: make(map[string]string)}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	ctx, span := Tracer().Start(
+		ctx,
+		spanName,
+		trace.WithAttributes(cfg.teleKeyValues()...),
+	)
+	endFn := func() {
+		span.End()
+	}
+	lggr := log.FromContext(ctx).WithName(spanName)
+	return ctx, &compositeLogger{
+		loggers: []logr.Logger{
+			corrIDLogger(ctx, lggr),
+			&spanLogger{Span: span},
+		},
+	}, endFn
+}

--- a/util/tele/tele.go
+++ b/util/tele/tele.go
@@ -49,8 +49,13 @@ func (t tracer) Start(
 }
 
 // Tracer returns an OpenTelemetry Tracer implementation to be used
-// to create spans. Use this implementation instead of the "raw" one that
-// you could otherwise get from calling `otel.Tracer("whatever")`.
+// to create spans. If you need access to the raw globally-registered
+// tracer, use this function.
+//
+// Most people should not use this function directly, however.
+// Instead, consider using StartSpanWithLogger, which uses
+// this tracer to start a new span, configures logging, and
+// more.
 //
 // Example usage:
 //


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

This PR pulls the correlation ID out of trace contexts and includes it in reconcile loop loggers. This is necessary so that a user having an issue can convey valuable debugging information to someone just by submitting a log. A Microsoft employee can, using that log, look up the correlation ID on Azure's backend and gain a lot more visibility into what happened and what went wrong.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1310 

**Special notes for your reviewer**:

This PR is part of a 3-part series including #1460 and #1574. All are part of the fix to #1310. This should be merged only after #1460. I am marking this as a draft PR until that time.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation (@CecileRobertMichon @devigned can you point me to any documentation that should be updated?)
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Including correlation ID in all log output
```
