### PR TITLE
lowercase AzureManagedMachinePool providerID

### DIFF
--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -153,7 +153,7 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context, scope *s
 
 	var providerIDs = make([]string, len(instances))
 	for i := 0; i < len(instances); i++ {
-		providerIDs[i] = azure.ProviderIDPrefix + *instances[i].ID
+		providerIDs[i] = strings.ToLower(azure.ProviderIDPrefix + *instances[i].ID)
 	}
 
 	scope.InfraMachinePool.Spec.ProviderIDList = providerIDs


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
normalizes AzureManagedMachinePool providerID

**Which issue(s) this PR fixes**
Fixes #1585

**Release note**:
```release-note
lowercase AzureManagedMachinePool providerID
```
