### PR TITLE
fix: don't create outbound LB if using NatGateway

### DIFF
--- a/api/v1alpha4/azurecluster_default.go
+++ b/api/v1alpha4/azurecluster_default.go
@@ -202,10 +202,10 @@ func (c *AzureCluster) setNodeOutboundLBDefaults() {
 			return
 		}
 
-		var oneSubnetWithoutNatGateway bool
+		var needsOutboundLB bool
 		for _, subnet := range c.Spec.NetworkSpec.Subnets {
 			if subnet.Role == SubnetNode && !subnet.IsNatGatewayEnabled() {
-				oneSubnetWithoutNatGateway = true
+				needsOutboundLB = true
 				break
 			}
 		}
@@ -213,7 +213,7 @@ func (c *AzureCluster) setNodeOutboundLBDefaults() {
 		// If we don't default the outbound LB when there are some subnets with nat gateway,
 		// and some without, those without wouldn't have outbound traffic. So taking the
 		// safer route, we configure the outbound LB in that scenario.
-		if len(c.Spec.NetworkSpec.Subnets) > 0 && !oneSubnetWithoutNatGateway {
+		if !needsOutboundLB {
 			return
 		}
 

--- a/azure/services/natgateways/natgateways_test.go
+++ b/azure/services/natgateways/natgateways_test.go
@@ -108,7 +108,7 @@ func TestReconcileNatGateways(t *testing.T) {
 			},
 		},
 		{
-			name: "update nat gateway if already exists but it's out of date",
+			name: "update nat gateway if actual state does not match desired state",
 			tags: infrav1.Tags{
 				"Name": "my-vnet",
 				"sigs.k8s.io_cluster-api-provider-azure_cluster_test-cluster": "owned",
@@ -180,7 +180,7 @@ func TestReconcileNatGateways(t *testing.T) {
 							Role: infrav1.SubnetNode,
 						},
 						NatGatewayIP: infrav1.PublicIPSpec{
-							Name: "/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip-my-node-natgateway-node-subnet-natgw",
+							Name: "pip-my-node-natgateway-node-subnet-natgw",
 						},
 					},
 				})
@@ -191,7 +191,9 @@ func TestReconcileNatGateways(t *testing.T) {
 					Name: to.StringPtr("my-node-natgateway"),
 					ID:   to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-node-natgateway"),
 					NatGatewayPropertiesFormat: &network.NatGatewayPropertiesFormat{PublicIPAddresses: &[]network.SubResource{
-						{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip-my-node-natgateway-node-subnet-natgw")},
+						{
+							ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip-my-node-natgateway-node-subnet-natgw"),
+						},
 					}},
 				}, nil)
 				s.SetSubnet(infrav1.SubnetSpec{
@@ -201,7 +203,7 @@ func TestReconcileNatGateways(t *testing.T) {
 						ID:   "/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-node-natgateway",
 						Name: "my-node-natgateway",
 						NatGatewayIP: infrav1.PublicIPSpec{
-							Name: "/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/pip-my-node-natgateway-node-subnet-natgw",
+							Name: "pip-my-node-natgateway-node-subnet-natgw",
 						},
 					},
 				})

--- a/azure/services/subnets/subnets_test.go
+++ b/azure/services/subnets/subnets_test.go
@@ -190,6 +190,18 @@ func TestReconcileSubnets(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_subnets.MockSubnetScopeMockRecorder, m *mock_subnets.MockClientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.Subnet("my-subnet").AnyTimes().Return(infrav1.SubnetSpec{
+					ID:         "subnet-id",
+					Name:       "my-subnet",
+					Role:       infrav1.SubnetNode,
+					CIDRBlocks: []string{"10.0.0.0/16"},
+				})
+				s.Subnet("my-subnet-1").AnyTimes().Return(infrav1.SubnetSpec{
+					ID:         "subnet-id-1",
+					Name:       "my-subnet-1",
+					Role:       infrav1.SubnetControlPlane,
+					CIDRBlocks: []string{"10.2.0.0/16"},
+				})
 				s.SubnetSpecs().AnyTimes().Return([]azure.SubnetSpec{
 					{
 						Name:              "my-subnet",
@@ -263,6 +275,18 @@ func TestReconcileSubnets(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_subnets.MockSubnetScopeMockRecorder, m *mock_subnets.MockClientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.Subnet("my-ipv6-subnet").AnyTimes().Return(infrav1.SubnetSpec{
+					ID:         "subnet-id",
+					Name:       "my-ipv6-subnet",
+					Role:       infrav1.SubnetNode,
+					CIDRBlocks: []string{"10.0.0.0/16", "2001:1234:5678:9abd::/64"},
+				})
+				s.Subnet("my-ipv6-subnet-cp").AnyTimes().Return(infrav1.SubnetSpec{
+					ID:         "subnet-id-1",
+					Name:       "my-ipv6-subnet-cp",
+					Role:       infrav1.SubnetControlPlane,
+					CIDRBlocks: []string{"10.2.0.0/16", "2001:1234:5678:9abc::/64"},
+				})
 				s.SubnetSpecs().AnyTimes().Return([]azure.SubnetSpec{
 					{
 						Name:              "my-ipv6-subnet",
@@ -335,6 +359,121 @@ func TestReconcileSubnets(t *testing.T) {
 					Name:       "my-ipv6-subnet-cp",
 					Role:       infrav1.SubnetControlPlane,
 					CIDRBlocks: []string{"10.2.0.0/16", "2001:1234:5678:9abc::/64"},
+				}).Times(1)
+			},
+		},
+		{
+			name:          "doesn't overwrite existing NAT Gateway",
+			expectedError: "",
+			expect: func(s *mock_subnets.MockSubnetScopeMockRecorder, m *mock_subnets.MockClientMockRecorder) {
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.Subnet("my-subnet").AnyTimes().Return(infrav1.SubnetSpec{
+					ID:         "subnet-id",
+					Name:       "my-subnet",
+					Role:       infrav1.SubnetNode,
+					CIDRBlocks: []string{"10.0.0.0/16"},
+					NatGateway: infrav1.NatGateway{
+						ID:   azure.NatGatewayID("123", "my-rg", "existing-natgateway"),
+						Name: "existing-natgateway",
+						NatGatewayIP: infrav1.PublicIPSpec{
+							Name: "existing-natgateway-ip-name",
+						},
+					},
+				})
+				s.SubnetSpecs().AnyTimes().Return([]azure.SubnetSpec{
+					{
+						Name:              "my-subnet",
+						CIDRs:             []string{"10.0.0.0/16"},
+						VNetName:          "my-vnet",
+						RouteTableName:    "my-subnet_route_table",
+						SecurityGroupName: "my-sg",
+						Role:              infrav1.SubnetNode,
+					},
+				})
+				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "my-vnet"})
+				s.ClusterName().AnyTimes().Return("fake-cluster")
+				s.SubscriptionID().AnyTimes().Return("123")
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				m.Get(gomockinternal.AContext(), "", "my-vnet", "my-subnet").
+					Return(network.Subnet{
+						ID:   to.StringPtr("subnet-id"),
+						Name: to.StringPtr("my-subnet"),
+						SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+							AddressPrefix: to.StringPtr("10.0.0.0/16"),
+							RouteTable: &network.RouteTable{
+								ID:   to.StringPtr("rt-id"),
+								Name: to.StringPtr("my-subnet_route_table"),
+							},
+							NetworkSecurityGroup: &network.SecurityGroup{
+								ID:   to.StringPtr("sg-id"),
+								Name: to.StringPtr("my-sg"),
+							},
+							NatGateway: &network.SubResource{
+								ID: to.StringPtr(azure.NatGatewayID("123", "my-rg", "existing-natgateway")),
+							},
+						},
+					}, nil)
+				s.SetSubnet(infrav1.SubnetSpec{
+					ID:         "subnet-id",
+					Name:       "my-subnet",
+					Role:       infrav1.SubnetNode,
+					CIDRBlocks: []string{"10.0.0.0/16"},
+					NatGateway: infrav1.NatGateway{
+						ID:   azure.NatGatewayID("123", "my-rg", "existing-natgateway"),
+						Name: "existing-natgateway",
+						NatGatewayIP: infrav1.PublicIPSpec{
+							Name: "existing-natgateway-ip-name",
+						},
+					},
+				}).Times(1)
+			},
+		},
+		{
+			name:          "spec has empty CIDR and ID data but GET from Azure has the values",
+			expectedError: "",
+			expect: func(s *mock_subnets.MockSubnetScopeMockRecorder, m *mock_subnets.MockClientMockRecorder) {
+				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
+				s.Subnet("my-subnet").AnyTimes().Return(infrav1.SubnetSpec{
+					ID:         "",
+					Name:       "my-subnet",
+					Role:       infrav1.SubnetNode,
+					CIDRBlocks: []string{},
+				})
+				s.SubnetSpecs().AnyTimes().Return([]azure.SubnetSpec{
+					{
+						Name:              "my-subnet",
+						CIDRs:             []string{},
+						VNetName:          "my-vnet",
+						RouteTableName:    "my-subnet_route_table",
+						SecurityGroupName: "my-sg",
+						Role:              infrav1.SubnetNode,
+					},
+				})
+				s.Vnet().AnyTimes().Return(&infrav1.VnetSpec{Name: "my-vnet"})
+				s.ClusterName().AnyTimes().Return("fake-cluster")
+				s.SubscriptionID().AnyTimes().Return("123")
+				s.ResourceGroup().AnyTimes().Return("my-rg")
+				m.Get(gomockinternal.AContext(), "", "my-vnet", "my-subnet").
+					Return(network.Subnet{
+						ID:   to.StringPtr("subnet-id"),
+						Name: to.StringPtr("my-subnet"),
+						SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+							AddressPrefix: to.StringPtr("10.0.0.0/16"),
+							RouteTable: &network.RouteTable{
+								ID:   to.StringPtr("rt-id"),
+								Name: to.StringPtr("my-subnet_route_table"),
+							},
+							NetworkSecurityGroup: &network.SecurityGroup{
+								ID:   to.StringPtr("sg-id"),
+								Name: to.StringPtr("my-sg"),
+							},
+						},
+					}, nil)
+				s.SetSubnet(infrav1.SubnetSpec{
+					ID:         "subnet-id",
+					Name:       "my-subnet",
+					Role:       infrav1.SubnetNode,
+					CIDRBlocks: []string{"10.0.0.0/16"},
 				}).Times(1)
 			},
 		},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind bug

**What this PR does / why we need it**:

This PR fixes the nat-gateway + subnet reconciliation logic so that we stop creating unnecessary outbound LB resources if we're exclusively using NatGateway across all of our node subnets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1587

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
don't create outbound LB if using NatGateway
```
