### PR TITLE
fix managed clusters custom VNet delete issue

### DIFF
--- a/azure/services/virtualnetworks/virtualnetworks_test.go
+++ b/azure/services/virtualnetworks/virtualnetworks_test.go
@@ -294,6 +294,21 @@ func TestDeleteVnet(t *testing.T) {
 					Name:          "vnet-exists",
 					CIDRs:         []string{"10.0.0.0/16"},
 				})
+				m.Get(gomockinternal.AContext(), "my-rg", "vnet-exists").
+					Return(network.VirtualNetwork{
+						ID:   to.StringPtr("azure/fake/id"),
+						Name: to.StringPtr("vnet-exists"),
+						VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
+							AddressSpace: &network.AddressSpace{
+								AddressPrefixes: to.StringSlicePtr([]string{"10.0.0.0/8"}),
+							},
+						},
+						Tags: map[string]*string{
+							"Name": to.StringPtr("vnet-exists"),
+							"sigs.k8s.io_cluster-api-provider-azure_cluster_fake-cluster": to.StringPtr("owned"),
+							"sigs.k8s.io_cluster-api-provider-azure_role":                 to.StringPtr("common"),
+						},
+					}, nil)
 				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists")
 			},
 		},
@@ -315,8 +330,8 @@ func TestDeleteVnet(t *testing.T) {
 					Name:          "vnet-exists",
 					CIDRs:         []string{"10.0.0.0/16"},
 				})
-				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists").
-					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+				m.Get(gomockinternal.AContext(), "my-rg", "vnet-exists").
+					Return(network.VirtualNetwork{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
 		},
 		{
@@ -333,6 +348,19 @@ func TestDeleteVnet(t *testing.T) {
 					Name:          "my-vnet",
 					CIDRs:         []string{"10.0.0.0/16"},
 				})
+				m.Get(gomockinternal.AContext(), "my-rg", "my-vnet").
+					Return(network.VirtualNetwork{
+						ID:   to.StringPtr("azure/custom-vnet/id"),
+						Name: to.StringPtr("my-vnet"),
+						VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
+							AddressSpace: &network.AddressSpace{
+								AddressPrefixes: to.StringSlicePtr([]string{"10.0.0.0/16"}),
+							},
+						},
+						Tags: map[string]*string{
+							"Name": to.StringPtr("my-vnet"),
+						},
+					}, nil)
 			},
 		},
 		{
@@ -353,6 +381,21 @@ func TestDeleteVnet(t *testing.T) {
 					Name:          "vnet-exists",
 					CIDRs:         []string{"10.0.0.0/16"},
 				})
+				m.Get(gomockinternal.AContext(), "my-rg", "vnet-exists").
+					Return(network.VirtualNetwork{
+						ID:   to.StringPtr("azure/fake/id"),
+						Name: to.StringPtr("vnet-exists"),
+						VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
+							AddressSpace: &network.AddressSpace{
+								AddressPrefixes: to.StringSlicePtr([]string{"10.0.0.0/8"}),
+							},
+						},
+						Tags: map[string]*string{
+							"Name": to.StringPtr("vnet-exists"),
+							"sigs.k8s.io_cluster-api-provider-azure_cluster_fake-cluster": to.StringPtr("owned"),
+							"sigs.k8s.io_cluster-api-provider-azure_role":                 to.StringPtr("common"),
+						},
+					}, nil)
 				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists").
 					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Honk Server"))
 			},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
When we create managed clusters using custom vnet on cluster delete custom vnet also gets deleted. 
Custom vnets are not managed by capz and they should not be deleted while deleting the managed clusters 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1590 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix managed clusters custom VNet delete issue
```
