### PR TITLE
Remove dangling references to old branch

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-    - master # TODO: remove this after rename
     - main
 
 jobs:

--- a/scripts/ci-apidiff.sh
+++ b/scripts/ci-apidiff.sh
@@ -22,7 +22,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}"
 
 APIDIFF="${PWD}/hack/tools/bin/go-apidiff"
-PULL_BASE_SHA=${PULL_BASE_SHA:-$(git rev-parse origin/master)}
+PULL_BASE_SHA=${PULL_BASE_SHA:-$(git rev-parse origin/main)}
 
 make "${APIDIFF}"
 echo "*** Running go-apidiff ***"


### PR DESCRIPTION

/kind cleanup

**What this PR does / why we need it**:

Removes one reference to the old branch name, and updates another.

**Which issue(s) this PR fixes**:

Refs #749

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
