### PR TITLE
Print VNET range when subnet CIDR range is invalid

### DIFF
--- a/api/v1alpha4/azurecluster_validation.go
+++ b/api/v1alpha4/azurecluster_validation.go
@@ -238,7 +238,7 @@ func validateSubnetCIDR(subnetCidrBlocks []string, vnetCidrBlocks []string, fldP
 		}
 
 		if !found {
-			allErrs = append(allErrs, field.Invalid(fldPath, subnetCidr, "subnet CIDR not in vnet CIDR range"))
+			allErrs = append(allErrs, field.Invalid(fldPath, subnetCidr, fmt.Sprintf("subnet CIDR not in vnet address space: %s", vnetCidrBlocks)))
 		}
 	}
 

--- a/api/v1alpha4/azurecluster_validation_test.go
+++ b/api/v1alpha4/azurecluster_validation_test.go
@@ -588,7 +588,7 @@ func TestValidateSubnetCIDR(t *testing.T) {
 				Type:     "FieldValueInvalid",
 				Field:    "subnets.cidrBlocks",
 				BadValue: "11.1.0.0/16",
-				Detail:   "subnet CIDR not in vnet CIDR range",
+				Detail:   "subnet CIDR not in vnet address space: [10.0.0.0/8]",
 			},
 		},
 		{
@@ -602,14 +602,8 @@ func TestValidateSubnetCIDR(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := validateSubnetCIDR(testCase.subnetCidrBlocks, testCase.vnetCidrBlocks, field.NewPath("subnets.cidrBlocks"))
 			if testCase.wantErr {
-				g.Expect(err).NotTo(HaveLen(0))
-				found := false
-				for _, actual := range err {
-					if actual.Error() == testCase.expectedErr.Error() {
-						found = true
-					}
-				}
-				g.Expect(found).To(BeTrue())
+				// Searches for expected error in list of thrown errors
+				g.Expect(err).To(ContainElement(MatchError(testCase.expectedErr.Error())))
 			} else {
 				g.Expect(err).To(HaveLen(0))
 			}


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind feature

**What this PR does / why we need it**: Provide more descriptive error message giving vnet address space. Also changed the corresponding test case to show the expected error when the test fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1595 

**Special notes for your reviewer**: This way of organizing the test cases can be applied to all the similar tests in the file. It shortens the code where it searches for a matching error message, and it helps developers debug since the thrown error message must be an exact match to the error message in the test case.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
