### PR TITLE
docs: mention Troubleshooting in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,8 @@ about: Tell us about a problem you are experiencing.
 
 /kind bug
 
+[Before submitting an issue, have you checked the [Troubleshooting Guide](https://capz.sigs.k8s.io/topics/troubleshooting.html)?]
+
 **What steps did you take and what happened:**
 [A clear and concise description of what the bug is.]
 


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:

Makes the CAPZ [Troubleshooting Guide](https://capz.sigs.k8s.io/topics/troubleshooting.html) obvious when submitting an issue, to help users investigate further when they get stuck.

**Which issue(s) this PR fixes**:

Fixes #1627

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
