### PR TITLE
Streamline error matching in cluster validation tests

### DIFF
--- a/api/v1alpha4/azurecluster_validation_test.go
+++ b/api/v1alpha4/azurecluster_validation_test.go
@@ -398,14 +398,7 @@ func TestValidateVnetCIDR(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := validateVnetCIDR(testCase.vnetCidrBlocks, field.NewPath("vnet.cidrBlocks"))
 			if testCase.wantErr {
-				g.Expect(err).NotTo(HaveLen(0))
-				found := false
-				for _, actual := range err {
-					if actual.Error() == testCase.expectedErr.Error() {
-						found = true
-					}
-				}
-				g.Expect(found).To(BeTrue())
+				g.Expect(err).To(ContainElement(MatchError(testCase.expectedErr.Error())))
 			} else {
 				g.Expect(err).To(HaveLen(0))
 			}
@@ -849,14 +842,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 			t.Parallel()
 			err := validateAPIServerLB(test.lb, test.old, test.cpCIDRS, field.NewPath("apiServerLB"))
 			if test.wantErr {
-				g.Expect(err).NotTo(HaveLen(0))
-				found := false
-				for _, actual := range err {
-					if actual.Error() == test.expectedErr.Error() {
-						found = true
-					}
-				}
-				g.Expect(found).To(BeTrue())
+				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {
 				g.Expect(err).To(HaveLen(0))
 			}
@@ -927,14 +913,7 @@ func TestPrivateDNSZoneName(t *testing.T) {
 			t.Parallel()
 			err := validatePrivateDNSZoneName(test.network, field.NewPath("spec", "networkSpec", "privateDNSZoneName"))
 			if test.wantErr {
-				g.Expect(err).NotTo(HaveLen(0))
-				found := false
-				for _, actual := range err {
-					if actual.Error() == test.expectedErr.Error() {
-						found = true
-					}
-				}
-				g.Expect(found).To(BeTrue())
+				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {
 				g.Expect(err).To(HaveLen(0))
 			}
@@ -1079,14 +1058,7 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 			t.Parallel()
 			err := validateNodeOutboundLB(test.lb, test.old, test.apiServerLB, field.NewPath("nodeOutboundLB"))
 			if test.wantErr {
-				g.Expect(err).NotTo(HaveLen(0))
-				found := false
-				for _, actual := range err {
-					if actual.Error() == test.expectedErr.Error() {
-						found = true
-					}
-				}
-				g.Expect(found).To(BeTrue())
+				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {
 				g.Expect(err).To(HaveLen(0))
 			}
@@ -1151,14 +1123,7 @@ func TestValidateControlPlaneNodeOutboundLB(t *testing.T) {
 			t.Parallel()
 			err := validateControlPlaneOutboundLB(test.lb, test.apiServerLB, field.NewPath("controlPlaneOutboundLB"))
 			if test.wantErr {
-				g.Expect(err).NotTo(HaveLen(0))
-				found := false
-				for _, actual := range err {
-					if actual.Error() == test.expectedErr.Error() {
-						found = true
-					}
-				}
-				g.Expect(found).To(BeTrue())
+				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {
 				g.Expect(err).To(HaveLen(0))
 			}
@@ -1249,14 +1214,7 @@ func TestValidateCloudProviderConfigOverrides(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := validateCloudProviderConfigOverrides(testCase.oldConfig, testCase.newConfig, field.NewPath("spec.cloudProviderConfigOverrides"))
 			if testCase.wantErr {
-				g.Expect(err).NotTo(HaveLen(0))
-				found := false
-				for _, actual := range err {
-					if actual.Error() == testCase.expectedErr.Error() {
-						found = true
-					}
-				}
-				g.Expect(found).To(BeTrue())
+				g.Expect(err).To(ContainElement(MatchError(testCase.expectedErr.Error())))
 			} else {
 				g.Expect(err).To(HaveLen(0))
 			}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind feature

**What this PR does / why we need it**: In PR #1626 which addresses #1595, the test case code for matching expected errors with the produced error was streamlined. This change was applied to other test cases with similar error matching functionality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1595 and #1626

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
