### PR TITLE
update templates to use 8GB of etcd db data

### DIFF
--- a/templates/cluster-template-aad.yaml
+++ b/templates/cluster-template-aad.yaml
@@ -73,6 +73,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-azure-bastion.yaml
+++ b/templates/cluster-template-azure-bastion.yaml
@@ -70,6 +70,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -68,6 +68,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -69,6 +69,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -89,6 +89,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
       scheduler:
         extraArgs:
           bind-address: '::'

--- a/templates/cluster-template-machinepool-multiple-subnets.yaml
+++ b/templates/cluster-template-machinepool-multiple-subnets.yaml
@@ -75,6 +75,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-machinepool-system-assigned-identity.yaml
+++ b/templates/cluster-template-machinepool-system-assigned-identity.yaml
@@ -64,6 +64,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-machinepool-user-assigned-identity.yaml
+++ b/templates/cluster-template-machinepool-user-assigned-identity.yaml
@@ -64,6 +64,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -69,6 +69,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -68,6 +68,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-nat-gateway.yaml
+++ b/templates/cluster-template-nat-gateway.yaml
@@ -81,6 +81,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-nvidia-gpu.yaml
+++ b/templates/cluster-template-nvidia-gpu.yaml
@@ -69,6 +69,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-private.yaml
+++ b/templates/cluster-template-private.yaml
@@ -77,6 +77,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -64,6 +64,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -64,6 +64,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -69,6 +69,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -68,6 +68,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -81,6 +81,8 @@ spec:
       etcd:
         local:
           dataDir: "/var/lib/etcddisk/etcd"
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     files:
       - contentFrom:
           secret:

--- a/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
@@ -74,6 +74,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
     diskSetup:
       filesystems:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -73,6 +73,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
     diskSetup:
       filesystems:

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -84,6 +84,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -74,6 +74,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -94,6 +94,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
       scheduler:
         extraArgs:
           bind-address: '::'

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -73,6 +73,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
     diskSetup:
       filesystems:

--- a/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
@@ -74,6 +74,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -73,6 +73,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -74,6 +74,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -100,6 +100,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -74,6 +74,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -73,6 +73,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -75,6 +75,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
     diskSetup:
       filesystems:

--- a/templates/test/dev/cluster-template-custom-builds-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-windows.yaml
@@ -76,6 +76,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
     diskSetup:
       filesystems:

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -75,6 +75,8 @@ spec:
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
       kubernetesVersion: ci/${CI_VERSION}
     diskSetup:
       filesystems:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind other

^-- Test configuration change

**What this PR does / why we need it**:

This PR updates the base etcd config for all cluster templates to use an 8 GB data size configuration. This is based on two things:

1) the 2 GB data default can be problematic (i.e., too small) for large clusters
2) 8 GB is the recommended maximum to use (there are ways to use more data but for now using the recommended max seems good and 4x compared to the current 2 GB size is a non-trivial increase)

See:

https://etcd.io/docs/v3.4/dev-guide/limit/

I think the guiding motivation of this change is to help unlock large cluster scenarios by rigorously testing this configuration recommendation. Because we are already using a 256 GB data disk volume for etcd in these templates, the additional etcd data size does not require any changes there.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cluster templates now use 8 GB of etcd db data (was 2 GB)
```
