### PR TITLE
optimal defaults for UltraSSD data disk

### DIFF
--- a/api/v1alpha4/azuremachine_default.go
+++ b/api/v1alpha4/azuremachine_default.go
@@ -70,7 +70,11 @@ func (s *AzureMachineSpec) SetDataDisksDefaults() {
 			}
 		}
 		if disk.CachingType == "" {
-			s.DataDisks[i].CachingType = "ReadWrite"
+			if s.DataDisks[i].ManagedDisk != nil && s.DataDisks[i].ManagedDisk.StorageAccountType == "UltraSSD_LRS" {
+				s.DataDisks[i].CachingType = "None"
+			} else {
+				s.DataDisks[i].CachingType = "ReadWrite"
+			}
 		}
 	}
 }

--- a/api/v1alpha4/azuremachine_default_test.go
+++ b/api/v1alpha4/azuremachine_default_test.go
@@ -232,6 +232,30 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "UltraSSD",
+			disks: []DataDisk{
+				{
+					NameSuffix: "testdisk1",
+					DiskSizeGB: 30,
+					Lun:        to.Int32Ptr(0),
+					ManagedDisk: &ManagedDiskParameters{
+						StorageAccountType: "UltraSSD_LRS",
+					},
+				},
+			},
+			output: []DataDisk{
+				{
+					NameSuffix: "testdisk1",
+					DiskSizeGB: 30,
+					Lun:        to.Int32Ptr(0),
+					ManagedDisk: &ManagedDiskParameters{
+						StorageAccountType: "UltraSSD_LRS",
+					},
+					CachingType: "None", // UltraSSD requires a None CachingType
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -2017,10 +2017,12 @@ func TestReconcileVM(t *testing.T) {
 									DiskSizeGB:   to.Int32Ptr(64),
 								},
 								{
-									Lun:          to.Int32Ptr(1),
-									Name:         to.StringPtr("my-ultra-ssd-vm_myDiskWithUltraDisk"),
-									CreateOption: "Empty",
-									DiskSizeGB:   to.Int32Ptr(128),
+									Lun:               to.Int32Ptr(1),
+									Name:              to.StringPtr("my-ultra-ssd-vm_myDiskWithUltraDisk"),
+									CreateOption:      "Empty",
+									DiskSizeGB:        to.Int32Ptr(128),
+									DiskIOPSReadWrite: to.Int64Ptr(38400),
+									DiskMBpsReadWrite: to.Int64Ptr(2000),
 									ManagedDisk: &compute.ManagedDiskParameters{
 										StorageAccountType: "UltraSSD_LRS",
 									},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

/kind feature

**What this PR does / why we need it**:

This PR updates the default data disk cachingType if using UltraSSD to the only allowable option of "None". This doesn't strictly fix a bug, as it's possible to use UltraSSD on an data disk (e.g., etcd) right now by explicitly including the `cachingType: None` configuration in your AzureMachineTemplate; but because "None" is the only valid value we should default to it.

Also we assign sensible IOPS and throughput configuration based on the size of the data disk. See:

- https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-size

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
optimal defaults for UltraSSD data disk
```
