### PR TITLE
Fix redundant import and rename instances of meta package v1 to metav1

### DIFF
--- a/api/v1alpha3/azureclusteridentity_conversion.go
+++ b/api/v1alpha3/azureclusteridentity_conversion.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
@@ -61,7 +61,7 @@ func (src *AzureClusterIdentity) ConvertTo(dstRaw conversion.Hub) error { // nol
 	}
 
 	// removing ownerReference for AzureCluster as ownerReference is not required from v1alpha4 onwards.
-	var restoredOwnerReferences []v1.OwnerReference
+	var restoredOwnerReferences []metav1.OwnerReference
 	for _, ownerRef := range dst.OwnerReferences {
 		if ownerRef.Kind != AzureClusterKind {
 			restoredOwnerReferences = append(restoredOwnerReferences, ownerRef)

--- a/api/v1alpha4/azurecluster_default_test.go
+++ b/api/v1alpha4/azurecluster_default_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestResourceGroupDefault(t *testing.T) {
@@ -140,7 +139,7 @@ func TestVnetDefaults(t *testing.T) {
 		{
 			name: "vnet not specified",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -148,7 +147,7 @@ func TestVnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -166,7 +165,7 @@ func TestVnetDefaults(t *testing.T) {
 		{
 			name: "custom CIDR",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -179,7 +178,7 @@ func TestVnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -197,7 +196,7 @@ func TestVnetDefaults(t *testing.T) {
 		{
 			name: "IPv6 enabled",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -210,7 +209,7 @@ func TestVnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -250,7 +249,7 @@ func TestSubnetDefaults(t *testing.T) {
 		{
 			name: "no subnets",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -258,7 +257,7 @@ func TestSubnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -286,7 +285,7 @@ func TestSubnetDefaults(t *testing.T) {
 		{
 			name: "subnets with custom attributes",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -308,7 +307,7 @@ func TestSubnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -342,7 +341,7 @@ func TestSubnetDefaults(t *testing.T) {
 		{
 			name: "subnets specified",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -361,7 +360,7 @@ func TestSubnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -389,7 +388,7 @@ func TestSubnetDefaults(t *testing.T) {
 		{
 			name: "subnets route tables specified",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -411,7 +410,7 @@ func TestSubnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -439,7 +438,7 @@ func TestSubnetDefaults(t *testing.T) {
 		{
 			name: "only node subnet specified",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -454,7 +453,7 @@ func TestSubnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -482,7 +481,7 @@ func TestSubnetDefaults(t *testing.T) {
 		{
 			name: "subnets specified with IPv6 enabled",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -506,7 +505,7 @@ func TestSubnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -537,7 +536,7 @@ func TestSubnetDefaults(t *testing.T) {
 		{
 			name: "subnets with custom security group",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -567,7 +566,7 @@ func TestSubnetDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -631,7 +630,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 		{
 			name: "no lb",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -639,7 +638,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -666,7 +665,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 		{
 			name: "internal lb",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -678,7 +677,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -797,7 +796,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		{
 			name: "default lb for public clusters",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -821,7 +820,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -863,7 +862,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		{
 			name: "NAT Gateway enabled - no LB",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -890,7 +889,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -922,7 +921,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		{
 			name: "NAT Gateway enabled on 1 of 2 node subnets",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -955,7 +954,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1006,7 +1005,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		{
 			name: "multiple node subnets, NAT Gateway not enabled in any of them",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1042,7 +1041,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1096,7 +1095,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		{
 			name: "multiple node subnets, NAT Gateway enabled on all of them",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1141,7 +1140,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1191,7 +1190,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		{
 			name: "no lb for private clusters",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1201,7 +1200,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1216,7 +1215,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		{
 			name: "NodeOutboundLB declared as input with non-default IdleTimeoutInMinutes and FrontendIPsCount values",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1230,7 +1229,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1288,7 +1287,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 		{
 			name: "no cp lb for public clusters",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1298,7 +1297,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1313,7 +1312,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 		{
 			name: "no cp lb for private clusters",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1323,7 +1322,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1338,7 +1337,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 		{
 			name: "frontendIPsCount > 1",
 			cluster: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
@@ -1352,7 +1351,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 			},
 			output: &AzureCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{

--- a/api/v1alpha4/azuremachinetemplate_webhook_test.go
+++ b/api/v1alpha4/azuremachinetemplate_webhook_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
@@ -201,7 +201,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 						},
 					},
 				},
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "OldTemplate",
 				},
 			},
@@ -220,7 +220,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 						},
 					},
 				},
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "NewTemplate",
 				},
 			},

--- a/test/e2e/kubernetes/node/node.go
+++ b/test/e2e/kubernetes/node/node.go
@@ -26,7 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
@@ -34,7 +34,7 @@ import (
 )
 
 func GetWindowsVersion(ctx context.Context, clientset *kubernetes.Clientset) (windows.OSVersion, error) {
-	options := v1.ListOptions{
+	options := metav1.ListOptions{
 		LabelSelector: "kubernetes.io/os=windows",
 	}
 	result, err := clientset.CoreV1().Nodes().List(ctx, options)
@@ -60,7 +60,7 @@ func GetWindowsVersion(ctx context.Context, clientset *kubernetes.Clientset) (wi
 	}
 }
 
-func TaintNode(clientset *kubernetes.Clientset, options v1.ListOptions, taint *corev1.Taint) error {
+func TaintNode(clientset *kubernetes.Clientset, options metav1.ListOptions, taint *corev1.Taint) error {
 	result, err := clientset.CoreV1().Nodes().List(context.Background(), options)
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ func PatchNodeTaints(clientset *kubernetes.Clientset, nodeName string, oldNode *
 		return fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
 	}
 
-	_, err = clientset.CoreV1().Nodes().Patch(context.Background(), nodeName, types.StrategicMergePatchType, patchBytes, v1.PatchOptions{})
+	_, err = clientset.CoreV1().Nodes().Patch(context.Background(), nodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 	return err
 }
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind bug

**What this PR does / why we need it**: Fix redundant import of package `k8s.io/apimachinery/pkg/apis/meta/v1` in `azurecluster_default_test.go`. Also renamed the instances of v1 to metav1 for consistency with the rest of the imports.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
