### PR TITLE
Fix AzureClusterIdentity conversion and add missing webhook

### DIFF
--- a/api/v1alpha3/azureclusteridentity_conversion.go
+++ b/api/v1alpha3/azureclusteridentity_conversion.go
@@ -19,9 +19,10 @@ package v1alpha3
 import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
-	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 )
 
 const (
@@ -41,17 +42,27 @@ func (src *AzureClusterIdentity) ConvertTo(dstRaw conversion.Hub) error { // nol
 		return err
 	}
 
+	if len(dst.Annotations) == 0 {
+		dst.Annotations = nil
+	}
+
 	if len(src.Spec.AllowedNamespaces) > 0 {
 		dst.Spec.AllowedNamespaces = &infrav1alpha4.AllowedNamespaces{}
 		for _, ns := range src.Spec.AllowedNamespaces {
 			dst.Spec.AllowedNamespaces.NamespaceList = append(dst.Spec.AllowedNamespaces.NamespaceList, ns)
+		}
+	}
+
+	if restored.Spec.AllowedNamespaces != nil && restored.Spec.AllowedNamespaces.Selector != nil {
+		if dst.Spec.AllowedNamespaces == nil {
+			dst.Spec.AllowedNamespaces = &infrav1alpha4.AllowedNamespaces{}
 		}
 		dst.Spec.AllowedNamespaces.Selector = restored.Spec.AllowedNamespaces.Selector
 	}
 
 	// removing ownerReference for AzureCluster as ownerReference is not required from v1alpha4 onwards.
 	var restoredOwnerReferences []v1.OwnerReference
-	for _, ownerRef :=  range dst.OwnerReferences {
+	for _, ownerRef := range dst.OwnerReferences {
 		if ownerRef.Kind != AzureClusterKind {
 			restoredOwnerReferences = append(restoredOwnerReferences, ownerRef)
 		}
@@ -83,7 +94,7 @@ func (dst *AzureClusterIdentity) ConvertFrom(srcRaw conversion.Hub) error { // n
 }
 
 // Convert_v1alpha3_AzureClusterIdentitySpec_To_v1alpha4_AzureClusterIdentitySpec.
-func Convert_v1alpha3_AzureClusterIdentitySpec_To_v1alpha4_AzureClusterIdentitySpec(in *AzureClusterIdentitySpec, out *infrav1alpha4.AzureClusterIdentitySpec, s apiconversion.Scope) error { //nolint
+func Convert_v1alpha3_AzureClusterIdentitySpec_To_v1alpha4_AzureClusterIdentitySpec(in *AzureClusterIdentitySpec, out *infrav1alpha4.AzureClusterIdentitySpec, s apiconversion.Scope) error { // nolint
 	if err := autoConvert_v1alpha3_AzureClusterIdentitySpec_To_v1alpha4_AzureClusterIdentitySpec(in, out, s); err != nil {
 		return err
 	}
@@ -92,7 +103,7 @@ func Convert_v1alpha3_AzureClusterIdentitySpec_To_v1alpha4_AzureClusterIdentityS
 }
 
 // Convert_v1alpha4_AzureClusterIdentitySpec_To_v1alpha3_AzureClusterIdentitySpec
-func Convert_v1alpha4_AzureClusterIdentitySpec_To_v1alpha3_AzureClusterIdentitySpec(in *infrav1alpha4.AzureClusterIdentitySpec, out *AzureClusterIdentitySpec, s apiconversion.Scope) error { //nolint
+func Convert_v1alpha4_AzureClusterIdentitySpec_To_v1alpha3_AzureClusterIdentitySpec(in *infrav1alpha4.AzureClusterIdentitySpec, out *AzureClusterIdentitySpec, s apiconversion.Scope) error { // nolint
 	if err := autoConvert_v1alpha4_AzureClusterIdentitySpec_To_v1alpha3_AzureClusterIdentitySpec(in, out, s); err != nil {
 		return err
 	}

--- a/api/v1alpha4/azureclusteridentity_webhook.go
+++ b/api/v1alpha4/azureclusteridentity_webhook.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// SetupWebhookWithManager sets up and registers the webhook with the manager.
+func (c *AzureClusterIdentity) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(c).
+		Complete()
+}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -22,6 +22,7 @@ patchesStrategicMerge:
   # patches here are for enabling the conversion webhook for each CRD
   - patches/webhook_in_azuremachines.yaml
   - patches/webhook_in_azureclusters.yaml
+  - patches/webhook_in_azureclusteridentities.yaml
   - patches/webhook_in_azuremachinetemplates.yaml
   - patches/webhook_in_azuremachinepools.yaml
   - patches/webhook_in_azuremachinepoolmachines.yaml
@@ -34,6 +35,7 @@ patchesStrategicMerge:
   # patches here are for enabling the CA injection for each CRD
   - patches/cainjection_in_azuremachines.yaml
   - patches/cainjection_in_azureclusters.yaml
+  - patches/cainjection_in_azureclusteridentities.yaml
   - patches/cainjection_in_azuremachinetemplates.yaml
   - patches/cainjection_in_azuremachinepools.yaml
   - patches/cainjection_in_azuremachinepoolmachines.yaml

--- a/config/crd/patches/cainjection_in_azureclusteridentities.yaml
+++ b/config/crd/patches/cainjection_in_azureclusteridentities.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: azureclusteridentities.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/webhook_in_azureclusteridentities.yaml
+++ b/config/crd/patches/webhook_in_azureclusteridentities.yaml
@@ -1,0 +1,19 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: azureclusteridentities.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/main.go
+++ b/main.go
@@ -462,6 +462,11 @@ func registerControllers(ctx context.Context, mgr manager.Manager) {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachineTemplate")
 		os.Exit(1)
 	}
+
+	if err := (&infrav1alpha4.AzureClusterIdentity{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "AzureClusterIdentity")
+		os.Exit(1)
+	}
 	// just use CAPI MachinePool feature flag rather than create a new one
 	if feature.Gates.Enabled(capifeature.MachinePool) {
 		if err := (&infrav1alpha4exp.AzureMachinePool{}).SetupWebhookWithManager(mgr); err != nil {


### PR DESCRIPTION
 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

AzureClusterIdentity conversion webhook is currently missing. Also when adding a unit test for the existing conversion, the unit test fails.

This PR fixes the AzureClusterIdentity conversion implementation, adds the unit test and adds conversion webhook.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1634

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix AzureClusterIdentity conversion and add missing webhook
```
