### PR TITLE
fix: remove log_dump_pods variable declaration

### DIFF
--- a/hack/log/log-dump.sh
+++ b/hack/log/log-dump.sh
@@ -91,8 +91,7 @@ dump_workload_cluster_logs() {
     kubectl apply -f "${REPO_ROOT}/hack/log/log-dump-daemonset.yaml"
     kubectl wait pod -l app=log-dump-node --for=condition=Ready --timeout=5m
 
-    local -r log_dump_pods=()
-    IFS=" " read -r -a log_dump_pods <<< "$(kubectl get pod -l app=log-dump-node -ojsonpath='{.items[*].metadata.name}')"
+    IFS=" " read -ra log_dump_pods <<< "$(kubectl get pod -l app=log-dump-node -ojsonpath='{.items[*].metadata.name}')"
     local log_dump_commands=(
         "journalctl --output=short-precise -u kubelet > kubelet.log"
         "journalctl --output=short-precise -u containerd > containerd.log"


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

Fixes the following log dumping error in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-cloud-provider-azure-e2e-ccm-capz/1429729125685268480:

```
./scripts/../scripts/../hack/log/log-dump.sh: line 95: log_dump_pods: readonly variable
```

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
