### PR TITLE
update Azure compute API to 2021-04-01

### DIFF
--- a/api/v1alpha4/azuremachine_validation.go
+++ b/api/v1alpha4/azuremachine_validation.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )

--- a/api/v1alpha4/azuremachine_validation_test.go
+++ b/api/v1alpha4/azuremachine_validation_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	. "github.com/onsi/gomega"
@@ -107,7 +107,7 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 				CachingType: "None",
 				OSType:      "blah",
 				DiffDiskSettings: &DiffDiskSettings{
-					Option: string(compute.Local),
+					Option: string(compute.DiffDiskOptionsLocal),
 				},
 				ManagedDisk: &ManagedDiskParameters{
 					StorageAccountType: "Standard_LRS",
@@ -122,7 +122,7 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 				CachingType: "None",
 				OSType:      "blah",
 				DiffDiskSettings: &DiffDiskSettings{
-					Option: string(compute.Local),
+					Option: string(compute.DiffDiskOptionsLocal),
 				},
 				ManagedDisk: &ManagedDiskParameters{
 					StorageAccountType: "Standard_LRS",
@@ -195,7 +195,7 @@ func generateNegativeTestCases() []osDiskTestInput {
 				StorageAccountType: "Premium_LRS",
 			},
 			DiffDiskSettings: &DiffDiskSettings{
-				Option: string(compute.Local),
+				Option: string(compute.DiffDiskOptionsLocal),
 			},
 		},
 	}

--- a/api/v1alpha4/azuremachinetemplate_webhook_test.go
+++ b/api/v1alpha4/azuremachinetemplate_webhook_test.go
@@ -19,7 +19,7 @@ package v1alpha4
 import (
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/azure/converters/identity.go
+++ b/azure/converters/identity.go
@@ -21,7 +21,7 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/pkg/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"

--- a/azure/converters/identity_test.go
+++ b/azure/converters/identity_test.go
@@ -19,7 +19,7 @@ package converters
 import (
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/onsi/gomega"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"

--- a/azure/converters/image.go
+++ b/azure/converters/image.go
@@ -19,7 +19,7 @@ package converters
 import (
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/pkg/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"

--- a/azure/converters/spotinstances.go
+++ b/azure/converters/spotinstances.go
@@ -19,7 +19,7 @@ package converters
 import (
 	"strconv"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 )
 
@@ -40,5 +40,5 @@ func GetSpotVMOptions(spotVMOptions *infrav1.SpotVMOptions) (compute.VirtualMach
 			MaxPrice: &maxPrice,
 		}
 	}
-	return compute.Spot, compute.Deallocate, billingProfile, nil
+	return compute.VirtualMachinePriorityTypesSpot, compute.VirtualMachineEvictionPolicyTypesDeallocate, billingProfile, nil
 }

--- a/azure/converters/vm.go
+++ b/azure/converters/vm.go
@@ -17,7 +17,7 @@ limitations under the License.
 package converters
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 )

--- a/azure/converters/vmss.go
+++ b/azure/converters/vmss.go
@@ -17,7 +17,7 @@ limitations under the License.
 package converters
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"

--- a/azure/converters/vmss_test.go
+++ b/azure/converters/vmss_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"

--- a/azure/services/availabilitysets/availabilitysets.go
+++ b/azure/services/availabilitysets/availabilitysets.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -65,7 +65,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		return nil
 	}
 
-	asSku, err := s.resourceSKUCache.Get(ctx, string(compute.Aligned), resourceskus.AvailabilitySets)
+	asSku, err := s.resourceSKUCache.Get(ctx, string(compute.AvailabilitySetSkuTypesAligned), resourceskus.AvailabilitySets)
 	if err != nil {
 		return errors.Wrap(err, "failed to get availability sets sku")
 	}
@@ -84,7 +84,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 	asParams := compute.AvailabilitySet{
 		Sku: &compute.Sku{
-			Name: to.StringPtr(string(compute.Aligned)),
+			Name: to.StringPtr(string(compute.AvailabilitySetSkuTypesAligned)),
 		},
 		AvailabilitySetProperties: &compute.AvailabilitySetProperties{
 			PlatformFaultDomainCount: to.Int32Ptr(int32(faultDomainCount)),

--- a/azure/services/availabilitysets/availabilitysets_test.go
+++ b/azure/services/availabilitysets/availabilitysets_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"

--- a/azure/services/availabilitysets/client.go
+++ b/azure/services/availabilitysets/client.go
@@ -19,7 +19,7 @@ package availabilitysets
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"

--- a/azure/services/availabilitysets/mock_availabilitysets/client_mock.go
+++ b/azure/services/availabilitysets/mock_availabilitysets/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/azure/services/disks/client.go
+++ b/azure/services/disks/client.go
@@ -19,7 +19,7 @@ package disks
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"

--- a/azure/services/networkinterfaces/networkinterfaces_test.go
+++ b/azure/services/networkinterfaces/networkinterfaces_test.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	gomockinternal "sigs.k8s.io/cluster-api-provider-azure/internal/test/matchers/gomock"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"

--- a/azure/services/resourceskus/cache.go
+++ b/azure/services/resourceskus/cache.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -182,7 +182,7 @@ func (c *Cache) GetZones(ctx context.Context, location string) ([]string, error)
 					if sku.Restrictions != nil {
 						for _, restriction := range *sku.Restrictions {
 							// Can't deploy anything in this subscription in this location. Bail out.
-							if restriction.Type == compute.Location {
+							if restriction.Type == compute.ResourceSkuRestrictionsTypeLocation {
 								availableZones = nil
 								break
 							}
@@ -243,7 +243,7 @@ func (c *Cache) GetZonesWithVMSize(ctx context.Context, size, location string) (
 					if sku.Restrictions != nil {
 						for _, restriction := range *sku.Restrictions {
 							// Can't deploy anything in this subscription in this location. Bail out.
-							if restriction.Type == compute.Location {
+							if restriction.Type == compute.ResourceSkuRestrictionsTypeLocation {
 								availableZones = nil
 								break
 							}

--- a/azure/services/resourceskus/cache_test.go
+++ b/azure/services/resourceskus/cache_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -190,7 +190,7 @@ func TestCacheGetZones(t *testing.T) {
 					},
 					Restrictions: &[]compute.ResourceSkuRestrictions{
 						{
-							Type:   compute.Location,
+							Type:   compute.ResourceSkuRestrictionsTypeLocation,
 							Values: &[]string{"baz"},
 						},
 					},
@@ -214,7 +214,7 @@ func TestCacheGetZones(t *testing.T) {
 					},
 					Restrictions: &[]compute.ResourceSkuRestrictions{
 						{
-							Type: compute.Zone,
+							Type: compute.ResourceSkuRestrictionsTypeZone,
 							RestrictionInfo: &compute.ResourceSkuRestrictionInfo{
 								Zones: &[]string{"1"},
 							},
@@ -339,7 +339,7 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 					},
 					Restrictions: &[]compute.ResourceSkuRestrictions{
 						{
-							Type:   compute.Location,
+							Type:   compute.ResourceSkuRestrictionsTypeLocation,
 							Values: &[]string{"baz"},
 						},
 					},
@@ -363,7 +363,7 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 					},
 					Restrictions: &[]compute.ResourceSkuRestrictions{
 						{
-							Type: compute.Zone,
+							Type: compute.ResourceSkuRestrictionsTypeZone,
 							RestrictionInfo: &compute.ResourceSkuRestrictionInfo{
 								Zones: &[]string{"1"},
 							},

--- a/azure/services/resourceskus/client.go
+++ b/azure/services/resourceskus/client.go
@@ -19,7 +19,7 @@ package resourceskus
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/pkg/errors"
 

--- a/azure/services/resourceskus/mock_resourceskus/resourceskus_mock.go
+++ b/azure/services/resourceskus/mock_resourceskus/resourceskus_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/azure/services/resourceskus/sku.go
+++ b/azure/services/resourceskus/sku.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/pkg/errors"
 )
 

--- a/azure/services/roleassignments/roleassignments_test.go
+++ b/azure/services/roleassignments/roleassignments_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/authorization/mgmt/authorization"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"

--- a/azure/services/scalesets/client.go
+++ b/azure/services/scalesets/client.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
@@ -169,7 +170,7 @@ func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, vmssName stri
 	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.Get")
 	defer span.End()
 
-	return ac.scalesets.Get(ctx, resourceGroupName, vmssName)
+	return ac.scalesets.Get(ctx, resourceGroupName, vmssName, "")
 }
 
 // CreateOrUpdate the operation to create or update a virtual machine scale set.
@@ -350,7 +351,7 @@ func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, vmssName s
 	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.Delete")
 	defer span.End()
 
-	future, err := ac.scalesets.Delete(ctx, resourceGroupName, vmssName)
+	future, err := ac.scalesets.Delete(ctx, resourceGroupName, vmssName, to.BoolPtr(false))
 	if err != nil {
 		return err
 	}
@@ -373,7 +374,7 @@ func (ac *AzureClient) DeleteAsync(ctx context.Context, resourceGroupName, vmssN
 	ctx, span := tele.Tracer().Start(ctx, "scalesets.AzureClient.DeleteAsync")
 	defer span.End()
 
-	future, err := ac.scalesets.Delete(ctx, resourceGroupName, vmssName)
+	future, err := ac.scalesets.Delete(ctx, resourceGroupName, vmssName, to.BoolPtr(false))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed deleting vmss named %q", vmssName)
 	}

--- a/azure/services/scalesets/mock_scalesets/client_mock.go
+++ b/azure/services/scalesets/mock_scalesets/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "github.com/golang/mock/gomock"

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -445,7 +445,7 @@ func (s *Service) buildVMSSFromSpec(ctx context.Context, vmssSpec azure.ScaleSet
 												ID: to.StringPtr(azure.SubnetID(s.Scope.SubscriptionID(), vmssSpec.VNetResourceGroup, vmssSpec.VNetName, vmssSpec.SubnetName)),
 											},
 											Primary:                         to.BoolPtr(true),
-											PrivateIPAddressVersion:         compute.IPv4,
+											PrivateIPAddressVersion:         compute.IPVersionIPv4,
 											LoadBalancerBackendAddressPools: &backendAddressPools,
 										},
 									},
@@ -640,7 +640,7 @@ func (s *Service) generateOSProfile(ctx context.Context, vmssSpec azure.ScaleSet
 	}
 
 	switch vmssSpec.OSDisk.OSType {
-	case string(compute.Windows):
+	case string(compute.OperatingSystemTypesWindows):
 		// Cloudbase-init is used to generate a password.
 		// https://cloudbase-init.readthedocs.io/en/latest/plugins.html#setting-password-main
 		//

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/utils/pointer"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
@@ -323,8 +323,8 @@ func TestReconcileVMSS(t *testing.T) {
 				setupDefaultVMSSStartCreatingExpectations(s, m)
 				vmss := newDefaultVMSS("VM_SIZE")
 				vmss.VirtualMachineScaleSetProperties.AdditionalCapabilities = &compute.AdditionalCapabilities{UltraSSDEnabled: pointer.Bool(true)}
-				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.Priority = compute.Spot
-				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.EvictionPolicy = compute.Deallocate
+				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.Priority = compute.VirtualMachinePriorityTypesSpot
+				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.EvictionPolicy = compute.VirtualMachineEvictionPolicyTypesDeallocate
 				m.CreateOrUpdateAsync(gomockinternal.AContext(), defaultResourceGroup, defaultVMSSName, gomockinternal.DiffEq(vmss)).
 					Return(putFuture, nil)
 				setupCreatingSucceededExpectations(s, m, newDefaultExistingVMSS("VM_SIZE"), putFuture)
@@ -350,12 +350,12 @@ func TestReconcileVMSS(t *testing.T) {
 				s.ScaleSetSpec().Return(spec).AnyTimes()
 				setupDefaultVMSSStartCreatingExpectations(s, m)
 				vmss := newDefaultVMSS("VM_SIZE")
-				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.Priority = compute.Spot
+				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.Priority = compute.VirtualMachinePriorityTypesSpot
 				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.BillingProfile = &compute.BillingProfile{
 					MaxPrice: to.Float64Ptr(0.001),
 				}
 				vmss.VirtualMachineScaleSetProperties.AdditionalCapabilities = &compute.AdditionalCapabilities{UltraSSDEnabled: pointer.Bool(true)}
-				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.EvictionPolicy = compute.Deallocate
+				vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.EvictionPolicy = compute.VirtualMachineEvictionPolicyTypesDeallocate
 				m.CreateOrUpdateAsync(gomockinternal.AContext(), defaultResourceGroup, defaultVMSSName, gomockinternal.DiffEq(vmss)).
 					Return(putFuture, nil)
 				setupCreatingSucceededExpectations(s, m, newDefaultExistingVMSS("VM_SIZE"), putFuture)
@@ -967,7 +967,7 @@ func newDefaultExistingVMSS(vmSize string) compute.VirtualMachineScaleSet {
 
 func newDefaultWindowsVMSS() compute.VirtualMachineScaleSet {
 	vmss := newDefaultVMSS("VM_SIZE")
-	vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.OsType = compute.Windows
+	vmss.VirtualMachineScaleSetProperties.VirtualMachineProfile.StorageProfile.OsDisk.OsType = compute.OperatingSystemTypesWindows
 	vmss.VirtualMachineProfile.OsProfile.LinuxConfiguration = nil
 	vmss.VirtualMachineProfile.OsProfile.WindowsConfiguration = &compute.WindowsConfiguration{
 		EnableAutomaticUpdates: to.BoolPtr(false),
@@ -1051,7 +1051,7 @@ func newDefaultVMSS(vmSize string) compute.VirtualMachineScaleSet {
 												ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet"),
 											},
 											Primary:                         to.BoolPtr(true),
-											PrivateIPAddressVersion:         compute.IPv4,
+											PrivateIPAddressVersion:         compute.IPVersionIPv4,
 											LoadBalancerBackendAddressPools: &[]compute.SubResource{{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/capz-lb/backendAddressPools/backendPool")}},
 										},
 									},

--- a/azure/services/scalesetvms/client.go
+++ b/azure/services/scalesetvms/client.go
@@ -22,8 +22,9 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
@@ -139,7 +140,7 @@ func (ac *azureClient) DeleteAsync(ctx context.Context, resourceGroupName, vmssN
 	ctx, span := tele.Tracer().Start(ctx, "scalesetvms.azureClient.DeleteAsync")
 	defer span.End()
 
-	future, err := ac.scalesetvms.Delete(ctx, resourceGroupName, vmssName, instanceID)
+	future, err := ac.scalesetvms.Delete(ctx, resourceGroupName, vmssName, instanceID, to.BoolPtr(false))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed deleting vmss named %q", vmssName)
 	}

--- a/azure/services/scalesetvms/mock_scalesetvms/client_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"

--- a/azure/services/scalesetvms/scalesetvms_test.go
+++ b/azure/services/scalesetvms/scalesetvms_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"

--- a/azure/services/virtualmachines/client.go
+++ b/azure/services/virtualmachines/client.go
@@ -19,7 +19,7 @@ package virtualmachines
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 

--- a/azure/services/virtualmachines/mock_virtualmachines/client_mock.go
+++ b/azure/services/virtualmachines/mock_virtualmachines/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -484,7 +484,7 @@ func (s *Service) generateOSProfile(ctx context.Context, vmSpec azure.VMSpec) (*
 	}
 
 	switch vmSpec.OSDisk.OSType {
-	case string(compute.Windows):
+	case string(compute.OperatingSystemTypesWindows):
 		// Cloudbase-init is used to generate a password.
 		// https://cloudbase-init.readthedocs.io/en/latest/plugins.html#setting-password-main
 		//

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/utils/pointer"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -657,8 +657,8 @@ func TestReconcileVM(t *testing.T) {
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
 				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
-					g.Expect(vm.Priority).To(Equal(compute.Spot))
-					g.Expect(vm.EvictionPolicy).To(Equal(compute.Deallocate))
+					g.Expect(vm.Priority).To(Equal(compute.VirtualMachinePriorityTypesSpot))
+					g.Expect(vm.EvictionPolicy).To(Equal(compute.VirtualMachineEvictionPolicyTypesDeallocate))
 					g.Expect(vm.BillingProfile).To(BeNil())
 				})
 			},
@@ -743,7 +743,7 @@ func TestReconcileVM(t *testing.T) {
 				s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
 				s.AvailabilitySet().Return("", false)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-vm", gomock.AssignableToTypeOf(compute.VirtualMachine{})).Do(func(_, _, _ interface{}, vm compute.VirtualMachine) {
-					g.Expect(vm.VirtualMachineProperties.StorageProfile.OsDisk.OsType).To(Equal(compute.Windows))
+					g.Expect(vm.VirtualMachineProperties.StorageProfile.OsDisk.OsType).To(Equal(compute.OperatingSystemTypesWindows))
 					g.Expect(*vm.VirtualMachineProperties.OsProfile.AdminPassword).Should(HaveLen(123))
 					g.Expect(*vm.VirtualMachineProperties.OsProfile.AdminUsername).Should(Equal("capi"))
 					g.Expect(*vm.VirtualMachineProperties.OsProfile.WindowsConfiguration.EnableAutomaticUpdates).Should(Equal(false))
@@ -1359,7 +1359,7 @@ func TestReconcileVM(t *testing.T) {
 							StorageAccountType: "Premium_LRS",
 						},
 						DiffDiskSettings: &infrav1.DiffDiskSettings{
-							Option: string(compute.Local),
+							Option: string(compute.DiffDiskOptionsLocal),
 						},
 					},
 					DataDisks: []infrav1.DataDisk{
@@ -1432,7 +1432,7 @@ func TestReconcileVM(t *testing.T) {
 							StorageAccountType: "Premium_LRS",
 						},
 						DiffDiskSettings: &infrav1.DiffDiskSettings{
-							Option: string(compute.Local),
+							Option: string(compute.DiffDiskOptionsLocal),
 						},
 					},
 					DataDisks: []infrav1.DataDisk{
@@ -1483,7 +1483,7 @@ func TestReconcileVM(t *testing.T) {
 									StorageAccountType: "Premium_LRS",
 								},
 								DiffDiskSettings: &compute.DiffDiskSettings{
-									Option: compute.Local,
+									Option: compute.DiffDiskOptionsLocal,
 								},
 							},
 							DataDisks: &[]compute.DataDisk{

--- a/azure/services/vmextensions/client.go
+++ b/azure/services/vmextensions/client.go
@@ -19,7 +19,7 @@ package vmextensions
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"

--- a/azure/services/vmextensions/mock_vmextensions/client_mock.go
+++ b/azure/services/vmextensions/mock_vmextensions/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/azure/services/vmextensions/vmextensions.go
+++ b/azure/services/vmextensions/vmextensions.go
@@ -19,7 +19,7 @@ package vmextensions
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"

--- a/azure/services/vmextensions/vmextensions_test.go
+++ b/azure/services/vmextensions/vmextensions_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/vmextensions/mock_vmextensions"
 

--- a/azure/services/vmssextensions/client.go
+++ b/azure/services/vmssextensions/client.go
@@ -19,7 +19,7 @@ package vmssextensions
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"

--- a/azure/services/vmssextensions/mock_vmssextensions/client_mock.go
+++ b/azure/services/vmssextensions/mock_vmssextensions/client_mock.go
@@ -24,7 +24,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/azure/services/vmssextensions/vmssextensions_test.go
+++ b/azure/services/vmssextensions/vmssextensions_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/vmssextensions/mock_vmssextensions"
 

--- a/controllers/azurecluster_reconciler_test.go
+++ b/controllers/azurecluster_reconciler_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 

--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/cluster-api-provider-azure/azure"

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	autorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/pkg/errors"

--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-30/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	azuresdk "github.com/Azure/go-autorest/autorest/azure"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

This PR updates the Azure compute API Version to `2021-04-01` (from `2020-06-30`). In the large, we simply fulfill any necessary interface changes that the newer API Version requires (primarily changing const references as needed).

There are two specific interface changes that are interesting:

- VMSS client `Get` includes a new `expand` option. We pass in `""` to indicate that we are not using that interface feature
  - https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute#VirtualMachineScaleSetsClient.Get
- VMSS client `Delete` includes a new "force delete" option. We pass in *`false` to bypass this new, preview (as of this new API version) feature
  - https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute#VirtualMachineScaleSetsClient.Delete

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update Azure compute API to 2021-04-01
```
