### PR TITLE
Use same k8s version for linux and windows tests

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -479,17 +479,14 @@ var _ = Describe("Workload cluster creation", func() {
 			clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 				ClusterProxy: bootstrapClusterProxy,
 				ConfigCluster: clusterctl.ConfigClusterInput{
-					LogFolder:              filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
-					ClusterctlConfigPath:   clusterctlConfigPath,
-					KubeconfigPath:         bootstrapClusterProxy.GetKubeconfigPath(),
-					InfrastructureProvider: clusterctl.DefaultInfrastructureProvider,
-					Flavor:                 "windows",
-					Namespace:              namespace.Name,
-					ClusterName:            clusterName,
-					// using a different version for windows because of an issue on azure cloud provider
-					// that only affects windows and external load balancer
-					// https://github.com/kubernetes-sigs/cloud-provider-azure/issues/706
-					KubernetesVersion:        e2eConfig.GetVariable(WindowsKubernetesVersion),
+					LogFolder:                filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
+					ClusterctlConfigPath:     clusterctlConfigPath,
+					KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+					InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+					Flavor:                   "windows",
+					Namespace:                namespace.Name,
+					ClusterName:              clusterName,
+					KubernetesVersion:        e2eConfig.GetVariable(capi_e2e.KubernetesVersion),
 					ControlPlaneMachineCount: pointer.Int64Ptr(3),
 					WorkerMachineCount:       pointer.Int64Ptr(1),
 				},

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -62,7 +62,6 @@ const (
 	JobName                        = "JOB_NAME"
 	Timestamp                      = "TIMESTAMP"
 	AKSKubernetesVersion           = "AKS_KUBERNETES_VERSION"
-	WindowsKubernetesVersion       = "WINDOWS_KUBERNETES_VERSION"
 	ManagedClustersResourceType    = "managedClusters"
 )
 

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -97,10 +97,6 @@ providers:
 
 variables:
   KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.22.1}"
-  # using a different version for windows because of an issue on azure cloud provider
-  # that only affects windows and external load balancer  
-  # https://github.com/kubernetes-sigs/cloud-provider-azure/issues/706
-  WINDOWS_KUBERNETES_VERSION: "${WINDOWS_KUBERNETES_VERSION:-v1.22.1}"
   AKS_KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.19.9}"
   ETCD_VERSION_UPGRADE_TO: "3.4.3-0"
   COREDNS_VERSION_UPGRADE_TO: "1.6.7"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
- Remove the `WINDOWS_KUBERNETES_VERSION` variable from e2e tests config now we are using K8s v1.22.1


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
follow up to this comment here: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1588#discussion_r694371825 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
