### PR TITLE
Fixes #1656 Migrate codecov action to v2

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -12,7 +12,7 @@ jobs:
       with:
         go-version: '^1.17'
     - run: "PATH=/usr/local/go/bin:$PATH make test-cover"
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v2
       with:
         file: ./coverage.out
         fail_ci_if_error: true


### PR DESCRIPTION
update cluster-api-provider-azure/cover.yaml with v2 as v1 is deprecated

This fixes the issue below  #1656
```
Migrate codecov action to v2 #1656
```
<!--
/kind deprecation
-->

```release-note
As part of codecov v1 version deprecation this change is required to update parameters with v2
```
/help
/good-first-issue

