### PR TITLE
Tiltfile decodes Azure SSH key from base 64 encoding

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -223,20 +223,18 @@ def create_crs():
 # create flavor resources from cluster-template files in the templates directory 
 def flavors():
     substitutions = settings.get("kustomize_substitutions", {})
-    ssh_pub_key_B64 = "AZURE_SSH_PUBLIC_KEY_B64"
-    ssh_pub_key_path = "$HOME/.ssh/id_rsa.pub"
-    if substitutions.get(ssh_pub_key_B64):
-        os.environ.update({ssh_pub_key_B64: substitutions.get(ssh_pub_key_B64)})
-    else:
-        print("{} was not specified in tilt-settings.json, attempting to load {}".format(ssh_pub_key_B64, ssh_pub_key_path))
-        os.environ.update({ssh_pub_key_B64: base64_encode_file(ssh_pub_key_path)})
 
-    ssh_pub_key = "AZURE_SSH_PUBLIC_KEY"
-    if substitutions.get(ssh_pub_key):
-        os.environ.update({ssh_pub_key: substitutions.get(ssh_pub_key)})
+    az_key_b64_name = "AZURE_SSH_PUBLIC_KEY_B64"
+    az_key_name = "AZURE_SSH_PUBLIC_KEY"
+    default_key_path = "$HOME/.ssh/id_rsa.pub"
+
+    if substitutions.get(az_key_b64_name):
+        os.environ.update({az_key_b64_name: substitutions.get(az_key_b64_name)})
+        os.environ.update({az_key_name: base64_decode( substitutions.get(az_key_b64_name) )})
     else:
-        print("{} was not specified in tilt-settings.json, attempting to load {}".format(ssh_pub_key_B64, ssh_pub_key_path))
-        os.environ.update({ssh_pub_key: read_file_from_path(ssh_pub_key_path)})
+        print("{} was not specified in tilt-settings.json, attempting to load {}".format(az_key_b64_name, default_key_path))
+        os.environ.update({az_key_b64_name: base64_encode_file(default_key_path)})
+        os.environ.update({az_key_name: read_file_from_path(default_key_path)})
 
     template_list = [ item for item in listdir("./templates") ]
     template_list = [ template for template in template_list if os.path.basename(template).endswith("yaml") ]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->
/kind feature

**What this PR does / why we need it**: Tiltfile uses 'AZURE_SSH_PUBLIC_KEY_B64' to decode 'AZURE_SSH_PUBLIC_KEY' instead of getting the value again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1572 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
