### PR TITLE
fix RANDOM var being omitted on Linux

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -311,7 +311,7 @@ def deploy_worker_templates(template, substitutions):
     yaml = yaml.replace('"', '\\"')     # add escape character to double quotes in yaml
     local_resource(
         name = os.path.basename(flavor),
-        cmd = "CLUSTER_NAME=" + flavor.replace("windows", "win") + "-$(echo $RANDOM); make generate-flavors; echo \"" + yaml + "\" > ./.tiltbuild/" + flavor + "; cat ./.tiltbuild/" + flavor + " | " + envsubst_cmd + " | kubectl apply -f - && echo \"Cluster \'$CLUSTER_NAME\' created, don't forget to delete\"",
+        cmd = "RANDOM=$(bash -c 'echo $RANDOM'); CLUSTER_NAME=" + flavor.replace("windows", "win") + "-$RANDOM; make generate-flavors; echo \"" + yaml + "\" > ./.tiltbuild/" + flavor + "; cat ./.tiltbuild/" + flavor + " | " + envsubst_cmd + " | kubectl apply -f - && echo \"Cluster \'$CLUSTER_NAME\' created, don't forget to delete\"",
         auto_init = False,
         trigger_mode = TRIGGER_MODE_MANUAL,
         labels = [ "flavors" ]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
On Linux when running Tilt and deploying a flavor, the CLUSTER_NAME variable will not be populated with $RANDOM. This change shells out to bash to populate RANDOM env var in sh to be used to generate the CLUSTER_NAME.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
