### PR TITLE
Remove test regions where GPU SKU isn't available

### DIFF
--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -48,7 +48,7 @@ source "${REPO_ROOT}/hack/util.sh"
 : "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
 
 get_random_region() {
-    local REGIONS=("northcentralus" "westus" "westus2" "canadacentral" "eastus" "eastus2" "westeurope" "uksouth" "northeurope" "francecentral")
+    local REGIONS=("eastus" "eastus2" "northcentralus" "northeurope" "uksouth" "westeurope" "westus2")
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -46,7 +46,7 @@ source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 : "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
 
 get_random_region() {
-    local REGIONS=("northcentralus" "westus" "westus2" "canadacentral" "eastus" "eastus2" "westeurope" "uksouth" "northeurope" "francecentral")
+    local REGIONS=("eastus" "eastus2" "northcentralus" "northeurope" "uksouth" "westeurope" "westus2")
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
 

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -41,7 +41,7 @@ source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 source "${REPO_ROOT}/hack/util.sh"
 
 get_random_region() {
-    local REGIONS=("northcentralus" "westus" "westus2" "canadacentral" "eastus" "eastus2" "westeurope" "uksouth" "northeurope" "francecentral")
+    local REGIONS=("eastus" "eastus2" "northcentralus" "northeurope" "uksouth" "westeurope" "westus2")
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Fixes (one of) the problems causing the GPU-enabled cluster tests to fail in [testgrid e2e](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capz-postsubmit-capi-e2e-full-main) by removing three regions where capz controller manager logs show the preferred, less expensive SKU isn't available:

```
09/08 message: failed to reconcile AzureMachine: failed to create network interface: reconcile error that cannot be recovered occurred: failed to get SKU Standard_NV6 in compute api: resource sku with name 'Standard_NV6' and category 'virtualMachines' not found in location 'canadacentral'. Object will not be requeued
09/09 message: failed to reconcile AzureMachine: failed to create network interface: reconcile error that cannot be recovered occurred: failed to get SKU Standard_NV6 in compute api: resource sku with name 'Standard_NV6' and category 'virtualMachines' not found in location 'francecentral'. Object will not be requeued
09/13 message: 	message: failed to reconcile AzureMachine: failed to create network interface: reconcile error that cannot be recovered occurred: failed to get SKU Standard_NV6 in compute api: resource sku with name 'Standard_NV6' and category 'virtualMachines' not found in location 'westus'. Object will not be requeued
```

**Which issue(s) this PR fixes**:

Refs #1648

**Special notes for your reviewer**:

I wanted to move to the next-gen GPU SKU in this PR since `Standard_NV6` is being retired in a year, but getting quota will take some time and maneuvering, so this seems like the simplest change to help.

This doesn't cover it all, but should slow the bleeding.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
