### PR TITLE
Test if GPU resources are available before scheduling e2e job

### DIFF
--- a/test/e2e/azure_gpu.go
+++ b/test/e2e/azure_gpu.go
@@ -61,6 +61,20 @@ func AzureGPUSpec(ctx context.Context, inputGetter func() AzureGPUSpecInput) {
 	clientset := clusterProxy.GetClientSet()
 	Expect(clientset).NotTo(BeNil())
 
+	By("Waiting for a node to have an \"nvidia.com/gpu\" allocatable resource")
+	Eventually(func() bool {
+		nodeList, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		for _, node := range nodeList.Items {
+			for k, v := range node.Status.Allocatable {
+				if k == "nvidia.com/gpu" && v.Value() > 0 {
+					return true
+				}
+			}
+		}
+		return false
+	}, e2eConfig.GetIntervals(specName, "wait-worker-nodes")...).Should(BeTrue())
+
 	By("running a CUDA vector calculation job")
 	jobsClient := clientset.BatchV1().Jobs(corev1.NamespaceDefault)
 	jobName := "cuda-vector-add"


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Fixes (one of) the problems causing the GPU-enabled cluster tests to fail in [testgrid e2e](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capz-postsubmit-capi-e2e-full-main) by waiting for the GPU resources to be exposed before running the cuda-vector Job.

**Which issue(s) this PR fixes**:

Refs #1648

**Special notes for your reviewer**:

The behavior I've observed with the nvidia-operator machinery is that after the node is available, it still takes several minutes for the "nvidia.com/gpu" resource to be available. This has been enough to make the GPU-requiring Job fail. This essentially is just extending the timeout, but will give more information if the failure relates to GPU resources.

I assume this is considered acceptable--I know the previous non-operator implementation also took a little bit to finish `PostKubeAdmCommands`. But if we would rather address it by trying to ensure the GPU resource is available earlier during provisioning, I could look at that instead.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
