### PR TITLE
Try to fix prow CI test failures with iptables change

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -23,6 +23,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# HACK: try to work around networking issues, see https://github.com/kubernetes/test-infra/issues/23741
+iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}" || exit 1
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Tries to work around networking issues that cropped up recently in CI, based on success with this approach by the secrets-store-csi-driver project.

**Which issue(s) this PR fixes**:

Refs kubernetes/test-infra#23741
See kubernetes/test-infra#23744

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
