### PR TITLE
Wiring up CAPZ bootstrapping extension for Windows

### DIFF
--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -221,22 +221,15 @@ func (m *MachineScope) RoleAssignmentSpecs() []azure.RoleAssignmentSpec {
 }
 
 // VMExtensionSpecs returns the vm extension specs.
-func (m *MachineScope) VMExtensionSpecs() []azure.VMExtensionSpec {
-	name, publisher, version := azure.GetBootstrappingVMExtension(m.AzureMachine.Spec.OSDisk.OSType, m.CloudEnvironment())
-	if name != "" {
-		return []azure.VMExtensionSpec{
-			{
-				Name:      name,
-				VMName:    m.Name(),
-				Publisher: publisher,
-				Version:   version,
-				ProtectedSettings: map[string]string{
-					"commandToExecute": azure.BootstrapExtensionCommand(),
-				},
-			},
-		}
+func (m *MachineScope) VMExtensionSpecs() []azure.ExtensionSpec {
+	var extensionSpecs = []azure.ExtensionSpec{}
+	extensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachine.Spec.OSDisk.OSType, m.CloudEnvironment(), m.Name())
+
+	if extensionSpec != nil {
+		extensionSpecs = append(extensionSpecs, *extensionSpec)
 	}
-	return []azure.VMExtensionSpec{}
+
+	return extensionSpecs
 }
 
 // Subnet returns the machine's subnet.

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -586,22 +586,15 @@ func (m *MachinePoolScope) RoleAssignmentSpecs() []azure.RoleAssignmentSpec {
 }
 
 // VMSSExtensionSpecs returns the vmss extension specs.
-func (m *MachinePoolScope) VMSSExtensionSpecs() []azure.VMSSExtensionSpec {
-	name, publisher, version := azure.GetBootstrappingVMExtension(m.AzureMachinePool.Spec.Template.OSDisk.OSType, m.CloudEnvironment())
-	if name != "" {
-		return []azure.VMSSExtensionSpec{
-			{
-				Name:         name,
-				ScaleSetName: m.Name(),
-				Publisher:    publisher,
-				Version:      version,
-				ProtectedSettings: map[string]string{
-					"commandToExecute": azure.BootstrapExtensionCommand(),
-				},
-			},
-		}
+func (m *MachinePoolScope) VMSSExtensionSpecs() []azure.ExtensionSpec {
+	var extensionSpecs = []azure.ExtensionSpec{}
+	extensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachinePool.Spec.Template.OSDisk.OSType, m.CloudEnvironment(), m.Name())
+
+	if extensionSpec != nil {
+		extensionSpecs = append(extensionSpecs, *extensionSpec)
 	}
-	return []azure.VMSSExtensionSpec{}
+
+	return extensionSpecs
 }
 
 func (m *MachinePoolScope) getDeploymentStrategy() machinepool.TypedDeleteSelector {

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -19,8 +19,11 @@ package scope
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
+	autorestazure "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
@@ -33,6 +36,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha4"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	capiv1exp "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	clusterv1exp "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -620,6 +624,212 @@ func TestMachinePoolScope_updateReplicasAndProviderIDs(t *testing.T) {
 			}
 			err := s.updateReplicasAndProviderIDs(context.TODO())
 			c.Verify(g, s.AzureMachinePool, err)
+		})
+	}
+}
+
+func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
+	tests := []struct {
+		name             string
+		machinePoolScope MachinePoolScope
+		want             []azure.ExtensionSpec
+	}{
+		{
+			name: "If OS type is Linux and cloud is AzurePublicCloud, it returns ExtensionSpec",
+			machinePoolScope: MachinePoolScope{
+				MachinePool: &capiv1exp.MachinePool{},
+				AzureMachinePool: &infrav1exp.AzureMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machinepool-name",
+					},
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
+							OSDisk: infrav1.OSDisk{
+								OSType: "Linux",
+							},
+						},
+					},
+				},
+				ClusterScoper: &ClusterScope{
+					AzureClients: AzureClients{
+						EnvironmentSettings: auth.EnvironmentSettings{
+							Environment: autorestazure.Environment{
+								Name: autorestazure.PublicCloud.Name,
+							},
+						},
+					},
+				},
+			},
+			want: []azure.ExtensionSpec{
+				{
+					Name:      "CAPZ.Linux.Bootstrapping",
+					VMName:    "machinepool-name",
+					Publisher: "Microsoft.Azure.ContainerUpstream",
+					Version:   "1.0",
+					ProtectedSettings: map[string]string{
+						"commandToExecute": azure.LinuxBootstrapExtensionCommand,
+					},
+				},
+			},
+		},
+		{
+			name: "If OS type is Linux and cloud is not AzurePublicCloud, it returns empty",
+			machinePoolScope: MachinePoolScope{
+				MachinePool: &capiv1exp.MachinePool{},
+				AzureMachinePool: &infrav1exp.AzureMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machinepool-name",
+					},
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
+							OSDisk: infrav1.OSDisk{
+								OSType: "Linux",
+							},
+						},
+					},
+				},
+				ClusterScoper: &ClusterScope{
+					AzureClients: AzureClients{
+						EnvironmentSettings: auth.EnvironmentSettings{
+							Environment: autorestazure.Environment{
+								Name: autorestazure.USGovernmentCloud.Name,
+							},
+						},
+					},
+				},
+			},
+			want: []azure.ExtensionSpec{},
+		},
+		{
+			name: "If OS type is Windows and cloud is AzurePublicCloud, it returns ExtensionSpec",
+			machinePoolScope: MachinePoolScope{
+				MachinePool: &capiv1exp.MachinePool{},
+				AzureMachinePool: &infrav1exp.AzureMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						// Note: machine pool names longer than 9 characters get truncated. See MachinePoolScope::Name() for more details.
+						Name: "winpool",
+					},
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
+							OSDisk: infrav1.OSDisk{
+								OSType: "Windows",
+							},
+						},
+					},
+				},
+				ClusterScoper: &ClusterScope{
+					AzureClients: AzureClients{
+						EnvironmentSettings: auth.EnvironmentSettings{
+							Environment: autorestazure.Environment{
+								Name: autorestazure.PublicCloud.Name,
+							},
+						},
+					},
+				},
+			},
+			want: []azure.ExtensionSpec{
+				{
+					Name: "CAPZ.Windows.Bootstrapping",
+					// Note: machine pool names longer than 9 characters get truncated. See MachinePoolScope::Name() for more details.
+					VMName:    "winpool",
+					Publisher: "Microsoft.Azure.ContainerUpstream",
+					Version:   "1.0",
+					ProtectedSettings: map[string]string{
+						"commandToExecute": azure.WindowsBootstrapExtensionCommand,
+					},
+				},
+			},
+		},
+		{
+			name: "If OS type is Windows and cloud is not AzurePublicCloud, it returns empty",
+			machinePoolScope: MachinePoolScope{
+				MachinePool: &capiv1exp.MachinePool{},
+				AzureMachinePool: &infrav1exp.AzureMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machinepool-name",
+					},
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
+							OSDisk: infrav1.OSDisk{
+								OSType: "Windows",
+							},
+						},
+					},
+				},
+				ClusterScoper: &ClusterScope{
+					AzureClients: AzureClients{
+						EnvironmentSettings: auth.EnvironmentSettings{
+							Environment: autorestazure.Environment{
+								Name: autorestazure.USGovernmentCloud.Name,
+							},
+						},
+					},
+				},
+			},
+			want: []azure.ExtensionSpec{},
+		},
+		{
+			name: "If OS type is not Linux or Windows and cloud is AzurePublicCloud, it returns empty",
+			machinePoolScope: MachinePoolScope{
+				MachinePool: &capiv1exp.MachinePool{},
+				AzureMachinePool: &infrav1exp.AzureMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machinepool-name",
+					},
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
+							OSDisk: infrav1.OSDisk{
+								OSType: "Other",
+							},
+						},
+					},
+				},
+				ClusterScoper: &ClusterScope{
+					AzureClients: AzureClients{
+						EnvironmentSettings: auth.EnvironmentSettings{
+							Environment: autorestazure.Environment{
+								Name: autorestazure.PublicCloud.Name,
+							},
+						},
+					},
+				},
+			},
+			want: []azure.ExtensionSpec{},
+		},
+		{
+			name: "If OS type is not Windows or Linux and cloud is not AzurePublicCloud, it returns empty",
+			machinePoolScope: MachinePoolScope{
+				MachinePool: &capiv1exp.MachinePool{},
+				AzureMachinePool: &infrav1exp.AzureMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machinepool-name",
+					},
+					Spec: infrav1exp.AzureMachinePoolSpec{
+						Template: infrav1exp.AzureMachinePoolMachineTemplate{
+							OSDisk: infrav1.OSDisk{
+								OSType: "Other",
+							},
+						},
+					},
+				},
+				ClusterScoper: &ClusterScope{
+					AzureClients: AzureClients{
+						EnvironmentSettings: auth.EnvironmentSettings{
+							Environment: autorestazure.Environment{
+								Name: autorestazure.USGovernmentCloud.Name,
+							},
+						},
+					},
+				},
+			},
+			want: []azure.ExtensionSpec{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.machinePoolScope.VMSSExtensionSpecs(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VMSSExtensionSpecs() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/azure/services/scalesets/mock_scalesets/scalesets_mock.go
+++ b/azure/services/scalesets/mock_scalesets/scalesets_mock.go
@@ -495,10 +495,10 @@ func (mr *MockScaleSetScopeMockRecorder) V(level interface{}) *gomock.Call {
 }
 
 // VMSSExtensionSpecs mocks base method.
-func (m *MockScaleSetScope) VMSSExtensionSpecs() []azure.VMSSExtensionSpec {
+func (m *MockScaleSetScope) VMSSExtensionSpecs() []azure.ExtensionSpec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VMSSExtensionSpecs")
-	ret0, _ := ret[0].([]azure.VMSSExtensionSpec)
+	ret0, _ := ret[0].([]azure.ExtensionSpec)
 	return ret0
 }
 

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -49,7 +49,7 @@ type (
 		SaveVMImageToStatus(*infrav1.Image)
 		MaxSurge() (int, error)
 		ScaleSetSpec() azure.ScaleSetSpec
-		VMSSExtensionSpecs() []azure.VMSSExtensionSpec
+		VMSSExtensionSpecs() []azure.ExtensionSpec
 		SetAnnotation(string, string)
 		SetProviderID(string)
 		SetVMSSState(*azure.VMSS)

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -1275,12 +1275,12 @@ func setupVMSSExpectationsWithoutVMImage(s *mock_scalesets.MockScaleSetScopeMock
 	s.Location().AnyTimes().Return("test-location")
 	s.ClusterName().Return("my-cluster")
 	s.GetBootstrapData(gomockinternal.AContext()).Return("fake-bootstrap-data", nil)
-	s.VMSSExtensionSpecs().Return([]azure.VMSSExtensionSpec{
+	s.VMSSExtensionSpecs().Return([]azure.ExtensionSpec{
 		{
-			Name:         "someExtension",
-			ScaleSetName: "my-vmss",
-			Publisher:    "somePublisher",
-			Version:      "someVersion",
+			Name:      "someExtension",
+			VMName:    "my-vmss",
+			Publisher: "somePublisher",
+			Version:   "someVersion",
 			ProtectedSettings: map[string]string{
 				"commandToExecute": "echo hello",
 			},

--- a/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
+++ b/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
@@ -326,10 +326,10 @@ func (mr *MockVMExtensionScopeMockRecorder) V(level interface{}) *gomock.Call {
 }
 
 // VMExtensionSpecs mocks base method.
-func (m *MockVMExtensionScope) VMExtensionSpecs() []azure.VMExtensionSpec {
+func (m *MockVMExtensionScope) VMExtensionSpecs() []azure.ExtensionSpec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VMExtensionSpecs")
-	ret0, _ := ret[0].([]azure.VMExtensionSpec)
+	ret0, _ := ret[0].([]azure.ExtensionSpec)
 	return ret0
 }
 

--- a/azure/services/vmextensions/vmextensions.go
+++ b/azure/services/vmextensions/vmextensions.go
@@ -31,7 +31,7 @@ import (
 type VMExtensionScope interface {
 	logr.Logger
 	azure.ClusterDescriber
-	VMExtensionSpecs() []azure.VMExtensionSpec
+	VMExtensionSpecs() []azure.ExtensionSpec
 	SetBootstrapConditions(string, string) error
 }
 

--- a/azure/services/vmextensions/vmextensions_test.go
+++ b/azure/services/vmextensions/vmextensions_test.go
@@ -45,7 +45,7 @@ func TestReconcileVMExtension(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_vmextensions.MockVMExtensionScopeMockRecorder, m *mock_vmextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				s.VMExtensionSpecs().Return([]azure.VMExtensionSpec{
+				s.VMExtensionSpecs().Return([]azure.ExtensionSpec{
 					{
 						Name:      "my-extension-1",
 						VMName:    "my-vm",
@@ -72,7 +72,7 @@ func TestReconcileVMExtension(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_vmextensions.MockVMExtensionScopeMockRecorder, m *mock_vmextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				s.VMExtensionSpecs().Return([]azure.VMExtensionSpec{
+				s.VMExtensionSpecs().Return([]azure.ExtensionSpec{
 					{
 						Name:      "my-extension-1",
 						VMName:    "my-vm",
@@ -99,7 +99,7 @@ func TestReconcileVMExtension(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_vmextensions.MockVMExtensionScopeMockRecorder, m *mock_vmextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				s.VMExtensionSpecs().Return([]azure.VMExtensionSpec{
+				s.VMExtensionSpecs().Return([]azure.ExtensionSpec{
 					{
 						Name:      "my-extension-1",
 						VMName:    "my-vm",
@@ -126,7 +126,7 @@ func TestReconcileVMExtension(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_vmextensions.MockVMExtensionScopeMockRecorder, m *mock_vmextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				s.VMExtensionSpecs().Return([]azure.VMExtensionSpec{
+				s.VMExtensionSpecs().Return([]azure.ExtensionSpec{
 					{
 						Name:      "my-extension-1",
 						VMName:    "my-vm",
@@ -155,7 +155,7 @@ func TestReconcileVMExtension(t *testing.T) {
 			expectedError: "failed to get vm extension my-extension-1 on vm my-vm: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_vmextensions.MockVMExtensionScopeMockRecorder, m *mock_vmextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				s.VMExtensionSpecs().Return([]azure.VMExtensionSpec{
+				s.VMExtensionSpecs().Return([]azure.ExtensionSpec{
 					{
 						Name:      "my-extension-1",
 						VMName:    "my-vm",
@@ -180,7 +180,7 @@ func TestReconcileVMExtension(t *testing.T) {
 			expectedError: "failed to create VM extension my-extension-1 on VM my-vm in resource group my-rg: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_vmextensions.MockVMExtensionScopeMockRecorder, m *mock_vmextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				s.VMExtensionSpecs().Return([]azure.VMExtensionSpec{
+				s.VMExtensionSpecs().Return([]azure.ExtensionSpec{
 					{
 						Name:      "my-extension-1",
 						VMName:    "my-vm",

--- a/azure/services/vmssextensions/mock_vmssextensions/vmssextensions_mock.go
+++ b/azure/services/vmssextensions/mock_vmssextensions/vmssextensions_mock.go
@@ -326,10 +326,10 @@ func (mr *MockVMSSExtensionScopeMockRecorder) V(level interface{}) *gomock.Call 
 }
 
 // VMSSExtensionSpecs mocks base method.
-func (m *MockVMSSExtensionScope) VMSSExtensionSpecs() []azure.VMSSExtensionSpec {
+func (m *MockVMSSExtensionScope) VMSSExtensionSpecs() []azure.ExtensionSpec {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VMSSExtensionSpecs")
-	ret0, _ := ret[0].([]azure.VMSSExtensionSpec)
+	ret0, _ := ret[0].([]azure.ExtensionSpec)
 	return ret0
 }
 

--- a/azure/services/vmssextensions/vmssextensions.go
+++ b/azure/services/vmssextensions/vmssextensions.go
@@ -30,7 +30,7 @@ import (
 type VMSSExtensionScope interface {
 	logr.Logger
 	azure.ClusterDescriber
-	VMSSExtensionSpecs() []azure.VMSSExtensionSpec
+	VMSSExtensionSpecs() []azure.ExtensionSpec
 	SetBootstrapConditions(string, string) error
 }
 
@@ -54,13 +54,13 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	defer span.End()
 
 	for _, extensionSpec := range s.Scope.VMSSExtensionSpecs() {
-		if existing, err := s.client.Get(ctx, s.Scope.ResourceGroup(), extensionSpec.ScaleSetName, extensionSpec.Name); err == nil {
+		if existing, err := s.client.Get(ctx, s.Scope.ResourceGroup(), extensionSpec.VMName, extensionSpec.Name); err == nil {
 			// check the extension status and set the associated conditions.
 			if retErr := s.Scope.SetBootstrapConditions(to.String(existing.ProvisioningState), extensionSpec.Name); retErr != nil {
 				return retErr
 			}
 		} else if !azure.ResourceNotFound(err) {
-			return errors.Wrapf(err, "failed to get vm extension %s on scale set %s", extensionSpec.Name, extensionSpec.ScaleSetName)
+			return errors.Wrapf(err, "failed to get vm extension %s on scale set %s", extensionSpec.Name, extensionSpec.VMName)
 		}
 		//  Nothing else to do here, the extensions are applied to the model as part of the scale set Reconcile.
 		continue

--- a/azure/services/vmssextensions/vmssextensions_test.go
+++ b/azure/services/vmssextensions/vmssextensions_test.go
@@ -45,12 +45,12 @@ func TestReconcileVMSSExtension(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_vmssextensions.MockVMSSExtensionScopeMockRecorder, m *mock_vmssextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				s.VMSSExtensionSpecs().Return([]azure.VMSSExtensionSpec{
+				s.VMSSExtensionSpecs().Return([]azure.ExtensionSpec{
 					{
-						Name:         "my-extension-1",
-						ScaleSetName: "my-vmss",
-						Publisher:    "some-publisher",
-						Version:      "1.0",
+						Name:      "my-extension-1",
+						VMName:    "my-vmss",
+						Publisher: "some-publisher",
+						Version:   "1.0",
 					},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -72,18 +72,18 @@ func TestReconcileVMSSExtension(t *testing.T) {
 			expectedError: "",
 			expect: func(s *mock_vmssextensions.MockVMSSExtensionScopeMockRecorder, m *mock_vmssextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				s.VMSSExtensionSpecs().Return([]azure.VMSSExtensionSpec{
+				s.VMSSExtensionSpecs().Return([]azure.ExtensionSpec{
 					{
-						Name:         "my-extension-1",
-						ScaleSetName: "my-vmss",
-						Publisher:    "some-publisher",
-						Version:      "1.0",
+						Name:      "my-extension-1",
+						VMName:    "my-vmss",
+						Publisher: "some-publisher",
+						Version:   "1.0",
 					},
 					{
-						Name:         "other-extension",
-						ScaleSetName: "my-vmss",
-						Publisher:    "other-publisher",
-						Version:      "2.0",
+						Name:      "other-extension",
+						VMName:    "my-vmss",
+						Publisher: "other-publisher",
+						Version:   "2.0",
 					},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")
@@ -99,18 +99,18 @@ func TestReconcileVMSSExtension(t *testing.T) {
 			expectedError: "failed to get vm extension my-extension-1 on scale set my-vmss: #: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_vmssextensions.MockVMSSExtensionScopeMockRecorder, m *mock_vmssextensions.MockclientMockRecorder) {
 				s.V(gomock.AssignableToTypeOf(2)).AnyTimes().Return(klogr.New())
-				s.VMSSExtensionSpecs().Return([]azure.VMSSExtensionSpec{
+				s.VMSSExtensionSpecs().Return([]azure.ExtensionSpec{
 					{
-						Name:         "my-extension-1",
-						ScaleSetName: "my-vmss",
-						Publisher:    "some-publisher",
-						Version:      "1.0",
+						Name:      "my-extension-1",
+						VMName:    "my-vmss",
+						Publisher: "some-publisher",
+						Version:   "1.0",
 					},
 					{
-						Name:         "other-extension",
-						ScaleSetName: "my-vmss",
-						Publisher:    "other-publisher",
-						Version:      "2.0",
+						Name:      "other-extension",
+						VMName:    "my-vmss",
+						Publisher: "other-publisher",
+						Version:   "2.0",
 					},
 				})
 				s.ResourceGroup().AnyTimes().Return("my-rg")

--- a/azure/types.go
+++ b/azure/types.go
@@ -207,19 +207,10 @@ type AvailabilitySetSpec struct {
 	Name string
 }
 
-// VMExtensionSpec defines the specification for a VM extension.
-type VMExtensionSpec struct {
+// ExtensionSpec defines the specification for a VM or VMScaleSet extension.
+type ExtensionSpec struct {
 	Name              string
 	VMName            string
-	Publisher         string
-	Version           string
-	ProtectedSettings map[string]string
-}
-
-// VMSSExtensionSpec defines the specification for a VMSS extension.
-type VMSSExtensionSpec struct {
-	Name              string
-	ScaleSetName      string
 	Publisher         string
 	Version           string
 	ProtectedSettings map[string]string


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds an Azure VM extension to ensure VM bootstrapping succeeds for Windows nodes.
```
