### PR TITLE
E2E tests for timesync has issue with closure

### DIFF
--- a/test/e2e/azure_timesync.go
+++ b/test/e2e/azure_timesync.go
@@ -70,12 +70,13 @@ func AzureTimeSyncSpec(ctx context.Context, inputGetter func() AzureTimeSyncSpec
 		var testFuncs []func() error
 		for _, s := range sshInfo {
 			Byf("checking that time synchronization is healthy on %s", s.Hostname)
-
+			// must capture for closure
+			machineInfo := s
 			execToStringFn := func(expected, command string, args ...string) func() error {
 				// don't assert in this test func, just return errors
 				return func() error {
 					f := &strings.Builder{}
-					if err := execOnHost(s.Endpoint, s.Hostname, s.Port, f, command, args...); err != nil {
+					if err := execOnHost(machineInfo.Endpoint, machineInfo.Hostname, machineInfo.Port, f, command, args...); err != nil {
 						return err
 					}
 					if !strings.Contains(f.String(), expected) {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup



<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change

/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
When testing for windows I found the closure variable wasn't handled properly.  As is now, the ssh information is only run against the last VM in the list:

example: https://play.golang.org/p/PDwWMdiQ9Cp

The intent of the test is to run this against every VM.  For Windows we need a different command which is where I noticed this (#1672)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
