### PR TITLE
create AKS with all node pools at creation time

### DIFF
--- a/azure/services/managedclusters/managedclusters_test.go
+++ b/azure/services/managedclusters/managedclusters_test.go
@@ -129,7 +129,7 @@ func TestReconcile(t *testing.T) {
 					Name:              "my-managedcluster",
 					ResourceGroupName: "my-rg",
 				}, nil)
-				s.GetSystemAgentPoolSpecs(gomockinternal.AContext()).AnyTimes().Return([]azure.AgentPoolSpec{
+				s.GetAgentPoolSpecs(gomockinternal.AContext()).AnyTimes().Return([]azure.AgentPoolSpec{
 					{
 						Name:         "my-agentpool",
 						SKU:          "Standard_D4s_v3",

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -213,6 +213,21 @@ func (mr *MockManagedClusterScopeMockRecorder) Error(err, msg interface{}, keysA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockManagedClusterScope)(nil).Error), varargs...)
 }
 
+// GetAgentPoolSpecs mocks base method.
+func (m *MockManagedClusterScope) GetAgentPoolSpecs(ctx context.Context) ([]azure.AgentPoolSpec, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAgentPoolSpecs", ctx)
+	ret0, _ := ret[0].([]azure.AgentPoolSpec)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAgentPoolSpecs indicates an expected call of GetAgentPoolSpecs.
+func (mr *MockManagedClusterScopeMockRecorder) GetAgentPoolSpecs(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentPoolSpecs", reflect.TypeOf((*MockManagedClusterScope)(nil).GetAgentPoolSpecs), ctx)
+}
+
 // GetKubeConfigData mocks base method.
 func (m *MockManagedClusterScope) GetKubeConfigData() []byte {
 	m.ctrl.T.Helper()
@@ -225,21 +240,6 @@ func (m *MockManagedClusterScope) GetKubeConfigData() []byte {
 func (mr *MockManagedClusterScopeMockRecorder) GetKubeConfigData() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKubeConfigData", reflect.TypeOf((*MockManagedClusterScope)(nil).GetKubeConfigData))
-}
-
-// GetSystemAgentPoolSpecs mocks base method.
-func (m *MockManagedClusterScope) GetSystemAgentPoolSpecs(ctx context.Context) ([]azure.AgentPoolSpec, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSystemAgentPoolSpecs", ctx)
-	ret0, _ := ret[0].([]azure.AgentPoolSpec)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSystemAgentPoolSpecs indicates an expected call of GetSystemAgentPoolSpecs.
-func (mr *MockManagedClusterScopeMockRecorder) GetSystemAgentPoolSpecs(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSystemAgentPoolSpecs", reflect.TypeOf((*MockManagedClusterScope)(nil).GetSystemAgentPoolSpecs), ctx)
 }
 
 // HashKey mocks base method.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

/kind bug

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

Fixing issue
https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1743

CAPZ will launch AKS with all the node pools defined.

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CAPZ will launch AKS with all the node pools defined including both system and user node pools.
```
