### PR TITLE
Assign all azs to public ip for backwards compatibility

### DIFF
--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -79,6 +79,7 @@ type ClusterDescriber interface {
 	AdditionalTags() infrav1.Tags
 	AvailabilitySetEnabled() bool
 	CloudProviderConfigOverrides() *infrav1.CloudProviderConfigOverrides
+	FailureDomains() []string
 }
 
 // AsyncStatusUpdater is an interface used to keep track of long running operations in Status that has Conditions and Futures.

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -662,6 +662,20 @@ func (mr *MockClusterDescriberMockRecorder) ClusterName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterName", reflect.TypeOf((*MockClusterDescriber)(nil).ClusterName))
 }
 
+// FailureDomains mocks base method.
+func (m *MockClusterDescriber) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockClusterDescriberMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockClusterDescriber)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockClusterDescriber) HashKey() string {
 	m.ctrl.T.Helper()
@@ -1032,6 +1046,20 @@ func (m *MockClusterScoper) ControlPlaneSubnet() v1alpha4.SubnetSpec {
 func (mr *MockClusterScoperMockRecorder) ControlPlaneSubnet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlPlaneSubnet", reflect.TypeOf((*MockClusterScoper)(nil).ControlPlaneSubnet))
+}
+
+// FailureDomains mocks base method.
+func (m *MockClusterScoper) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockClusterScoperMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockClusterScoper)(nil).FailureDomains))
 }
 
 // GetPrivateDNSZoneName mocks base method.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -605,6 +605,17 @@ func (s *ClusterScope) SetFailureDomain(id string, spec clusterv1.FailureDomainS
 	s.AzureCluster.Status.FailureDomains[id] = spec
 }
 
+// FailureDomains returns the failure domains for the cluster.
+func (s *ClusterScope) FailureDomains() []string {
+	fds := make([]string, len(s.AzureCluster.Status.FailureDomains))
+	i := 0
+	for id := range s.AzureCluster.Status.FailureDomains {
+		fds[i] = id
+		i++
+	}
+	return fds
+}
+
 // SetControlPlaneSecurityRules sets the default security rules of the control plane subnet.
 // Note that this is not done in a webhook as it requires a valid Cluster object to exist to get the API Server port.
 func (s *ClusterScope) SetControlPlaneSecurityRules() {

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -337,6 +337,11 @@ func (s *ManagedControlPlaneScope) CloudProviderConfigOverrides() *infrav1.Cloud
 	return nil
 }
 
+// FailureDomains returns the failure domains for the cluster.
+func (s *ManagedControlPlaneScope) FailureDomains() []string {
+	return []string{}
+}
+
 // ManagedClusterSpec returns the managed cluster spec.
 func (s *ManagedControlPlaneScope) ManagedClusterSpec() (azure.ManagedClusterSpec, error) {
 	decodedSSHPublicKey, err := base64.StdEncoding.DecodeString(s.ControlPlane.Spec.SSHPublicKey)

--- a/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
+++ b/azure/services/availabilitysets/mock_availabilitysets/availabilitysets_mock.go
@@ -224,6 +224,20 @@ func (mr *MockAvailabilitySetScopeMockRecorder) Error(err, msg interface{}, keys
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockAvailabilitySetScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockAvailabilitySetScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockAvailabilitySetScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockAvailabilitySetScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockAvailabilitySetScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -280,6 +280,20 @@ func (mr *MockBastionScopeMockRecorder) Error(err, msg interface{}, keysAndValue
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockBastionScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockBastionScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockBastionScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockBastionScope)(nil).FailureDomains))
+}
+
 // GetPrivateDNSZoneName mocks base method.
 func (m *MockBastionScope) GetPrivateDNSZoneName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/disks/mock_disks/disks_mock.go
+++ b/azure/services/disks/mock_disks/disks_mock.go
@@ -224,6 +224,20 @@ func (mr *MockDiskScopeMockRecorder) Error(err, msg interface{}, keysAndValues .
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockDiskScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockDiskScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockDiskScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockDiskScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockDiskScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
+++ b/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
@@ -210,6 +210,20 @@ func (mr *MockInboundNatScopeMockRecorder) Error(err, msg interface{}, keysAndVa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockInboundNatScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockInboundNatScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockInboundNatScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockInboundNatScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockInboundNatScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -266,6 +266,20 @@ func (mr *MockLBScopeMockRecorder) Error(err, msg interface{}, keysAndValues ...
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockLBScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockLBScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockLBScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockLBScope)(nil).FailureDomains))
+}
+
 // GetPrivateDNSZoneName mocks base method.
 func (m *MockLBScope) GetPrivateDNSZoneName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -213,6 +213,20 @@ func (mr *MockManagedClusterScopeMockRecorder) Error(err, msg interface{}, keysA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockManagedClusterScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockManagedClusterScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockManagedClusterScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockManagedClusterScope)(nil).FailureDomains))
+}
+
 // GetAgentPoolSpecs mocks base method.
 func (m *MockManagedClusterScope) GetAgentPoolSpecs(ctx context.Context) ([]azure.AgentPoolSpec, error) {
 	m.ctrl.T.Helper()

--- a/azure/services/natgateways/mock_natgateways/natgateways_mock.go
+++ b/azure/services/natgateways/mock_natgateways/natgateways_mock.go
@@ -266,6 +266,20 @@ func (mr *MockNatGatewayScopeMockRecorder) Error(err, msg interface{}, keysAndVa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockNatGatewayScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockNatGatewayScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockNatGatewayScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockNatGatewayScope)(nil).FailureDomains))
+}
+
 // GetPrivateDNSZoneName mocks base method.
 func (m *MockNatGatewayScope) GetPrivateDNSZoneName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
+++ b/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
@@ -210,6 +210,20 @@ func (mr *MockNICScopeMockRecorder) Error(err, msg interface{}, keysAndValues ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockNICScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockNICScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockNICScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockNICScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockNICScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/privatedns/mock_privatedns/privatedns_mock.go
+++ b/azure/services/privatedns/mock_privatedns/privatedns_mock.go
@@ -210,6 +210,20 @@ func (mr *MockScopeMockRecorder) Error(err, msg interface{}, keysAndValues ...in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/publicips/mock_publicips/publicips_mock.go
+++ b/azure/services/publicips/mock_publicips/publicips_mock.go
@@ -210,6 +210,20 @@ func (mr *MockPublicIPScopeMockRecorder) Error(err, msg interface{}, keysAndValu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockPublicIPScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockPublicIPScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockPublicIPScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockPublicIPScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockPublicIPScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/publicips/publicips.go
+++ b/azure/services/publicips/publicips.go
@@ -94,6 +94,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 					PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 					DNSSettings:              dnsSettings,
 				},
+				Zones: to.StringSlicePtr(s.Scope.FailureDomains()),
 			},
 		)
 

--- a/azure/services/publicips/publicips_test.go
+++ b/azure/services/publicips/publicips_test.go
@@ -77,6 +77,7 @@ func TestReconcilePublicIP(t *testing.T) {
 				s.ClusterName().AnyTimes().Return("my-cluster")
 				s.AdditionalTags().AnyTimes().Return(infrav1.Tags{})
 				s.Location().AnyTimes().Return("testlocation")
+				s.FailureDomains().AnyTimes().Return([]string{"1,2,3"})
 				gomock.InOrder(
 					m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-publicip", gomockinternal.DiffEq(network.PublicIPAddress{
 						Name:     to.StringPtr("my-publicip"),
@@ -94,6 +95,7 @@ func TestReconcilePublicIP(t *testing.T) {
 								Fqdn:            to.StringPtr("fakedns.mydomain.io"),
 							},
 						},
+						Zones: to.StringSlicePtr([]string{"1,2,3"}),
 					})).Times(1),
 					m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-publicip-2", gomockinternal.DiffEq(network.PublicIPAddress{
 						Name:     to.StringPtr("my-publicip-2"),
@@ -111,6 +113,7 @@ func TestReconcilePublicIP(t *testing.T) {
 								Fqdn:            to.StringPtr("fakedns2-52959.uksouth.cloudapp.azure.com"),
 							},
 						},
+						Zones: to.StringSlicePtr([]string{"1,2,3"}),
 					})).Times(1),
 					m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-publicip-3", gomockinternal.DiffEq(network.PublicIPAddress{
 						Name:     to.StringPtr("my-publicip-3"),
@@ -124,6 +127,7 @@ func TestReconcilePublicIP(t *testing.T) {
 							PublicIPAddressVersion:   network.IPVersionIPv4,
 							PublicIPAllocationMethod: network.IPAllocationMethodStatic,
 						},
+						Zones: to.StringSlicePtr([]string{"1,2,3"}),
 					})).Times(1),
 					m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-publicip-ipv6", gomockinternal.DiffEq(network.PublicIPAddress{
 						Name:     to.StringPtr("my-publicip-ipv6"),
@@ -141,6 +145,7 @@ func TestReconcilePublicIP(t *testing.T) {
 								Fqdn:            to.StringPtr("fakename.mydomain.io"),
 							},
 						},
+						Zones: to.StringSlicePtr([]string{"1,2,3"}),
 					})).Times(1),
 				)
 			},
@@ -160,6 +165,7 @@ func TestReconcilePublicIP(t *testing.T) {
 				s.ClusterName().AnyTimes().Return("my-cluster")
 				s.AdditionalTags().AnyTimes().Return(infrav1.Tags{})
 				s.Location().AnyTimes().Return("testlocation")
+				s.FailureDomains().Times(1)
 				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-publicip", gomock.AssignableToTypeOf(network.PublicIPAddress{})).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 			},
 		},

--- a/azure/services/roleassignments/mock_roleassignments/roleassignments_mock.go
+++ b/azure/services/roleassignments/mock_roleassignments/roleassignments_mock.go
@@ -210,6 +210,20 @@ func (mr *MockRoleAssignmentScopeMockRecorder) Error(err, msg interface{}, keysA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockRoleAssignmentScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockRoleAssignmentScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockRoleAssignmentScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockRoleAssignmentScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockRoleAssignmentScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/routetables/mock_routetables/routetables_mock.go
+++ b/azure/services/routetables/mock_routetables/routetables_mock.go
@@ -266,6 +266,20 @@ func (mr *MockRouteTableScopeMockRecorder) Error(err, msg interface{}, keysAndVa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockRouteTableScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockRouteTableScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockRouteTableScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockRouteTableScope)(nil).FailureDomains))
+}
+
 // GetPrivateDNSZoneName mocks base method.
 func (m *MockRouteTableScope) GetPrivateDNSZoneName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/scalesets/mock_scalesets/scalesets_mock.go
+++ b/azure/services/scalesets/mock_scalesets/scalesets_mock.go
@@ -224,6 +224,20 @@ func (mr *MockScaleSetScopeMockRecorder) Error(err, msg interface{}, keysAndValu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockScaleSetScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockScaleSetScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockScaleSetScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockScaleSetScope)(nil).FailureDomains))
+}
+
 // GetBootstrapData mocks base method.
 func (m *MockScaleSetScope) GetBootstrapData(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/scalesetvms_mock.go
@@ -223,6 +223,20 @@ func (mr *MockScaleSetVMScopeMockRecorder) Error(err, msg interface{}, keysAndVa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockScaleSetVMScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockScaleSetVMScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockScaleSetVMScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockScaleSetVMScope)(nil).FailureDomains))
+}
+
 // GetLongRunningOperationState mocks base method.
 func (m *MockScaleSetVMScope) GetLongRunningOperationState(arg0, arg1 string) *v1alpha4.Future {
 	m.ctrl.T.Helper()

--- a/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
+++ b/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
@@ -266,6 +266,20 @@ func (mr *MockNSGScopeMockRecorder) Error(err, msg interface{}, keysAndValues ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockNSGScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockNSGScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockNSGScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockNSGScope)(nil).FailureDomains))
+}
+
 // GetPrivateDNSZoneName mocks base method.
 func (m *MockNSGScope) GetPrivateDNSZoneName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/subnets/mock_subnets/subnets_mock.go
+++ b/azure/services/subnets/mock_subnets/subnets_mock.go
@@ -266,6 +266,20 @@ func (mr *MockSubnetScopeMockRecorder) Error(err, msg interface{}, keysAndValues
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockSubnetScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockSubnetScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockSubnetScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockSubnetScope)(nil).FailureDomains))
+}
+
 // GetPrivateDNSZoneName mocks base method.
 func (m *MockSubnetScope) GetPrivateDNSZoneName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/tags/mock_tags/tags_mock.go
+++ b/azure/services/tags/mock_tags/tags_mock.go
@@ -225,6 +225,20 @@ func (mr *MockTagScopeMockRecorder) Error(err, msg interface{}, keysAndValues ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockTagScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockTagScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockTagScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockTagScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockTagScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
+++ b/azure/services/virtualmachines/mock_virtualmachines/virtualmachines_mock.go
@@ -227,6 +227,20 @@ func (mr *MockVMScopeMockRecorder) Error(err, msg interface{}, keysAndValues ...
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockVMScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockVMScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockVMScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockVMScope)(nil).FailureDomains))
+}
+
 // GetBootstrapData mocks base method.
 func (m *MockVMScope) GetBootstrapData(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
+++ b/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
@@ -210,6 +210,20 @@ func (mr *MockVNetScopeMockRecorder) Error(err, msg interface{}, keysAndValues .
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockVNetScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockVNetScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockVNetScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockVNetScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockVNetScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
+++ b/azure/services/vmextensions/mock_vmextensions/vmextensions_mock.go
@@ -210,6 +210,20 @@ func (mr *MockVMExtensionScopeMockRecorder) Error(err, msg interface{}, keysAndV
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockVMExtensionScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockVMExtensionScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockVMExtensionScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockVMExtensionScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockVMExtensionScope) HashKey() string {
 	m.ctrl.T.Helper()

--- a/azure/services/vmssextensions/mock_vmssextensions/vmssextensions_mock.go
+++ b/azure/services/vmssextensions/mock_vmssextensions/vmssextensions_mock.go
@@ -210,6 +210,20 @@ func (mr *MockVMSSExtensionScopeMockRecorder) Error(err, msg interface{}, keysAn
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockVMSSExtensionScope)(nil).Error), varargs...)
 }
 
+// FailureDomains mocks base method.
+func (m *MockVMSSExtensionScope) FailureDomains() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailureDomains")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FailureDomains indicates an expected call of FailureDomains.
+func (mr *MockVMSSExtensionScopeMockRecorder) FailureDomains() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockVMSSExtensionScope)(nil).FailureDomains))
+}
+
 // HashKey mocks base method.
 func (m *MockVMSSExtensionScope) HashKey() string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**: 
This pr assigns all available azs in the cluster's region to public ip. This is required to mimic the old sdk behaviour so that clusters created in version prior to v0.4.15 don't break.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1739 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Assign all azs to public ip for backwards compatibility
```
