### PR TITLE
export KUBECTL in ci-entrypoint.sh to fix cluster provisioning

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -33,7 +33,11 @@ source "${REPO_ROOT}/hack/ensure-kind.sh"
 # building kubectl from tools folder
 mkdir -p "${REPO_ROOT}/hack/tools/bin"
 KUBECTL=$(realpath hack/tools/bin/kubectl)
+# export the variable so it is available in bash -c wait_for_nodes below
+export KUBECTL
 make "${KUBECTL}" &>/dev/null
+echo "KUBECTL is set to ${KUBECTL}"
+
 
 # shellcheck source=hack/ensure-kustomize.sh
 source "${REPO_ROOT}/hack/ensure-kustomize.sh"


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature

/kind api-change

/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:

Fixes a regression introduced by https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1683 where kubectl envvar was not available.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
