### PR TITLE
Add supported versions link

### DIFF
--- a/docs/book/src/topics/getting-started.md
+++ b/docs/book/src/topics/getting-started.md
@@ -6,6 +6,7 @@
 
 - A [Microsoft Azure account](https://azure.microsoft.com/en-us/)
 - Install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+- A [supported version](https://github.com/kubernetes-sigs/cluster-api-provider-azure#support-policy) of `clusterctl`
 
 ### Setting up your Azure environment
 


### PR DESCRIPTION
Related - https://github.com/kubernetes-sigs/cluster-api/issues/5448

```release-note
Docs: Add links to supported versions in quickstart
```