### PR TITLE
🌱 use k8s-staging-test-infra/gcb-docker-gcloud

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
Related:
 - Part of: https://github.com/kubernetes/k8s.io/issues/1523
 - Followup of: https://github.com/kubernetes/test-infra/pull/23656

Use a version of gcb-docker-gcloud that is hosted in a community-owned
repo instead of a google.com-owned repo.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
