### PR TITLE
Run the kubescape security scanner in e2e tests

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -357,6 +357,19 @@ var _ = Describe("Workload cluster creation", func() {
 				WaitForMachinePools:          e2eConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 			}, result)
 
+			Context("Running a security scanner", func() {
+				KubescapeSpec(ctx, func() KubescapeSpecInput {
+					return KubescapeSpecInput{
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+						FailThreshold:         e2eConfig.GetVariable(SecurityScanFailThreshold),
+						Container:             e2eConfig.GetVariable(SecurityScanContainer),
+						SkipCleanup:           skipCleanup,
+					}
+				})
+			})
+
 			Context("Validating time synchronization", func() {
 				AzureTimeSyncSpec(ctx, func() AzureTimeSyncSpecInput {
 					return AzureTimeSyncSpecInput{

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -64,6 +64,8 @@ const (
 	JobName                        = "JOB_NAME"
 	Timestamp                      = "TIMESTAMP"
 	AKSKubernetesVersion           = "AKS_KUBERNETES_VERSION"
+	SecurityScanFailThreshold      = "SECURITY_SCAN_FAIL_THRESHOLD"
+	SecurityScanContainer          = "SECURITY_SCAN_CONTAINER"
 	ManagedClustersResourceType    = "managedClusters"
 	capiImagePublisher             = "cncf-upstream"
 	capiOfferName                  = "capi"

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -199,6 +199,8 @@ variables:
   INIT_WITH_KUBERNETES_VERSION: "v1.21.2"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
+  SECURITY_SCAN_FAIL_THRESHOLD: "${SECURITY_SCAN_FAIL_THRESHOLD:-8}"
+  SECURITY_SCAN_CONTAINER: "${SECURITY_SCAN_CONTAINER:-quay.io/armosec/kubescape:v1.0.138}"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e/kubescape.go
+++ b/test/e2e/kubescape.go
@@ -1,0 +1,197 @@
+// +build e2e
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/test/framework"
+)
+
+// KubescapeSpecInput is the input for KubescapeSpec.
+type KubescapeSpecInput struct {
+	BootstrapClusterProxy framework.ClusterProxy
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	FailThreshold         string
+	Container             string
+	SkipCleanup           bool
+}
+
+// KubescapeSpec implements a test that runs the kubescape security scanner.
+// See https://github.com/armosec/kubescape for details about kubescape.
+func KubescapeSpec(ctx context.Context, inputGetter func() KubescapeSpecInput) {
+	var (
+		specName      = "kubescape-scan"
+		input         KubescapeSpecInput
+		failThreshold int
+	)
+
+	input = inputGetter()
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+	failThreshold, err := strconv.Atoi(input.FailThreshold)
+	Expect(err).NotTo(HaveOccurred(), "Invalid argument. input.FailThreshold can't be parsed to int when calling %s spec", specName)
+	Expect(failThreshold).To(BeNumerically(">=", 0), "Invalid argument. input.FailThreshold can't be less than 0 when calling %s spec", specName)
+	Expect(failThreshold).To(BeNumerically("<=", 100), "Invalid argument. input.FailThreshold can't be more than 100 when calling %s spec", specName)
+	Expect(input.Container).NotTo(BeEmpty(), "Invalid argument. input.Container can't be empty when calling %s spec", specName)
+
+	By("creating a Kubernetes client to the workload cluster")
+	clusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
+	Expect(clusterProxy).NotTo(BeNil())
+	clientset := clusterProxy.GetClientSet()
+	Expect(clientset).NotTo(BeNil())
+
+	By("running a security scan job")
+	const (
+		saName                 = "kubescape-discovery"
+		roleName               = saName + "-role"
+		roleBindingName        = roleName + "binding"
+		clusterRoleName        = saName + "-clusterrole"
+		clusterRoleBindingName = clusterRoleName + "binding"
+	)
+
+	Log("Creating a service account")
+	saClient := clientset.CoreV1().ServiceAccounts(corev1.NamespaceDefault)
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: corev1.NamespaceDefault,
+			Labels:    map[string]string{"app": "kubescape"},
+		},
+	}
+	_, err = saClient.Create(ctx, serviceAccount, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	Log("Creating a role")
+	rolesClient := clientset.RbacV1().Roles(corev1.NamespaceDefault)
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: corev1.NamespaceDefault},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{rbacv1.APIGroupAll},
+				Resources: []string{rbacv1.ResourceAll},
+				Verbs:     []string{"get", "list", "describe"},
+			},
+		},
+	}
+	_, err = rolesClient.Create(ctx, role, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	Log("Creating a role binding")
+	rolebindingsClient := clientset.RbacV1().RoleBindings(corev1.NamespaceDefault)
+	rolebinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: roleBindingName, Namespace: corev1.NamespaceDefault},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: roleName},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: saName}},
+	}
+	_, err = rolebindingsClient.Create(ctx, rolebinding, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	Log("Creating a cluster role")
+	clusterRolesClient := clientset.RbacV1().ClusterRoles()
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{rbacv1.APIGroupAll},
+				Resources: []string{rbacv1.ResourceAll},
+				Verbs:     []string{"get", "list", "describe"},
+			},
+		},
+	}
+	_, err = clusterRolesClient.Create(ctx, clusterRole, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	Log("Creating a cluster role binding")
+	clusterRolebindingsClient := clientset.RbacV1().ClusterRoleBindings()
+	clusterRolebinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: clusterRoleName},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: saName, Namespace: corev1.NamespaceDefault}},
+	}
+	_, err = clusterRolebindingsClient.Create(ctx, clusterRolebinding, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	Log("Creating a security scan job")
+	jobsClient := clientset.BatchV1().Jobs(corev1.NamespaceDefault)
+	args := []string{"scan", "framework", "nsa", "--enable-host-scan", "--exclude-namespaces", "kube-system,kube-public"}
+	if failThreshold < 100 {
+		args = append(args, "--fail-threshold", strconv.Itoa(failThreshold))
+	}
+	scanJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: specName, Namespace: corev1.NamespaceDefault},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  specName,
+							Image: input.Container,
+							Args:  args,
+						},
+					},
+					NodeSelector:       map[string]string{corev1.LabelOSStable: "linux"},
+					RestartPolicy:      corev1.RestartPolicyNever,
+					ServiceAccountName: saName,
+				},
+			},
+		},
+	}
+	_, err = jobsClient.Create(ctx, scanJob, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	scanJobInput := WaitForJobCompleteInput{
+		Getter:    jobsClientAdapter{client: jobsClient},
+		Job:       scanJob,
+		Clientset: clientset,
+	}
+	WaitForJobComplete(ctx, scanJobInput, e2eConfig.GetIntervals(specName, "wait-job")...)
+
+	fmt.Fprint(GinkgoWriter, getJobPodLogs(ctx, scanJobInput))
+
+	if !input.SkipCleanup {
+		Log("Cleaning up resources")
+		if err := jobsClient.Delete(ctx, specName, metav1.DeleteOptions{}); err != nil {
+			Logf("Failed to delete job %s: %v", specName, err)
+		}
+		if err := clusterRolebindingsClient.Delete(ctx, clusterRoleBindingName, metav1.DeleteOptions{}); err != nil {
+			Logf("Failed to delete cluster role binding %s: %v", clusterRoleBindingName, err)
+		}
+		if err := clusterRolesClient.Delete(ctx, clusterRoleName, metav1.DeleteOptions{}); err != nil {
+			Logf("Failed to delete cluster role %s: %v", clusterRoleName, err)
+		}
+		if err := rolebindingsClient.Delete(ctx, roleBindingName, metav1.DeleteOptions{}); err != nil {
+			Logf("Failed to delete role binding %s: %v", roleBindingName, err)
+		}
+		if err := rolesClient.Delete(ctx, roleName, metav1.DeleteOptions{}); err != nil {
+			Logf("Failed to delete role %s: %v", roleName, err)
+		}
+		if err := saClient.Delete(ctx, saName, metav1.DeleteOptions{}); err != nil {
+			Logf("Failed to delete service account %s: %v", saName, err)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**:

/kind other

**What this PR does / why we need it**:

Runs a Kubernetes job in e2e with the open source [`kubescape`](https://github.com/armosec/kubescape) security scanner and logs the results to stdout. Fails the test if the overall score drops below a specified threshold (currently 92% passing).

Inspired by the blog post [Kubernetes hardening using Kubescape](https://medium.com/@LachlanEvenson/kubernetes-hardening-using-kubescape-ab7f9df341cc).

Here is an example of the output it shows for a VMSS workload cluster in e2e:

<details>
<summary><b>STEP: running a security scan job...92%</b></summary>
<pre>
[1mSTEP[0m: running a security scan job
Oct 25 23:35:08.320: INFO: Creating a service account
Oct 25 23:35:08.549: INFO: Creating a role
Oct 25 23:35:08.607: INFO: Creating a role binding
Oct 25 23:35:08.667: INFO: Creating a cluster role
Oct 25 23:35:08.793: INFO: Creating a cluster role binding
Oct 25 23:35:08.852: INFO: Creating a security scan job
[1mSTEP[0m: waiting for job default/kubescape-scan to be complete
Oct 25 23:35:08.954: INFO: waiting for job default/kubescape-scan to be complete
Oct 25 23:35:19.073: INFO: job default/kubescape-scan is complete, took 10.118964003s
Oct 25 23:35:19.224: INFO: Output of "kubescape scan framework nsa --exclude-namespaces kube-system,kube-public":
Warning: You are not updated to the latest release: v1.0.126
ARMO security scanner starting
[progress] Downloading/Loading policy definitions
[success] Downloaded/Loaded policy
[progress] Accessing Kubernetes objects
E1025 23:35:14.858683       1 resourcegroupmapping.go:91] Resource 'podsecuritypolicies' unknown
W1025 23:35:14.899942       1 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
[success] Accessed successfully to Kubernetes objects, let’s start!!!
[progress] Scanning cluster 
E1025 23:35:15.036718       1 resourcegroupmapping.go:91] Resource 'podsecuritypolicies' unknown
[success] Done scanning cluster 
[control: Allow privilege escalation] failed 😥
Description: Attackers may gain access to a container and uplift its privilege to enable excessive capabilities.
Failed:
   Namespace default
      Job - kubescape-scan
Summary - Passed:0   Excluded:0   Failed:1   Total:1
Remediation: If your application does not need it, make sure the allowPrivilegeEscalation field of the securityContext is set to false.

[control: Allowed hostPath] passed 👍
Description: Mounting host directory to the container can be abused to get access to sensitive data and gain persistence on the host machine.
Summary - Passed:1   Excluded:0   Failed:0   Total:1

[control: Applications credentials in configuration files] failed 😥
Description: Attackers who have access to configuration files can steal the stored secrets and use them. This control checks if ConfigMaps or pod specifications have sensitive information in their configuration.
Failed:
   Namespace default
      ConfigMap - kube-root-ca.crt
   Namespace kube-node-lease
      ConfigMap - kube-root-ca.crt
Summary - Passed:1   Excluded:0   Failed:2   Total:3
Remediation: Use Kubernetes secrets or Key Management Systems to store credentials.

[control: Automatic mapping of service account] failed 😥
Description: Potential attacker may gain access to a POD and steal its service account token. Therefore, it is recommended to disable automatic mapping of the service account tokens in service account configuration and enable it only for PODs that need to use them.
Failed:
   Namespace default
      ServiceAccount - default
      ServiceAccount - kubescape-discovery
   Namespace kube-node-lease
      ServiceAccount - default
Summary - Passed:0   Excluded:0   Failed:3   Total:3
Remediation: Disable automatic mounting of service account tokens to PODs either at the service account level or at the individual POD level, by specifying the automountServiceAccountToken: false. Note that POD level takes precedence.

[control: CVE-2021-25741 - Using symlink for arbitrary host file system access.] passed 👍
Description: A user may be able to create a container with subPath or subPathExpr volume mounts to access files & directories anywhere on the host filesystem. Following Kubernetes versions are affected: v1.22.0 - v1.22.1, v1.21.0 - v1.21.4, v1.20.0 - v1.20.10, version v1.19.14 and lower. This control checks the vulnerable versions and the actual usage of the subPath feature in all Pods in the cluster.
Summary - Passed:8   Excluded:0   Failed:0   Total:8

[control: CVE-2021-25742-nginx-ingress-snippet-annotation-vulnerability] passed 👍
Description: Security issue in ingress-nginx where a user that can create or update ingress objects can use the custom snippets feature to obtain all secrets in the cluster (see more at https://github.com/kubernetes/ingress-nginx/issues/7837)
Summary - Passed:2   Excluded:0   Failed:0   Total:2

[control: Cluster-admin binding] failed 😥
Description: Attackers who have cluster admin permissions (can perform any action on any resource), can take advantage of their privileges for malicious activities. This control determines which subjects have cluster admin permissions.
Failed:
      ClusterRole - cluster-admin
      ClusterRoleBinding - cluster-admin
Summary - Passed:119   Excluded:0   Failed:2   Total:121
Remediation: You should apply least privilege principle. Make sure cluster admin permissions are granted only when it is absolutely necessary. Don't use subjects with such high permissions for daily operations.

[control: Container hostPort] passed 👍
Description: Configuring hostPort limits you to a particular port, and if any two workloads that specify the same HostPort they cannot be deployed to the same node. Therefore, if the number of replica of such workload is higher than the number of nodes, the deployment will fail.
Summary - Passed:1   Excluded:0   Failed:0   Total:1

[control: Control plane hardening] passed 👍
Description: Kubernetes control plane API is running with non-secure port enabled which allows attackers to gain unprotected access to the cluster.
Summary - Passed:1   Excluded:0   Failed:0   Total:1

[control: Dangerous capabilities] passed 👍
Description: Giving dangerous and unnecessary LINUX capabilities to a container can increase the impact of the container compromise. This control identifies all the PODs with dangerous capabilities such as SYS_ADMIN and others.
Summary - Passed:1   Excluded:0   Failed:0   Total:1

[control: Exec into container] failed 😥
Description: Attackers with relevant permissions can run malicious commands in the context of legitimate containers in the cluster using “kubectl exec” command. This control determines which subjects have permissions to use this command.
Failed:
      ClusterRole - cluster-admin
      ClusterRoleBinding - cluster-admin
Summary - Passed:119   Excluded:0   Failed:2   Total:121
Remediation: It is recommended to prohibit “kubectl exec” command in production environments. It is also recommended not to use subjects with this permission for daily cluster operations.

[control: Exposed dashboard] passed 👍
Description: Kubernetes dashboard versions before v2.0.1 do not support user authentication. If exposed externally, it will allow unauthenticated remote management of the cluster. This control checks presence of the kubernetes-dashboard deployment and its version number.
Summary - Passed:1   Excluded:0   Failed:0   Total:1

[control: Host PID/IPC privileges] passed 👍
Description: Containers should be as isolated as possible from the host machine. The hostPID and hostIPC fields in Kubernetes may excessively expose the host to potentially malicious actions.
Summary - Passed:1   Excluded:0   Failed:0   Total:1

[control: Immutable container filesystem] failed 😥
Description: Mutable container filesystem can be abused to inject malicious code or data into containers. Use immutable (read-only) filesystem to limit potential attacks.
Failed:
   Namespace default
      Job - kubescape-scan
Summary - Passed:0   Excluded:0   Failed:1   Total:1
Remediation: Set the filesystem of the container to read-only when possible (POD securityContext, readOnlyRootFilesystem: true). If containers application needs to write into the filesystem, it is recommended to mount secondary filesystems for specific directories where application require write access.

[control: Ingress and Egress blocked] failed 😥
Description: Disable Ingress and Egress traffic on all pods wherever possible. It is recommended to define restrictive network policy on all new PODs, and then enable sources/destinations that this POD must communicate with.
Failed:
   Namespace default
      Job - kubescape-scan
Summary - Passed:0   Excluded:0   Failed:1   Total:1
Remediation: Define a network policy that restricts ingress and egress connections.

[control: Insecure capabilities] passed 👍
Description: Giving insecure or excsessive capabilities to a container can increase the impact of the container compromise. This control identifies all the PODs with dangerous capabilities (see documentation pages for details).
Summary - Passed:1   Excluded:0   Failed:0   Total:1

[control: Linux hardening] failed 😥
Description: Containers may be given more privileges than they actually need. This can increase the potential impact of a container compromise.
Failed:
   Namespace default
      Job - kubescape-scan
Summary - Passed:0   Excluded:0   Failed:1   Total:1
Remediation: You can use AppArmor, Seccomp, SELinux and Linux Capabilities mechanisms to restrict containers abilities to utilize unwanted privileges.

[control: Network policies] failed 😥
Description: If no network policy is defined, attackers who gain access to a single container may use it to probe the network. This control lists all namespaces in which no network policies are defined.
Failed:
      Namespace - default
      Namespace - kube-node-lease
Summary - Passed:0   Excluded:0   Failed:2   Total:2
Remediation: Define network policies or use similar network protection mechanisms.

[control: Non-root containers] passed 👍
Description: Potential attackers may gain access to a container and leverage its existing privileges to conduct an attack. Therefore, it is not recommended to deploy containers with root privileges unless it is absolutely necessary. This contol identifies all the Pods running as root or can escalate to root.
Summary - Passed:1   Excluded:0   Failed:0   Total:1

[control: Privileged container] passed 👍
Description: Potential attackers may gain access to privileged containers and inherit access to the host resources. Therefore, it is not recommended to deploy privileged containers unless it is absolutely necessary. This control identifies all the privileged Pods.
Summary - Passed:1   Excluded:0   Failed:0   Total:1

[control: Resource policies] failed 😥
Description: CPU and memory resources should have a limit set for every container to prevent resource exhaustion. This control identifies all the Pods without resource limit definition.
Failed:
   Namespace default
      Job - kubescape-scan
Summary - Passed:0   Excluded:0   Failed:1   Total:1
Remediation: Define LimitRange and ResourceQuota policies to limit resource usage for namespaces or nodes.

[control: hostNetwork access] passed 👍
Description: Potential attackers may gain access to a POD and inherit access to the entire host network. For example, in AWS case, they will have access to the entire VPC. This control identifies all the PODs with host network access enabled.
Summary - Passed:1   Excluded:0   Failed:0   Total:1

+-----------------------------------------------------------------------+------------------+--------------------+---------------+-----------+
|                             CONTROL NAME                              | FAILED RESOURCES | EXCLUDED RESOURCES | ALL RESOURCES | % SUCCESS |
+-----------------------------------------------------------------------+------------------+--------------------+---------------+-----------+
| Allow privilege escalation                                            |        1         |         0          |       1       |    0%     |
| Allowed hostPath                                                      |        0         |         0          |       1       |   100%    |
| Applications credentials in configuration files                       |        2         |         0          |       3       |    33%    |
| Automatic mapping of service account                                  |        3         |         0          |       3       |    0%     |
| CVE-2021-25741 - Using symlink for arbitrary host file system access. |        0         |         0          |       8       |   100%    |
| CVE-2021-25742-nginx-ingress-snippet-annotation-vulnerability         |        0         |         0          |       2       |   100%    |
| Cluster-admin binding                                                 |        2         |         0          |      121      |    98%    |
| Container hostPort                                                    |        0         |         0          |       1       |   100%    |
| Control plane hardening                                               |        0         |         0          |       1       |   100%    |
| Dangerous capabilities                                                |        0         |         0          |       1       |   100%    |
| Exec into container                                                   |        2         |         0          |      121      |    98%    |
| Exposed dashboard                                                     |        0         |         0          |       1       |   100%    |
| Host PID/IPC privileges                                               |        0         |         0          |       1       |   100%    |
| Immutable container filesystem                                        |        1         |         0          |       1       |    0%     |
| Ingress and Egress blocked                                            |        1         |         0          |       1       |    0%     |
| Insecure capabilities                                                 |        0         |         0          |       1       |   100%    |
| Linux hardening                                                       |        1         |         0          |       1       |    0%     |
| Network policies                                                      |        2         |         0          |       2       |    0%     |
| Non-root containers                                                   |        0         |         0          |       1       |   100%    |
| Privileged container                                                  |        0         |         0          |       1       |   100%    |
| Resource policies                                                     |        1         |         0          |       1       |    0%     |
| hostNetwork access                                                    |        0         |         0          |       1       |   100%    |
+-----------------------------------------------------------------------+------------------+--------------------+---------------+-----------+
|                           RESOURCE SUMMARY                            |        10        |         0          |      137      |    92%    |
+-----------------------------------------------------------------------+------------------+--------------------+---------------+-----------+
</pre>
</details>

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Is this something we find useful? We probably can't lock down workload clusters in testing enough to meet all these recommendations, but maybe it points to some things we can tighten up by default.

It can be given arguments such that it returns failure if the passing test % drops below a specified threshold.

Would it be more useful in a different output format? Should it run in each e2e configuration?

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Run the kubescape security scanner in e2e tests
```
