### PR TITLE
Use same env variables as Containerd solution

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
@@ -249,9 +249,8 @@ metadata:
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${LINUX_WORKER_MACHINE_COUNT:-1}
-  selector:
-    matchLabels: null
+  replicas: ${WORKER_MACHINE_COUNT:-1}
+  selector: {}
   template:
     spec:
       bootstrap:
@@ -403,9 +402,8 @@ metadata:
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_MACHINE_COUNT}
-  selector:
-    matchLabels: null
+  replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-2}
+  selector: {}
   template:
     spec:
       bootstrap:

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -175,9 +175,8 @@ metadata:
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${LINUX_WORKER_MACHINE_COUNT:-1}
-  selector:
-    matchLabels: null
+  replicas: ${WORKER_MACHINE_COUNT:-1}
+  selector: {}
   template:
     spec:
       bootstrap:
@@ -257,9 +256,8 @@ metadata:
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_MACHINE_COUNT}
-  selector:
-    matchLabels: null
+  replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-2}
+  selector: {}
   template:
     spec:
       bootstrap:

--- a/templates/test/ci/prow-windows/kustomization.yaml
+++ b/templates/test/ci/prow-windows/kustomization.yaml
@@ -8,6 +8,7 @@ patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/cluster-cni-windows.yaml
   - ../patches/controller-manager.yaml
+  - patches/machine-deployment-worker-counts.yaml
 patches:
 - target:
     group: bootstrap.cluster.x-k8s.io

--- a/templates/test/ci/prow-windows/patches/machine-deployment-worker-counts.yaml
+++ b/templates/test/ci/prow-windows/patches/machine-deployment-worker-counts.yaml
@@ -1,0 +1,14 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-win"
+spec:
+  replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-2}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT:-1}

--- a/templates/test/dev/cluster-template-custom-builds-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-windows.yaml
@@ -236,9 +236,8 @@ metadata:
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${LINUX_WORKER_MACHINE_COUNT:-1}
-  selector:
-    matchLabels: null
+  replicas: ${WORKER_MACHINE_COUNT:-1}
+  selector: {}
   template:
     spec:
       bootstrap:
@@ -346,9 +345,8 @@ metadata:
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_MACHINE_COUNT}
-  selector:
-    matchLabels: null
+  replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-2}
+  selector: {}
   template:
     spec:
       bootstrap:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation

/kind flake
/kind other
-->

**What this PR does / why we need it**:

In https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1790 we moved to using `WINDOWS_WORKER_MACHINE_COUNT` and missed updating this on the dockershim Windows tests.

the ci scripts will set this value: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/3ad17000ca0c88ea975e26ab5d43a3e49211cd0a/test/e2e/conformance_test.go#L137

This was caught in CI:
https://testgrid.k8s.io/sig-windows-master-release#capz-windows-dockershim-master
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-staging-dockershim-windows/1452959739100008448

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
