### PR TITLE
Add missing fields to tilt-provider.json

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -11,6 +11,8 @@
       "controllers",
       "pkg",
       "exp"
-    ]
+    ],
+    "label": "CAPZ",
+    "manager_name": "capz-controller-manager"
   }
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds some missing fields to `tilt-provider.json` that were effectively ignorable before kubernetes-sigs/cluster-api#5485 merged. Copied from [AWS' version](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/tilt-provider.json#L18-L19).

**Which issue(s) this PR fixes**:

Refs kubernetes-sigs/cluster-api#5505

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
