### PR TITLE
Add hub and conversion for AzureMachinePoolMachine

### DIFF
--- a/exp/api/v1alpha4/azuremachinepoolmachine_conversion.go
+++ b/exp/api/v1alpha4/azuremachinepoolmachine_conversion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	expv1beta1 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+// ConvertTo converts this AzureMachinePoolMachine to the Hub version (v1beta1).
+func (src *AzureMachinePoolMachine) ConvertTo(dstRaw conversion.Hub) error { // nolint
+	dst := dstRaw.(*expv1beta1.AzureMachinePoolMachine)
+
+	return Convert_v1alpha4_AzureMachinePoolMachine_To_v1beta1_AzureMachinePoolMachine(src, dst, nil)
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this version.
+func (dst *AzureMachinePoolMachine) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+	src := srcRaw.(*expv1beta1.AzureMachinePoolMachine)
+
+	return Convert_v1beta1_AzureMachinePoolMachine_To_v1alpha4_AzureMachinePoolMachine(src, dst, nil)
+}

--- a/exp/api/v1alpha4/conversion_test.go
+++ b/exp/api/v1alpha4/conversion_test.go
@@ -56,4 +56,10 @@ func TestFuzzyConversion(t *testing.T) {
 		Spoke:  &AzureManagedMachinePool{},
 	}))
 
+	t.Run("for AzureMachinePoolMachine", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Scheme: scheme,
+		Hub:    &v1beta1.AzureMachinePoolMachine{},
+		Spoke:  &AzureMachinePoolMachine{},
+	}))
+
 }

--- a/exp/api/v1beta1/azuremachinepoolmachine_conversion.go
+++ b/exp/api/v1beta1/azuremachinepoolmachine_conversion.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// Hub marks AzureMachinePoolMachine as a conversion hub.
+func (*AzureMachinePoolMachine) Hub() {}
+
+// Hub marks AzureMachinePoolMachineList as a conversion hub.
+func (*AzureMachinePoolMachineList) Hub() {}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
This PR adds in conversion logic for `AzureMachinePoolMachines`. I think this was missed in the v1beta1 API introduction. Without this change, v1alpha4 `AzureMachinePoolMachines` will not be able to be converted to or from other API versions.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add conversion support for `AzureMachinePoolMachine` for v1alpha4 <=> v1beta1
```
