### PR TITLE
fix(windows-calico-containerd): make envsubst working

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -220,8 +220,8 @@ def create_crs():
 
     # need to set version for kube-proxy on windows.
     os.putenv("KUBERNETES_VERSION", settings.get("kubernetes_version", {}))
-    local("kubectl create configmap flannel-windows-addon --from-file=templates/addons/windows/flannel/ --dry-run=client -o yaml | " + envsubst_cmd + " | kubectl apply -f -")
-    local("kubectl create configmap calico-windows-addon --from-file=templates/addons/windows/calico/ --dry-run=client -o yaml | " + envsubst_cmd + " | kubectl apply -f -")
+    local("kubectl create configmap flannel-windows-addon --from-file=templates/addons/windows/flannel/ --dry-run=client -o yaml | " + envsubst_cmd + " \$KUBERNETES_VERSION | kubectl apply -f -")
+    local("kubectl create configmap calico-windows-addon --from-file=templates/addons/windows/calico/ --dry-run=client -o yaml | " + envsubst_cmd + " \$KUBERNETES_VERSION | kubectl apply -f -")
 
     # set up crs
     local("kubectl apply -f templates/addons/calico-resource-set.yaml")

--- a/templates/addons/windows/calico/kube-proxy-windows.yaml
+++ b/templates/addons/windows/calico/kube-proxy-windows.yaml
@@ -21,7 +21,7 @@ spec:
           runAsUserName: "NT AUTHORITY\\system"
       hostNetwork: true
       containers:
-      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-calico-hostprocess
+      - image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION}-calico-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
         name: kube-proxy

--- a/templates/addons/windows/flannel/kube-proxy-windows.yaml
+++ b/templates/addons/windows/flannel/kube-proxy-windows.yaml
@@ -62,7 +62,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION/+/_}-nanoserver
+        image: sigwindowstools/kube-proxy:${KUBERNETES_VERSION}-nanoserver
         name: kube-proxy
         volumeMounts:
         - name: wins


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**: Fix envsubst
envsubst was not working before as it can't replace `${KUBERNETES_VERSION/+/_}` and also accidently did replace the `$env:CONTAINER_SANDBOX_MOUNT_POINT` variables in the container arguments. Example:
```bash
$ export KUBERNETES_VERSION=v1.22.3

# old behaviour
$ echo "aaaaa \${KUBERNETES_VERSION/+/_} aaaa \$env:CONTAINER_SANDBOX_MOUNT_POINT aaa" | envsubst
aaaaa ${KUBERNETES_VERSION/+/_} aaaa :CONTAINER_SANDBOX_MOUNT_POINT aaa

# new behaviour with fix
$ echo "aaaaa \${KUBERNETES_VERSION} aaaa \$env:CONTAINER_SANDBOX_MOUNT_POINT aaa" | envsubst \$KUBERNETES_VERSION
aaaaa v1.22.3 aaaa $env:CONTAINER_SANDBOX_MOUNT_POINT aaa
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
-

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation - not needed
- [x] adds unit tests - not needed

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
