### PR TITLE
Make virtual network peerings reconcile/delete async

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -82,6 +82,8 @@ const (
 	ResourceGroupReadyCondition clusterv1.ConditionType = "ResourceGroupReady"
 	// VNetReadyCondition means the virtual network exists and is ready to be used.
 	VNetReadyCondition clusterv1.ConditionType = "VNetReady"
+	// VnetPeeringReadyCondition means the virtual network peerings exist and are ready to be used.
+	VnetPeeringReadyCondition clusterv1.ConditionType = "VnetPeeringReady"
 	// SecurityGroupsReadyCondition means the security groups exist and are ready to be used.
 	SecurityGroupsReadyCondition clusterv1.ConditionType = "SecurityGroupsReady"
 	// RouteTablesReadyCondition means the route tables exist and are ready to be used.

--- a/azure/services/vnetpeerings/client.go
+++ b/azure/services/vnetpeerings/client.go
@@ -18,19 +18,26 @@ package vnetpeerings
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pkg/errors"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // Client wraps go-sdk.
 type Client interface {
 	Get(context.Context, string, string, string) (network.VirtualNetworkPeering, error)
-	CreateOrUpdate(context.Context, string, string, string, network.VirtualNetworkPeering) error
-	Delete(context.Context, string, string, string) error
+	CreateOrUpdateAsync(context.Context, azure.ResourceSpecGetter) (interface{}, azureautorest.FutureAPI, error)
+	DeleteAsync(context.Context, azure.ResourceSpecGetter) (azureautorest.FutureAPI, error)
+	IsDone(context.Context, azureautorest.FutureAPI) (bool, error)
+	Result(context.Context, azureautorest.FutureAPI, string) (interface{}, error)
 }
 
 // AzureClient contains the Azure go-sdk Client.
@@ -61,36 +68,120 @@ func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, vnetName, pee
 	return ac.peerings.Get(ctx, resourceGroupName, vnetName, peeringName)
 }
 
-// CreateOrUpdate creates or updates a virtual network peering in the specified virtual network.
-func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName, vnetName, peeringName string, peering network.VirtualNetworkPeering) error {
-	ctx, span := tele.Tracer().Start(ctx, "vnetpeerings.AzureClient.CreateOrUpdate")
+// CreateOrUpdateAsync creates or updates a virtual network peering asynchronously.
+// It sends a PUT request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// progress of the operation.
+func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter) (interface{}, azureautorest.FutureAPI, error) {
+	ctx, span := tele.Tracer().Start(ctx, "vnetpeerings.AzureClient.CreateOrUpdateAsync")
 	defer span.End()
 
-	future, err := ac.peerings.CreateOrUpdate(ctx, resourceGroupName, vnetName, peeringName, peering, network.SyncRemoteAddressSpaceTrue)
-	if err != nil {
-		return err
+	var existingPeering interface{}
+
+	if existing, err := ac.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName()); err != nil && !azure.ResourceNotFound(err) {
+		return nil, nil, errors.Wrapf(err, "failed to get virtual network peering %s for %s in %s", spec.ResourceName(), spec.OwnerResourceName(), spec.ResourceGroupName())
+	} else if err == nil {
+		existingPeering = existing
 	}
+
+	params, err := spec.Parameters(existingPeering)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to get desired parameters for virtual network peering %s", spec.ResourceName())
+	}
+
+	peering, ok := params.(network.VirtualNetworkPeering)
+	if !ok {
+		if params == nil {
+			// nothing to do here.
+			return existingPeering, nil, nil
+		}
+		return nil, nil, errors.Errorf("%T is not a network.VirtualNetworkPeering", params)
+	}
+
+	future, err := ac.peerings.CreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), peering, network.SyncRemoteAddressSpaceTrue)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
+	defer cancel()
+
 	err = future.WaitForCompletionRef(ctx, ac.peerings.Client)
 	if err != nil {
-		return err
+		// if an error occurs, return the future.
+		// this means the long-running operation didn't finish in the specified timeout.
+		return nil, &future, err
 	}
-	_, err = future.Result(ac.peerings)
-	return err
+
+	result, err := future.Result(ac.peerings)
+	// if the operation completed, return a nil future
+	return result, nil, err
 }
 
-// Delete deletes the specified virtual network peering.
-func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, vnetName, peeringName string) error {
+// DeleteAsync deletes a virtual network peering asynchronously. DeleteAsync sends a DELETE
+// request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// progress of the operation.
+func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (azureautorest.FutureAPI, error) {
 	ctx, span := tele.Tracer().Start(ctx, "vnetpeerings.AzureClient.Delete")
 	defer span.End()
 
-	future, err := ac.peerings.Delete(ctx, resourceGroupName, vnetName, peeringName)
+	future, err := ac.peerings.Delete(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName())
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
+	defer cancel()
+
 	err = future.WaitForCompletionRef(ctx, ac.peerings.Client)
 	if err != nil {
-		return err
+		// if an error occurs, return the future.
+		// this means the long-running operation didn't finish in the specified timeout.
+		return &future, err
 	}
 	_, err = future.Result(ac.peerings)
-	return err
+	// if the operation completed, return a nil future.
+	return nil, err
+}
+
+// IsDone returns true if the long-running operation has completed.
+func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (bool, error) {
+	ctx, span := tele.Tracer().Start(ctx, "vnetpeerings.AzureClient.IsDone")
+	defer span.End()
+
+	done, err := future.DoneWithContext(ctx, ac.peerings)
+	if err != nil {
+		return false, errors.Wrap(err, "failed checking if the operation was complete")
+	}
+
+	return done, nil
+}
+
+// Result fetches the result of a long-running operation future.
+func (ac *AzureClient) Result(ctx context.Context, futureData azureautorest.FutureAPI, futureType string) (interface{}, error) {
+	if futureData == nil {
+		return nil, errors.Errorf("cannot get result from nil future")
+	}
+	var result func(client network.VirtualNetworkPeeringsClient) (peering network.VirtualNetworkPeering, err error)
+
+	switch futureType {
+	case infrav1.PutFuture:
+		var future *network.VirtualNetworkPeeringsCreateOrUpdateFuture
+		jsonData, err := futureData.MarshalJSON()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to marshal future")
+		}
+		if err := json.Unmarshal(jsonData, &future); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal future data")
+		}
+		result = (*future).Result
+
+	case infrav1.DeleteFuture:
+		// Delete does not return a result virtual network peering
+		return nil, nil
+
+	default:
+		return nil, errors.Errorf("unknown future type %q", futureType)
+	}
+
+	return result(ac.peerings)
 }

--- a/azure/services/vnetpeerings/mock_vnetpeerings/client_mock.go
+++ b/azure/services/vnetpeerings/mock_vnetpeerings/client_mock.go
@@ -25,7 +25,9 @@ import (
 	reflect "reflect"
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	azure "github.com/Azure/go-autorest/autorest/azure"
 	gomock "github.com/golang/mock/gomock"
+	azure0 "sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // MockClient is a mock of Client interface.
@@ -51,32 +53,35 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreateOrUpdate mocks base method.
-func (m *MockClient) CreateOrUpdate(arg0 context.Context, arg1, arg2, arg3 string, arg4 network.VirtualNetworkPeering) error {
+// CreateOrUpdateAsync mocks base method.
+func (m *MockClient) CreateOrUpdateAsync(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (interface{}, azure.FutureAPI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", arg0, arg1)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(azure.FutureAPI)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// CreateOrUpdate indicates an expected call of CreateOrUpdate.
-func (mr *MockClientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+// CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
+func (mr *MockClientMockRecorder) CreateOrUpdateAsync(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockClient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockClient)(nil).CreateOrUpdateAsync), arg0, arg1)
 }
 
-// Delete mocks base method.
-func (m *MockClient) Delete(arg0 context.Context, arg1, arg2, arg3 string) error {
+// DeleteAsync mocks base method.
+func (m *MockClient) DeleteAsync(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (azure.FutureAPI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "DeleteAsync", arg0, arg1)
+	ret0, _ := ret[0].(azure.FutureAPI)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// Delete indicates an expected call of Delete.
-func (mr *MockClientMockRecorder) Delete(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// DeleteAsync indicates an expected call of DeleteAsync.
+func (mr *MockClientMockRecorder) DeleteAsync(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*MockClient)(nil).DeleteAsync), arg0, arg1)
 }
 
 // Get mocks base method.
@@ -92,4 +97,34 @@ func (m *MockClient) Get(arg0 context.Context, arg1, arg2, arg3 string) (network
 func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), arg0, arg1, arg2, arg3)
+}
+
+// IsDone mocks base method.
+func (m *MockClient) IsDone(arg0 context.Context, arg1 azure.FutureAPI) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDone", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsDone indicates an expected call of IsDone.
+func (mr *MockClientMockRecorder) IsDone(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDone", reflect.TypeOf((*MockClient)(nil).IsDone), arg0, arg1)
+}
+
+// Result mocks base method.
+func (m *MockClient) Result(arg0 context.Context, arg1 azure.FutureAPI, arg2 string) (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Result", arg0, arg1, arg2)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Result indicates an expected call of Result.
+func (mr *MockClientMockRecorder) Result(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Result", reflect.TypeOf((*MockClient)(nil).Result), arg0, arg1, arg2)
 }

--- a/azure/services/vnetpeerings/mock_vnetpeerings/vnetpeerings_mock.go
+++ b/azure/services/vnetpeerings/mock_vnetpeerings/vnetpeerings_mock.go
@@ -28,6 +28,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
+	v1beta10 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 // MockVnetPeeringScope is a mock of VnetPeeringScope interface.
@@ -123,18 +124,16 @@ func (mr *MockVnetPeeringScopeMockRecorder) CloudEnvironment() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudEnvironment", reflect.TypeOf((*MockVnetPeeringScope)(nil).CloudEnvironment))
 }
 
-// ClusterName mocks base method.
-func (m *MockVnetPeeringScope) ClusterName() string {
+// DeleteLongRunningOperationState mocks base method.
+func (m *MockVnetPeeringScope) DeleteLongRunningOperationState(arg0, arg1 string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClusterName")
-	ret0, _ := ret[0].(string)
-	return ret0
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
 }
 
-// ClusterName indicates an expected call of ClusterName.
-func (mr *MockVnetPeeringScopeMockRecorder) ClusterName() *gomock.Call {
+// DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
+func (mr *MockVnetPeeringScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterName", reflect.TypeOf((*MockVnetPeeringScope)(nil).ClusterName))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockVnetPeeringScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
 }
 
 // Enabled mocks base method.
@@ -168,6 +167,20 @@ func (mr *MockVnetPeeringScopeMockRecorder) Error(err, msg interface{}, keysAndV
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockVnetPeeringScope)(nil).Error), varargs...)
 }
 
+// GetLongRunningOperationState mocks base method.
+func (m *MockVnetPeeringScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret0, _ := ret[0].(*v1beta1.Future)
+	return ret0
+}
+
+// GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
+func (mr *MockVnetPeeringScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockVnetPeeringScope)(nil).GetLongRunningOperationState), arg0, arg1)
+}
+
 // HashKey mocks base method.
 func (m *MockVnetPeeringScope) HashKey() string {
 	m.ctrl.T.Helper()
@@ -199,6 +212,18 @@ func (mr *MockVnetPeeringScopeMockRecorder) Info(msg interface{}, keysAndValues 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockVnetPeeringScope)(nil).Info), varargs...)
 }
 
+// SetLongRunningOperationState mocks base method.
+func (m *MockVnetPeeringScope) SetLongRunningOperationState(arg0 *v1beta1.Future) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLongRunningOperationState", arg0)
+}
+
+// SetLongRunningOperationState indicates an expected call of SetLongRunningOperationState.
+func (mr *MockVnetPeeringScopeMockRecorder) SetLongRunningOperationState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLongRunningOperationState", reflect.TypeOf((*MockVnetPeeringScope)(nil).SetLongRunningOperationState), arg0)
+}
+
 // SubscriptionID mocks base method.
 func (m *MockVnetPeeringScope) SubscriptionID() string {
 	m.ctrl.T.Helper()
@@ -227,6 +252,42 @@ func (mr *MockVnetPeeringScopeMockRecorder) TenantID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockVnetPeeringScope)(nil).TenantID))
 }
 
+// UpdateDeleteStatus mocks base method.
+func (m *MockVnetPeeringScope) UpdateDeleteStatus(arg0 v1beta10.ConditionType, arg1 string, arg2 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateDeleteStatus", arg0, arg1, arg2)
+}
+
+// UpdateDeleteStatus indicates an expected call of UpdateDeleteStatus.
+func (mr *MockVnetPeeringScopeMockRecorder) UpdateDeleteStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeleteStatus", reflect.TypeOf((*MockVnetPeeringScope)(nil).UpdateDeleteStatus), arg0, arg1, arg2)
+}
+
+// UpdatePatchStatus mocks base method.
+func (m *MockVnetPeeringScope) UpdatePatchStatus(arg0 v1beta10.ConditionType, arg1 string, arg2 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatePatchStatus", arg0, arg1, arg2)
+}
+
+// UpdatePatchStatus indicates an expected call of UpdatePatchStatus.
+func (mr *MockVnetPeeringScopeMockRecorder) UpdatePatchStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePatchStatus", reflect.TypeOf((*MockVnetPeeringScope)(nil).UpdatePatchStatus), arg0, arg1, arg2)
+}
+
+// UpdatePutStatus mocks base method.
+func (m *MockVnetPeeringScope) UpdatePutStatus(arg0 v1beta10.ConditionType, arg1 string, arg2 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatePutStatus", arg0, arg1, arg2)
+}
+
+// UpdatePutStatus indicates an expected call of UpdatePutStatus.
+func (mr *MockVnetPeeringScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockVnetPeeringScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
+}
+
 // V mocks base method.
 func (m *MockVnetPeeringScope) V(level int) logr.Logger {
 	m.ctrl.T.Helper()
@@ -241,25 +302,11 @@ func (mr *MockVnetPeeringScopeMockRecorder) V(level interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V", reflect.TypeOf((*MockVnetPeeringScope)(nil).V), level)
 }
 
-// Vnet mocks base method.
-func (m *MockVnetPeeringScope) Vnet() *v1beta1.VnetSpec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Vnet")
-	ret0, _ := ret[0].(*v1beta1.VnetSpec)
-	return ret0
-}
-
-// Vnet indicates an expected call of Vnet.
-func (mr *MockVnetPeeringScopeMockRecorder) Vnet() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Vnet", reflect.TypeOf((*MockVnetPeeringScope)(nil).Vnet))
-}
-
 // VnetPeeringSpecs mocks base method.
-func (m *MockVnetPeeringScope) VnetPeeringSpecs() []azure.VnetPeeringSpec {
+func (m *MockVnetPeeringScope) VnetPeeringSpecs() []azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VnetPeeringSpecs")
-	ret0, _ := ret[0].([]azure.VnetPeeringSpec)
+	ret0, _ := ret[0].([]azure.ResourceSpecGetter)
 	return ret0
 }
 

--- a/azure/services/vnetpeerings/spec.go
+++ b/azure/services/vnetpeerings/spec.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vnetpeerings
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+)
+
+// VnetPeeringSpec defines the specification for a virtual network peering.
+type VnetPeeringSpec struct {
+	SourceResourceGroup string
+	SourceVnetName      string
+	RemoteResourceGroup string
+	RemoteVnetName      string
+	PeeringName         string
+	SubscriptionID      string
+}
+
+// ResourceName returns the name of the virtual network peering.
+func (s *VnetPeeringSpec) ResourceName() string {
+	return s.PeeringName
+}
+
+// ResourceGroupName returns the name of the resource group.
+func (s *VnetPeeringSpec) ResourceGroupName() string {
+	return s.SourceResourceGroup
+}
+
+// OwnerResourceName is a no-op for virtual network peerings.
+func (s *VnetPeeringSpec) OwnerResourceName() string {
+	return s.SourceVnetName
+}
+
+// Parameters returns the parameters for the virtual network peering.
+func (s *VnetPeeringSpec) Parameters(existing interface{}) (interface{}, error) {
+	if existing != nil {
+		if _, ok := existing.(network.VirtualNetworkPeering); !ok {
+			return nil, errors.Errorf("%T is not a network.VnetPeering", existing)
+		}
+		// virtual network peering already exists
+		return nil, nil
+	}
+	vnetID := azure.VNetID(s.SubscriptionID, s.RemoteResourceGroup, s.RemoteVnetName)
+	peeringProperties := network.VirtualNetworkPeeringPropertiesFormat{
+		RemoteVirtualNetwork: &network.SubResource{
+			ID: to.StringPtr(vnetID),
+		},
+	}
+	return network.VirtualNetworkPeering{
+		Name:                                  to.StringPtr(s.PeeringName),
+		VirtualNetworkPeeringPropertiesFormat: &peeringProperties,
+	}, nil
+}

--- a/azure/types.go
+++ b/azure/types.go
@@ -110,15 +110,6 @@ type VNetSpec struct {
 	Peerings      []infrav1.VnetPeeringSpec
 }
 
-// VnetPeeringSpec defines the specification for a virtual network peering.
-type VnetPeeringSpec struct {
-	SourceResourceGroup string
-	SourceVnetName      string
-	RemoteResourceGroup string
-	RemoteVnetName      string
-	PeeringName         string
-}
-
 // RoleAssignmentSpec defines the specification for a Role Assignment.
 type RoleAssignmentSpec struct {
 	MachineName  string


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature
**What this PR does / why we need it**: Implementation of an async service for virtual network peerings as a follow up for #1610 and #1541.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1829 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make virtual network peerings reconcile/delete async
```
