### PR TITLE
Make CAPZ tooling work on arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ PROD_REGISTRY := us.gcr.io/k8s-artifacts-prod/cluster-api-azure
 IMAGE_NAME ?= cluster-api-azure-controller
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= dev
-ARCH ?= amd64
+ARCH ?= $(GOARCH)
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 # Allow overriding manifest generation destination directory

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -20,18 +20,20 @@ set -o pipefail
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
 MINIMUM_KIND_VERSION=v0.10.0
+goarch="$(go env GOARCH)"
+goos="$(go env GOOS)"
 
 # Ensure the kind tool exists and is a viable version, or installs it
 verify_kind_version() {
 
   # If kind is not available on the path, get it
   if ! [ -x "$(command -v kind)" ]; then
-    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+    if [ "$goos" == "linux" ] || [ "$goos" == "darwin" ]; then
       echo 'kind not found, installing'
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"
       fi
-      curl -sLo "${GOPATH_BIN}/kind" https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-linux-amd64
+      curl -sLo "${GOPATH_BIN}/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-${goos}-${goarch}"
       chmod +x "${GOPATH_BIN}/kind"
     else
       echo "Missing required binary in path: kind"

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -20,18 +20,20 @@ set -o pipefail
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
 MINIMUM_KUBECTL_VERSION=v1.16.7
+goarch="$(go env GOARCH)"
+goos="$(go env GOOS)"
 
 # Ensure the kubectl tool exists and is a viable version, or installs it
 verify_kubectl_version() {
 
   # If kubectl is not available on the path, get it
   if ! [ -x "$(command -v kubectl)" ]; then
-    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+    if [ "$goos" == "linux" ] || [ "$goos" == "darwin" ]; then
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"
       fi
       echo 'kubectl not found, installing'
-      curl -sLo "${GOPATH_BIN}/kubectl" https://storage.googleapis.com/kubernetes-release/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
+      curl -sLo "${GOPATH_BIN}/kubectl" "https://storage.googleapis.com/kubernetes-release/release/${MINIMUM_KUBECTL_VERSION}/bin/${goos}/${goarch}/kubectl"
       chmod +x "${GOPATH_BIN}/kubectl"
     else
       echo "Missing required binary in path: kubectl"

--- a/hack/ensure-kustomize.sh
+++ b/hack/ensure-kustomize.sh
@@ -20,18 +20,20 @@ set -o pipefail
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
 MINIMUM_KUSTOMIZE_VERSION=3.1.0
+goarch="$(go env GOARCH)"
+goos="$(go env GOOS)"
 
 # Ensure the kustomize tool exists and is a viable version, or installs it
 verify_kustomize_version() {
 
   # If kustomize is not available on the path, get it
   if ! [ -x "$(command -v kustomize)" ]; then
-    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+    if [ "$goos" == "linux" ] || [ "$goos" == "darwin" ]; then
       echo 'kustomize not found, installing'
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"
       fi
-      curl -sLo "${GOPATH_BIN}/kustomize" https://github.com/kubernetes-sigs/kustomize/releases/download/v${MINIMUM_KUSTOMIZE_VERSION}/kustomize_${MINIMUM_KUSTOMIZE_VERSION}_linux_amd64
+      curl -sLo "${GOPATH_BIN}/kustomize" "https://github.com/kubernetes-sigs/kustomize/releases/download/v${MINIMUM_KUSTOMIZE_VERSION}/kustomize_${MINIMUM_KUSTOMIZE_VERSION}_${goos}_${goarch}"
       chmod +x "${GOPATH_BIN}/kustomize"
     else
       echo "Missing required binary in path: kustomize"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Removes some hard-coding of `amd64` to allow dev tooling to work on all platforms that Go supports.

See kubernetes-sigs/cluster-api#5547

**Which issue(s) this PR fixes**:

Fixes #1836

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
