### PR TITLE
Make inbound NAT rules reconcile/delete async

### DIFF
--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -62,6 +62,7 @@ type NetworkDescriber interface {
 	SetSubnet(infrav1.SubnetSpec)
 	IsIPv6Enabled() bool
 	ControlPlaneRouteTable() infrav1.RouteTable
+	APIServerLB() *infrav1.LoadBalancerSpec
 	APIServerLBName() string
 	APIServerLBPoolName(string) string
 	IsAPIServerPrivate() bool

--- a/azure/mock_azure/azure_mock.go
+++ b/azure/mock_azure/azure_mock.go
@@ -305,6 +305,20 @@ func (m *MockNetworkDescriber) EXPECT() *MockNetworkDescriberMockRecorder {
 	return m.recorder
 }
 
+// APIServerLB mocks base method.
+func (m *MockNetworkDescriber) APIServerLB() *v1beta1.LoadBalancerSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "APIServerLB")
+	ret0, _ := ret[0].(*v1beta1.LoadBalancerSpec)
+	return ret0
+}
+
+// APIServerLB indicates an expected call of APIServerLB.
+func (mr *MockNetworkDescriberMockRecorder) APIServerLB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLB", reflect.TypeOf((*MockNetworkDescriber)(nil).APIServerLB))
+}
+
 // APIServerLBName mocks base method.
 func (m *MockNetworkDescriber) APIServerLBName() string {
 	m.ctrl.T.Helper()
@@ -864,6 +878,20 @@ func NewMockClusterScoper(ctrl *gomock.Controller) *MockClusterScoper {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterScoper) EXPECT() *MockClusterScoperMockRecorder {
 	return m.recorder
+}
+
+// APIServerLB mocks base method.
+func (m *MockClusterScoper) APIServerLB() *v1beta1.LoadBalancerSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "APIServerLB")
+	ret0, _ := ret[0].(*v1beta1.LoadBalancerSpec)
+	return ret0
+}
+
+// APIServerLB indicates an expected call of APIServerLB.
+func (mr *MockClusterScoperMockRecorder) APIServerLB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLB", reflect.TypeOf((*MockClusterScoper)(nil).APIServerLB))
 }
 
 // APIServerLBName mocks base method.

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -316,6 +316,11 @@ func (s *ManagedControlPlaneScope) IsVnetManaged() bool {
 	return true
 }
 
+// APIServerLBName returns the API Server LB spec.
+func (s *ManagedControlPlaneScope) APIServerLB() *infrav1.LoadBalancerSpec {
+	return nil // does not apply for AKS
+}
+
 // APIServerLBName returns the API Server LB name.
 func (s *ManagedControlPlaneScope) APIServerLBName() string {
 	return "" // does not apply for AKS

--- a/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
+++ b/azure/services/bastionhosts/mocks_bastionhosts/bastionhosts_mock.go
@@ -52,6 +52,20 @@ func (m *MockBastionScope) EXPECT() *MockBastionScopeMockRecorder {
 	return m.recorder
 }
 
+// APIServerLB mocks base method.
+func (m *MockBastionScope) APIServerLB() *v1beta1.LoadBalancerSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "APIServerLB")
+	ret0, _ := ret[0].(*v1beta1.LoadBalancerSpec)
+	return ret0
+}
+
+// APIServerLB indicates an expected call of APIServerLB.
+func (mr *MockBastionScopeMockRecorder) APIServerLB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLB", reflect.TypeOf((*MockBastionScope)(nil).APIServerLB))
+}
+
 // APIServerLBName mocks base method.
 func (m *MockBastionScope) APIServerLBName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/inboundnatrules/client.go
+++ b/azure/services/inboundnatrules/client.go
@@ -18,19 +18,28 @@ package inboundnatrules
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pkg/errors"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // client wraps go-sdk.
 type client interface {
-	Get(context.Context, string, string, string) (network.InboundNatRule, error)
-	CreateOrUpdate(context.Context, string, string, string, network.InboundNatRule) error
-	Delete(context.Context, string, string, string) error
+	List(context.Context, string, string) (result []network.InboundNatRule, err error)
+	Get(context.Context, azure.ResourceSpecGetter) (result interface{}, err error)
+	CreateOrUpdateAsync(context.Context, azure.ResourceSpecGetter, interface{}) (result interface{}, future azureautorest.FutureAPI, err error)
+	DeleteAsync(context.Context, azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error)
+	IsDone(context.Context, azureautorest.FutureAPI) (isDone bool, err error)
+	Result(context.Context, azureautorest.FutureAPI, string) (result interface{}, err error)
 }
 
 // azureClient contains the Azure go-sdk Client.
@@ -42,11 +51,13 @@ var _ client = (*azureClient)(nil)
 
 // newClient creates a new inbound NAT rules client from subscription ID.
 func newClient(auth azure.Authorizer) *azureClient {
-	c := newInboundNatRulesClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer())
-	return &azureClient{c}
+	inboundNatRulesClient := newInboundNatRulesClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer())
+	return &azureClient{
+		inboundnatrules: inboundNatRulesClient,
+	}
 }
 
-// newLoadbalancersClient creates a new inbound NAT rules client from subscription ID.
+// newInboundNatClient creates a new inbound NAT rules client from subscription ID.
 func newInboundNatRulesClient(subscriptionID string, baseURI string, authorizer autorest.Authorizer) network.InboundNatRulesClient {
 	inboundNatRulesClient := network.NewInboundNatRulesClientWithBaseURI(baseURI, subscriptionID)
 	azure.SetAutoRestClientDefaults(&inboundNatRulesClient.Client, authorizer)
@@ -54,43 +65,134 @@ func newInboundNatRulesClient(subscriptionID string, baseURI string, authorizer 
 }
 
 // Get gets the specified inbound NAT rules.
-func (ac *azureClient) Get(ctx context.Context, resourceGroupName, lbName, inboundNatRuleName string) (network.InboundNatRule, error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.AzureClient.Get")
+func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (result interface{}, err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.azureClient.Get")
 	defer done()
 
-	return ac.inboundnatrules.Get(ctx, resourceGroupName, lbName, inboundNatRuleName, "")
+	return ac.inboundnatrules.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), "")
 }
 
-// CreateOrUpdate creates or updates a inbound NAT rules.
-func (ac *azureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, lbName string, inboundNatRuleName string, inboundNatRuleParameters network.InboundNatRule) error {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.AzureClient.CreateOrUpdate")
+// List returns all inbound NAT rules on a load balancer.
+func (ac *azureClient) List(ctx context.Context, resourceGroupName, lbName string) (result []network.InboundNatRule, err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.azureClient.List")
 	defer done()
 
-	future, err := ac.inboundnatrules.CreateOrUpdate(ctx, resourceGroupName, lbName, inboundNatRuleName, inboundNatRuleParameters)
+	iter, err := ac.inboundnatrules.ListComplete(ctx, resourceGroupName, lbName)
 	if err != nil {
-		return err
+		return nil, errors.Wrap(err, fmt.Sprintf("could not list inbound NAT rules for load balancer %s", lbName))
 	}
-	err = future.WaitForCompletionRef(ctx, ac.inboundnatrules.Client)
-	if err != nil {
-		return err
+
+	var natRules []network.InboundNatRule
+	for iter.NotDone() {
+		natRules = append(natRules, iter.Value())
+		if err := iter.NextWithContext(ctx); err != nil {
+			return natRules, errors.Wrap(err, "could not iterate inbound NAT rules")
+		}
 	}
-	_, err = future.Result(ac.inboundnatrules)
-	return err
+
+	return natRules, nil
 }
 
-// Delete deletes the specified inbound NAT rules.
-func (ac *azureClient) Delete(ctx context.Context, resourceGroupName, lbName, inboundNatRuleName string) error {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.AzureClient.Delete")
+// CreateOrUpdateAsync creates or updates an inbound NAT rule asynchronously.
+// It sends a PUT request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// progress of the operation.
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.azureClient.CreateOrUpdateAsync")
 	defer done()
 
-	future, err := ac.inboundnatrules.Delete(ctx, resourceGroupName, lbName, inboundNatRuleName)
-	if err != nil {
-		return err
+	natRule, ok := parameters.(network.InboundNatRule)
+	if !ok {
+		return nil, nil, errors.Errorf("%T is not a network.InboundNatRule", parameters)
 	}
-	err = future.WaitForCompletionRef(ctx, ac.inboundnatrules.Client)
+
+	createFuture, err := ac.inboundnatrules.CreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), natRule)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	_, err = future.Result(ac.inboundnatrules)
-	return err
+
+	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
+	defer cancel()
+
+	err = createFuture.WaitForCompletionRef(ctx, ac.inboundnatrules.Client)
+	if err != nil {
+		// if an error occurs, return the future.
+		// this means the long-running operation didn't finish in the specified timeout.
+		return nil, &createFuture, err
+	}
+
+	result, err = createFuture.Result(ac.inboundnatrules)
+	// if the operation completed, return a nil future
+	return result, nil, err
+}
+
+// DeleteAsync deletes an inbound NAT rule asynchronously. DeleteAsync sends a DELETE
+// request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// progress of the operation.
+func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.azureClient.DeleteAsync")
+	defer done()
+
+	deleteFuture, err := ac.inboundnatrules.Delete(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName())
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
+	defer cancel()
+
+	err = deleteFuture.WaitForCompletionRef(ctx, ac.inboundnatrules.Client)
+	if err != nil {
+		// if an error occurs, return the future.
+		// this means the long-running operation didn't finish in the specified timeout.
+		return &deleteFuture, err
+	}
+	_, err = deleteFuture.Result(ac.inboundnatrules)
+	// if the operation completed, return a nil future.
+	return nil, err
+}
+
+// IsDone returns true if the long-running operation has completed.
+func (ac *azureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.azureClient.IsDone")
+	defer done()
+
+	isDone, err = future.DoneWithContext(ctx, ac.inboundnatrules)
+	if err != nil {
+		return false, errors.Wrap(err, "failed checking if the operation was complete")
+	}
+
+	return isDone, nil
+}
+
+// Result fetches the result of a long-running operation future.
+func (ac *azureClient) Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error) {
+	_, _, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.azureClient.Result")
+	defer done()
+
+	if future == nil {
+		return nil, errors.Errorf("cannot get result from nil future")
+	}
+
+	switch futureType {
+	case infrav1.PutFuture:
+		// Marshal and Unmarshal the future to put it into the correct future type so we can access the Result function.
+		// Unfortunately the FutureAPI can't be casted directly to InboundNatRulesCreateOrUpdateFuture because it is a azureautorest.Future, which doesn't implement the Result function. See PR #1686 for discussion on alternatives.
+		// It was converted back to a generic azureautorest.Future from the CAPZ infrav1.Future type stored in Status: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/converters/futures.go#L49.
+		var createFuture *network.InboundNatRulesCreateOrUpdateFuture
+		jsonData, err := future.MarshalJSON()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to marshal future")
+		}
+		if err := json.Unmarshal(jsonData, &createFuture); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal future data")
+		}
+		return (*createFuture).Result(ac.inboundnatrules)
+
+	case infrav1.DeleteFuture:
+		// Delete does not return a result inbound NAT rule
+		return nil, nil
+
+	default:
+		return nil, errors.Errorf("unknown future type %q", futureType)
+	}
 }

--- a/azure/services/inboundnatrules/mock_inboundnatrules/client_mock.go
+++ b/azure/services/inboundnatrules/mock_inboundnatrules/client_mock.go
@@ -25,7 +25,9 @@ import (
 	reflect "reflect"
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	azure "github.com/Azure/go-autorest/autorest/azure"
 	gomock "github.com/golang/mock/gomock"
+	azure0 "sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // Mockclient is a mock of client interface.
@@ -51,45 +53,93 @@ func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 	return m.recorder
 }
 
-// CreateOrUpdate mocks base method.
-func (m *Mockclient) CreateOrUpdate(arg0 context.Context, arg1, arg2, arg3 string, arg4 network.InboundNatRule) error {
+// CreateOrUpdateAsync mocks base method.
+func (m *Mockclient) CreateOrUpdateAsync(arg0 context.Context, arg1 azure0.ResourceSpecGetter, arg2 interface{}) (interface{}, azure.FutureAPI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", arg0, arg1, arg2)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(azure.FutureAPI)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// CreateOrUpdate indicates an expected call of CreateOrUpdate.
-func (mr *MockclientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+// CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
+func (mr *MockclientMockRecorder) CreateOrUpdateAsync(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdateAsync), arg0, arg1, arg2)
 }
 
-// Delete mocks base method.
-func (m *Mockclient) Delete(arg0 context.Context, arg1, arg2, arg3 string) error {
+// DeleteAsync mocks base method.
+func (m *Mockclient) DeleteAsync(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (azure.FutureAPI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "DeleteAsync", arg0, arg1)
+	ret0, _ := ret[0].(azure.FutureAPI)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// Delete indicates an expected call of Delete.
-func (mr *MockclientMockRecorder) Delete(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// DeleteAsync indicates an expected call of DeleteAsync.
+func (mr *MockclientMockRecorder) DeleteAsync(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*Mockclient)(nil).Delete), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*Mockclient)(nil).DeleteAsync), arg0, arg1)
 }
 
 // Get mocks base method.
-func (m *Mockclient) Get(arg0 context.Context, arg1, arg2, arg3 string) (network.InboundNatRule, error) {
+func (m *Mockclient) Get(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(network.InboundNatRule)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockclientMockRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockclient)(nil).Get), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockclient)(nil).Get), arg0, arg1)
+}
+
+// IsDone mocks base method.
+func (m *Mockclient) IsDone(arg0 context.Context, arg1 azure.FutureAPI) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDone", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsDone indicates an expected call of IsDone.
+func (mr *MockclientMockRecorder) IsDone(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDone", reflect.TypeOf((*Mockclient)(nil).IsDone), arg0, arg1)
+}
+
+// List mocks base method.
+func (m *Mockclient) List(arg0 context.Context, arg1, arg2 string) ([]network.InboundNatRule, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]network.InboundNatRule)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockclientMockRecorder) List(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*Mockclient)(nil).List), arg0, arg1, arg2)
+}
+
+// Result mocks base method.
+func (m *Mockclient) Result(arg0 context.Context, arg1 azure.FutureAPI, arg2 string) (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Result", arg0, arg1, arg2)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Result indicates an expected call of Result.
+func (mr *MockclientMockRecorder) Result(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Result", reflect.TypeOf((*Mockclient)(nil).Result), arg0, arg1, arg2)
 }

--- a/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
+++ b/azure/services/inboundnatrules/mock_inboundnatrules/inboundnatrules_mock.go
@@ -27,6 +27,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
+	v1beta10 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 // MockInboundNatScope is a mock of InboundNatScope interface.
@@ -50,6 +51,20 @@ func NewMockInboundNatScope(ctrl *gomock.Controller) *MockInboundNatScope {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInboundNatScope) EXPECT() *MockInboundNatScopeMockRecorder {
 	return m.recorder
+}
+
+// APIServerLBName mocks base method.
+func (m *MockInboundNatScope) APIServerLBName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "APIServerLBName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// APIServerLBName indicates an expected call of APIServerLBName.
+func (mr *MockInboundNatScopeMockRecorder) APIServerLBName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBName", reflect.TypeOf((*MockInboundNatScope)(nil).APIServerLBName))
 }
 
 // AdditionalTags mocks base method.
@@ -178,6 +193,18 @@ func (mr *MockInboundNatScopeMockRecorder) ClusterName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterName", reflect.TypeOf((*MockInboundNatScope)(nil).ClusterName))
 }
 
+// DeleteLongRunningOperationState mocks base method.
+func (m *MockInboundNatScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+}
+
+// DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
+func (mr *MockInboundNatScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockInboundNatScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+}
+
 // FailureDomains mocks base method.
 func (m *MockInboundNatScope) FailureDomains() []string {
 	m.ctrl.T.Helper()
@@ -190,6 +217,20 @@ func (m *MockInboundNatScope) FailureDomains() []string {
 func (mr *MockInboundNatScopeMockRecorder) FailureDomains() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockInboundNatScope)(nil).FailureDomains))
+}
+
+// GetLongRunningOperationState mocks base method.
+func (m *MockInboundNatScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret0, _ := ret[0].(*v1beta1.Future)
+	return ret0
+}
+
+// GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
+func (mr *MockInboundNatScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockInboundNatScope)(nil).GetLongRunningOperationState), arg0, arg1)
 }
 
 // HashKey mocks base method.
@@ -207,17 +248,17 @@ func (mr *MockInboundNatScopeMockRecorder) HashKey() *gomock.Call {
 }
 
 // InboundNatSpecs mocks base method.
-func (m *MockInboundNatScope) InboundNatSpecs() []azure.InboundNatSpec {
+func (m *MockInboundNatScope) InboundNatSpecs(arg0 map[int32]struct{}) []azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InboundNatSpecs")
-	ret0, _ := ret[0].([]azure.InboundNatSpec)
+	ret := m.ctrl.Call(m, "InboundNatSpecs", arg0)
+	ret0, _ := ret[0].([]azure.ResourceSpecGetter)
 	return ret0
 }
 
 // InboundNatSpecs indicates an expected call of InboundNatSpecs.
-func (mr *MockInboundNatScopeMockRecorder) InboundNatSpecs() *gomock.Call {
+func (mr *MockInboundNatScopeMockRecorder) InboundNatSpecs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InboundNatSpecs", reflect.TypeOf((*MockInboundNatScope)(nil).InboundNatSpecs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InboundNatSpecs", reflect.TypeOf((*MockInboundNatScope)(nil).InboundNatSpecs), arg0)
 }
 
 // Location mocks base method.
@@ -248,6 +289,18 @@ func (mr *MockInboundNatScopeMockRecorder) ResourceGroup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockInboundNatScope)(nil).ResourceGroup))
 }
 
+// SetLongRunningOperationState mocks base method.
+func (m *MockInboundNatScope) SetLongRunningOperationState(arg0 *v1beta1.Future) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLongRunningOperationState", arg0)
+}
+
+// SetLongRunningOperationState indicates an expected call of SetLongRunningOperationState.
+func (mr *MockInboundNatScopeMockRecorder) SetLongRunningOperationState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLongRunningOperationState", reflect.TypeOf((*MockInboundNatScope)(nil).SetLongRunningOperationState), arg0)
+}
+
 // SubscriptionID mocks base method.
 func (m *MockInboundNatScope) SubscriptionID() string {
 	m.ctrl.T.Helper()
@@ -274,4 +327,40 @@ func (m *MockInboundNatScope) TenantID() string {
 func (mr *MockInboundNatScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockInboundNatScope)(nil).TenantID))
+}
+
+// UpdateDeleteStatus mocks base method.
+func (m *MockInboundNatScope) UpdateDeleteStatus(arg0 v1beta10.ConditionType, arg1 string, arg2 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateDeleteStatus", arg0, arg1, arg2)
+}
+
+// UpdateDeleteStatus indicates an expected call of UpdateDeleteStatus.
+func (mr *MockInboundNatScopeMockRecorder) UpdateDeleteStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeleteStatus", reflect.TypeOf((*MockInboundNatScope)(nil).UpdateDeleteStatus), arg0, arg1, arg2)
+}
+
+// UpdatePatchStatus mocks base method.
+func (m *MockInboundNatScope) UpdatePatchStatus(arg0 v1beta10.ConditionType, arg1 string, arg2 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatePatchStatus", arg0, arg1, arg2)
+}
+
+// UpdatePatchStatus indicates an expected call of UpdatePatchStatus.
+func (mr *MockInboundNatScopeMockRecorder) UpdatePatchStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePatchStatus", reflect.TypeOf((*MockInboundNatScope)(nil).UpdatePatchStatus), arg0, arg1, arg2)
+}
+
+// UpdatePutStatus mocks base method.
+func (m *MockInboundNatScope) UpdatePutStatus(arg0 v1beta10.ConditionType, arg1 string, arg2 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatePutStatus", arg0, arg1, arg2)
+}
+
+// UpdatePutStatus indicates an expected call of UpdatePutStatus.
+func (mr *MockInboundNatScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockInboundNatScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }

--- a/azure/services/inboundnatrules/spec.go
+++ b/azure/services/inboundnatrules/spec.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inboundnatrules
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/pkg/errors"
+)
+
+// InboundNatSpec defines the specification for an inbound NAT rule.
+type InboundNatSpec struct {
+	Name                      string
+	LoadBalancerName          string
+	ResourceGroup             string
+	FrontendIPConfigurationID *string
+	PortsInUse                map[int32]struct{}
+}
+
+// ResourceName returns the name of the inbound NAT rule.
+func (s *InboundNatSpec) ResourceName() string {
+	return s.Name
+}
+
+// ResourceGroupName returns the name of the resource group.
+func (s *InboundNatSpec) ResourceGroupName() string {
+	return s.ResourceGroup
+}
+
+// OwnerResourceName returns the name of the load balancer associated with an inbound NAT rule.
+func (s *InboundNatSpec) OwnerResourceName() string {
+	return s.LoadBalancerName
+}
+
+// Parameters returns the parameters for the inbound NAT rule.
+func (s *InboundNatSpec) Parameters(existing interface{}) (parameters interface{}, err error) {
+	if existing != nil {
+		if _, ok := existing.(network.InboundNatRule); !ok {
+			return nil, errors.Errorf("%T is not a network.InboundNatRule", existing)
+		}
+
+		return nil, nil
+	}
+
+	if s.FrontendIPConfigurationID == nil {
+		return nil, errors.Errorf("FrontendIPConfigurationID is not set")
+	}
+
+	sshFrontendPort, err := getAvailablePort(s.PortsInUse)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to find available SSH Frontend port for NAT Rule %s in load balancer %s", s.ResourceName(), s.OwnerResourceName())
+	}
+
+	rule := network.InboundNatRule{
+		Name: to.StringPtr(s.ResourceName()),
+		InboundNatRulePropertiesFormat: &network.InboundNatRulePropertiesFormat{
+			BackendPort:          to.Int32Ptr(22),
+			EnableFloatingIP:     to.BoolPtr(false),
+			IdleTimeoutInMinutes: to.Int32Ptr(4),
+			FrontendIPConfiguration: &network.SubResource{
+				ID: s.FrontendIPConfigurationID,
+			},
+			Protocol:     network.TransportProtocolTCP,
+			FrontendPort: &sshFrontendPort,
+		},
+	}
+
+	return rule, nil
+}
+
+func getAvailablePort(portsInUse map[int32]struct{}) (int32, error) {
+	// NAT rules need to use a unique port. Since we need one NAT rule per control plane and we expect to have 1, 3, 5, maybe 9 control planes, there should never be more than 9 ports in use.
+	// This is an artificial limit of 20 ports that we can pick from, which should be plenty enough (in reality we should never reach that limit).
+	// These NAT rules are used for SSH purposes which is why we start at 22 and then use 2201, 2202, etc.
+	var i int32 = 22
+	if _, ok := portsInUse[22]; ok {
+		for i = 2201; i < 2220; i++ {
+			if _, ok := portsInUse[i]; !ok {
+				// Found available port
+				return i, nil
+			}
+		}
+		return i, errors.Errorf("No available SSH Frontend ports")
+	}
+
+	return i, nil
+}

--- a/azure/services/inboundnatrules/spec_test.go
+++ b/azure/services/inboundnatrules/spec_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inboundnatrules
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetAvailablePort(t *testing.T) {
+	testcases := []struct {
+		name               string
+		portsInput         map[int32]struct{}
+		expectedError      string
+		expectedPortResult int32
+	}{
+		{
+			name:               "Empty ports",
+			portsInput:         map[int32]struct{}{},
+			expectedError:      "",
+			expectedPortResult: 22,
+		},
+		{
+			name: "22 taken",
+			portsInput: map[int32]struct{}{
+				22: {},
+			},
+			expectedError:      "",
+			expectedPortResult: 2201,
+		},
+		{
+			name: "Existing ports",
+			portsInput: map[int32]struct{}{
+				22:   {},
+				2201: {},
+				2202: {},
+				2204: {},
+			},
+			expectedError:      "",
+			expectedPortResult: 2203,
+		},
+		{
+			name:               "No ports available",
+			portsInput:         getFullPortsMap(),
+			expectedError:      "No available SSH Frontend ports",
+			expectedPortResult: 0,
+		},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
+
+			res, err := getAvailablePort(tc.portsInput)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(res).To(Equal(tc.expectedPortResult))
+			}
+		})
+	}
+}
+
+func getFullPortsMap() map[int32]struct{} {
+	res := map[int32]struct{}{
+		22: {},
+	}
+	for i := 2201; i < 2220; i++ {
+		res[int32(i)] = struct{}{}
+	}
+	return res
+}

--- a/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
+++ b/azure/services/loadbalancers/mock_loadbalancers/loadbalancers_mock.go
@@ -52,6 +52,20 @@ func (m *MockLBScope) EXPECT() *MockLBScopeMockRecorder {
 	return m.recorder
 }
 
+// APIServerLB mocks base method.
+func (m *MockLBScope) APIServerLB() *v1beta1.LoadBalancerSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "APIServerLB")
+	ret0, _ := ret[0].(*v1beta1.LoadBalancerSpec)
+	return ret0
+}
+
+// APIServerLB indicates an expected call of APIServerLB.
+func (mr *MockLBScopeMockRecorder) APIServerLB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLB", reflect.TypeOf((*MockLBScope)(nil).APIServerLB))
+}
+
 // APIServerLBName mocks base method.
 func (m *MockLBScope) APIServerLBName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/natgateways/mock_natgateways/natgateways_mock.go
+++ b/azure/services/natgateways/mock_natgateways/natgateways_mock.go
@@ -53,6 +53,20 @@ func (m *MockNatGatewayScope) EXPECT() *MockNatGatewayScopeMockRecorder {
 	return m.recorder
 }
 
+// APIServerLB mocks base method.
+func (m *MockNatGatewayScope) APIServerLB() *v1beta1.LoadBalancerSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "APIServerLB")
+	ret0, _ := ret[0].(*v1beta1.LoadBalancerSpec)
+	return ret0
+}
+
+// APIServerLB indicates an expected call of APIServerLB.
+func (mr *MockNatGatewayScopeMockRecorder) APIServerLB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLB", reflect.TypeOf((*MockNatGatewayScope)(nil).APIServerLB))
+}
+
 // APIServerLBName mocks base method.
 func (m *MockNatGatewayScope) APIServerLBName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
+++ b/azure/services/securitygroups/mock_securitygroups/securitygroups_mock.go
@@ -52,6 +52,20 @@ func (m *MockNSGScope) EXPECT() *MockNSGScopeMockRecorder {
 	return m.recorder
 }
 
+// APIServerLB mocks base method.
+func (m *MockNSGScope) APIServerLB() *v1beta1.LoadBalancerSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "APIServerLB")
+	ret0, _ := ret[0].(*v1beta1.LoadBalancerSpec)
+	return ret0
+}
+
+// APIServerLB indicates an expected call of APIServerLB.
+func (mr *MockNSGScopeMockRecorder) APIServerLB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLB", reflect.TypeOf((*MockNSGScope)(nil).APIServerLB))
+}
+
 // APIServerLBName mocks base method.
 func (m *MockNSGScope) APIServerLBName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/subnets/mock_subnets/subnets_mock.go
+++ b/azure/services/subnets/mock_subnets/subnets_mock.go
@@ -52,6 +52,20 @@ func (m *MockSubnetScope) EXPECT() *MockSubnetScopeMockRecorder {
 	return m.recorder
 }
 
+// APIServerLB mocks base method.
+func (m *MockSubnetScope) APIServerLB() *v1beta1.LoadBalancerSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "APIServerLB")
+	ret0, _ := ret[0].(*v1beta1.LoadBalancerSpec)
+	return ret0
+}
+
+// APIServerLB indicates an expected call of APIServerLB.
+func (mr *MockSubnetScopeMockRecorder) APIServerLB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLB", reflect.TypeOf((*MockSubnetScope)(nil).APIServerLB))
+}
+
 // APIServerLBName mocks base method.
 func (m *MockSubnetScope) APIServerLBName() string {
 	m.ctrl.T.Helper()

--- a/azure/types.go
+++ b/azure/types.go
@@ -64,12 +64,6 @@ type LBSpec struct {
 	IdleTimeoutInMinutes *int32
 }
 
-// InboundNatSpec defines the specification for an inbound NAT rule.
-type InboundNatSpec struct {
-	Name             string
-	LoadBalancerName string
-}
-
 // SubnetSpec defines the specification for a Subnet.
 type SubnetSpec struct {
 	Name              string


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature
**What this PR does / why we need it**: Implementation of an async service for inbound NAT rules as a follow up for #1610 and #1541.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1712

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make inbound NAT rules reconcile/delete async
```
