### PR TITLE
e2e: Only check for valid image if version is a semver version

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -482,6 +482,7 @@ func parseImageSkuNames(skus []string) semver.Versions {
 func getLatestSkuForMinor(version string, skus semver.Versions) string {
 	isStable, match := validateStableReleaseString(version)
 	if isStable {
+		// if the version is in the format "stable-1.21", we find the latest 1.21.x version.
 		major, err := strconv.ParseUint(match[1], 10, 64)
 		Expect(err).NotTo(HaveOccurred())
 		minor, err := strconv.ParseUint(match[2], 10, 64)
@@ -493,11 +494,11 @@ func getLatestSkuForMinor(version string, skus semver.Versions) string {
 				break
 			}
 		}
-	} else {
-		v, err := semver.ParseTolerant(version)
-		Expect(err).NotTo(HaveOccurred())
+	} else if v, err := semver.ParseTolerant(version); err == nil {
+		// if the version is in the format "v1.21.2", we make sure we have an existing image for it.
 		Expect(skus).To(ContainElement(v), fmt.Sprintf("Provided Kubernetes version %s does not have a corresponding VM image in the capi offer", version))
 	}
+	// otherwise, we just return the version as-is. This allows for versions in other formats, such as "latest" or "latest-1.21".
 	return version
 }
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Fixes a regression from #1767 that broke tests using `latest-x.x` as k8s version https://testgrid.k8s.io/provider-azure-master-signal#capz-conformance

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
