### PR TITLE
Fix AAD pod identity integration for sovereign clouds

### DIFF
--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -148,7 +148,7 @@ func (p *AzureCredentialsProvider) GetAuthorizer(ctx context.Context, resourceMa
 	var spt *adal.ServicePrincipalToken
 	switch p.Identity.Spec.Type {
 	case infrav1.ServicePrincipal:
-		if err := createAzureIdentityWithBindings(ctx, p.Identity, clusterMeta, p.Client); err != nil {
+		if err := createAzureIdentityWithBindings(ctx, p.Identity, resourceManagerEndpoint, activeDirectoryEndpoint, clusterMeta, p.Client); err != nil {
 			return nil, err
 		}
 
@@ -212,7 +212,7 @@ func (p *AzureCredentialsProvider) GetTenantID() string {
 	return p.Identity.Spec.TenantID
 }
 
-func createAzureIdentityWithBindings(ctx context.Context, azureIdentity *infrav1.AzureClusterIdentity, clusterMeta metav1.ObjectMeta,
+func createAzureIdentityWithBindings(ctx context.Context, azureIdentity *infrav1.AzureClusterIdentity, resourceManagerEndpoint, activeDirectoryEndpoint string, clusterMeta metav1.ObjectMeta,
 	kubeClient client.Client) error {
 	azureIdentityType, err := getAzureIdentityType(azureIdentity)
 	if err != nil {
@@ -247,6 +247,8 @@ func createAzureIdentityWithBindings(ctx context.Context, azureIdentity *infrav1
 			ClientID:       azureIdentity.Spec.ClientID,
 			ClientPassword: azureIdentity.Spec.ClientSecret,
 			ResourceID:     azureIdentity.Spec.ResourceID,
+			ADResourceID:   resourceManagerEndpoint,
+			ADEndpoint:     activeDirectoryEndpoint,
 		},
 	}
 	err = kubeClient.Create(ctx, copiedIdentity)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: AAD pod identity AzureIdentitySpec `ADEndpoint` and `ADResourceID` weren't being set which was causing it to default to AzurePublicCloud values. Setting those values so it works across all clouds.

```
k get azurecluster -o wide
NAME           CLUSTER        READY   REASON   MESSAGE   RESOURCE GROUP   SUBSCRIPTIONID   LOCATION     ENDPOINT
cecile-25545   cecile-25545   True                       cecile-25545     redacted         chinaeast2   cecile-25545-2b5a47a7.chinaeast2.cloudapp.chinacloudapi.cn
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1843 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix AAD pod identity integration for sovereign clouds
```
