### PR TITLE
Derive API server LB DNS name from user-defined private DNS zone name

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -139,9 +139,9 @@ func GeneratePrivateDNSZoneName(clusterName string) string {
 	return fmt.Sprintf("%s.capz.io", clusterName)
 }
 
-// GeneratePrivateFQDN generates FQDN for a private API Server.
-func GeneratePrivateFQDN(clusterName string) string {
-	return fmt.Sprintf("%s.%s", PrivateAPIServerHostname, GeneratePrivateDNSZoneName(clusterName))
+// GeneratePrivateFQDN generates the FQDN for a private API Server based on the private DNS zone name.
+func GeneratePrivateFQDN(zoneName string) string {
+	return fmt.Sprintf("%s.%s", PrivateAPIServerHostname, zoneName)
 }
 
 // GenerateVNetLinkName generates the name of a virtual network link name based on the vnet name.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -639,7 +639,7 @@ func (s *ClusterScope) APIServerPort() int32 {
 // APIServerHost returns the hostname used to reach the API server.
 func (s *ClusterScope) APIServerHost() string {
 	if s.IsAPIServerPrivate() {
-		return azure.GeneratePrivateFQDN(s.ClusterName())
+		return azure.GeneratePrivateFQDN(s.GetPrivateDNSZoneName())
 	}
 	return s.APIServerPublicIP().DNSName
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
If the user defines a private DNS zone name, they expect the API server LB DNS name to use that zone. Prior to this change, the API server LB DNS name always used the default private DNS zone (`capz.io`).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1885 

**Special notes for your reviewer**:
I'm not yet familiar with the code base, so the fix and/or tests might be off-track. Constructive criticism welcome :smile: 

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The user-defined private DNS zone name is now used to derive the cluster's API server load balancer DNS name. 
```
