### PR TITLE
Replace all occurrences of ToNot(HaveOccurred())

### DIFF
--- a/azure/regional_baseuri_test.go
+++ b/azure/regional_baseuri_test.go
@@ -68,7 +68,7 @@ func TestWithRegionalBaseURI(t *testing.T) {
 			defer mockCtrl.Finish()
 			authMock := mock_azure.NewMockAuthorizer(mockCtrl)
 			regionalAuth, err := WithRegionalBaseURI(c.AuthorizerFactory(authMock), c.Region)
-			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(regionalAuth.BaseURI()).To(Equal(c.Result))
 		})
 	}

--- a/azure/scope/clients_test.go
+++ b/azure/scope/clients_test.go
@@ -76,7 +76,7 @@ func TestGettingEnvironment(t *testing.T) {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(test.expectedErrorMessage))
 			} else {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(c.ResourceManagerEndpoint).To(Equal(test.expectedEndpoint))
 				g.Expect(c.ResourceManagerVMDNSSuffix).To(Equal(test.expectedDNSSuffix))
 			}

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -81,12 +81,12 @@ func TestGettingSecurityRules(t *testing.T) {
 		AzureCluster: azureCluster,
 		Client:       fakeClient,
 	})
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	clusterScope.SetControlPlaneSecurityRules()
 
 	subnet, err := clusterScope.AzureCluster.Spec.NetworkSpec.GetControlPlaneSubnet()
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(len(subnet.SecurityGroup.SecurityRules)).To(Equal(2))
 }
 
@@ -208,7 +208,7 @@ func TestOutboundLBName(t *testing.T) {
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
 			})
-			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
 			got := clusterScope.OutboundLBName(tc.role)
 			g.Expect(tc.expected).Should(Equal(got))
 		})

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -109,7 +109,7 @@ func TestMachinePoolScope_SetBootstrapConditions(t *testing.T) {
 				return string(infrav1.Succeeded), "foo"
 			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, err error) {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(conditions.IsTrue(amp, infrav1.BootstrapSucceededCondition))
 			},
 		},
@@ -172,7 +172,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 			Name: "default surge should be 1 if no deployment strategy is set",
 			Verify: func(g *WithT, surge int, err error) {
 				g.Expect(surge).To(Equal(1))
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 			},
 		},
 		{
@@ -182,7 +182,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 			},
 			Verify: func(g *WithT, surge int, err error) {
 				g.Expect(surge).To(Equal(1))
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 			},
 		},
 		{
@@ -199,7 +199,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 			},
 			Verify: func(g *WithT, surge int, err error) {
 				g.Expect(surge).To(Equal(2))
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 			},
 		},
 		{
@@ -216,7 +216,7 @@ func TestMachinePoolScope_MaxSurge(t *testing.T) {
 			},
 			Verify: func(g *WithT, surge int, err error) {
 				g.Expect(surge).To(Equal(2))
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 			},
 		},
 	}
@@ -312,7 +312,7 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 				mp.Spec.Template.Spec.Version = to.StringPtr("v1.19.11")
 			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, vmImage *infrav1.Image, err error) {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				image := &infrav1.Image{
 					Marketplace: &infrav1.AzureMarketplaceImage{
 						Publisher:       "cncf-upstream",
@@ -341,7 +341,7 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 				}
 			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, vmImage *infrav1.Image, err error) {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				image := &infrav1.Image{
 					Marketplace: &infrav1.AzureMarketplaceImage{
 						Publisher:       "cncf-upstream",
@@ -539,7 +539,7 @@ func TestMachinePoolScope_updateReplicasAndProviderIDs(t *testing.T) {
 				}
 			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, err error) {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(amp.Status.Replicas).To(BeEquivalentTo(3))
 				g.Expect(amp.Spec.ProviderIDList).To(ConsistOf("/foo/ampm0", "/foo/ampm1", "/foo/ampm2"))
 			},
@@ -555,7 +555,7 @@ func TestMachinePoolScope_updateReplicasAndProviderIDs(t *testing.T) {
 				}
 			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, err error) {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(amp.Status.Replicas).To(BeEquivalentTo(2))
 			},
 		},
@@ -570,7 +570,7 @@ func TestMachinePoolScope_updateReplicasAndProviderIDs(t *testing.T) {
 				}
 			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, err error) {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(amp.Status.Replicas).To(BeEquivalentTo(2))
 			},
 		},

--- a/azure/scope/machinepoolmachine_test.go
+++ b/azure/scope/machinepoolmachine_test.go
@@ -127,7 +127,7 @@ func TestNewMachinePoolMachineScope(t *testing.T) {
 			if c.Err != "" {
 				g.Expect(err).To(MatchError(c.Err))
 			} else {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(s).ToNot(BeNil())
 			}
 		})
@@ -298,7 +298,7 @@ func TestMachineScope_UpdateStatus(t *testing.T) {
 			})
 			params.AzureMachinePoolMachine = ampm
 			s, err := NewMachinePoolMachineScope(params)
-			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(s).ToNot(BeNil())
 			s.instance = instance
 			s.workloadNodeGetter = mockClient
@@ -396,7 +396,7 @@ func TestMachinePoolMachineScope_CordonAndDrain(t *testing.T) {
 			})
 			params.AzureMachinePoolMachine = ampm
 			s, err := NewMachinePoolMachineScope(params)
-			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(s).ToNot(BeNil())
 			s.Logger = klogr.New()
 			s.workloadNodeGetter = mockClient

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -84,7 +84,7 @@ func TestNewService(t *testing.T) {
 			},
 		},
 	})
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	mps, err := scope.NewMachinePoolScope(scope.MachinePoolScopeParams{
 		Client:           client,
@@ -93,7 +93,7 @@ func TestNewService(t *testing.T) {
 		AzureMachinePool: new(infrav1exp.AzureMachinePool),
 		ClusterScope:     s,
 	})
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 	actual := NewService(mps, resourceskus.NewStaticCache(nil, ""))
 	g.Expect(actual).ToNot(BeNil())
 }

--- a/azure/services/scalesetvms/scalesetvms_test.go
+++ b/azure/services/scalesetvms/scalesetvms_test.go
@@ -74,7 +74,7 @@ func TestNewService(t *testing.T) {
 			},
 		},
 	})
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	mpms, err := scope.NewMachinePoolMachineScope(scope.MachinePoolMachineScopeParams{
 		Client:                  client,
@@ -84,7 +84,7 @@ func TestNewService(t *testing.T) {
 		AzureMachinePoolMachine: new(infrav1exp.AzureMachinePoolMachine),
 		ClusterScope:            s,
 	})
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 	actual := NewService(mpms)
 	g.Expect(actual).ToNot(BeNil())
 }

--- a/controllers/azurecluster_controller_test.go
+++ b/controllers/azurecluster_controller_test.go
@@ -80,7 +80,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 			})
 
 			c, err := client.New(testEnv.Config, client.Options{Scheme: testEnv.GetScheme()})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			reconciler := NewAzureClusterReconciler(c, log, testEnv.GetEventRecorderFor("azurecluster-reconciler"), 1*time.Second, "")
 
 			instance := &infrav1.AzureCluster{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}

--- a/exp/controllers/azuremachinepoolmachine_controller_test.go
+++ b/exp/controllers/azuremachinepoolmachine_controller_test.go
@@ -57,7 +57,7 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 				cb.WithObjects(cluster, azCluster, mp, amp, ampm)
 			},
 			Verify: func(g *WithT, result ctrl.Result, err error) {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 				cb.WithObjects(cluster, azCluster, mp, amp, ampm)
 			},
 			Verify: func(g *WithT, result ctrl.Result, err error) {
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 			},
 		},
 	}

--- a/test/e2e/azure_machinepool_drain.go
+++ b/test/e2e/azure_machinepool_drain.go
@@ -97,7 +97,7 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 		clientset         = workloadClusterProxy.GetClientSet()
 		owningMachinePool = func() *clusterv1exp.MachinePool {
 			mp, err := getOwnerMachinePool(ctx, mgmtClusterProxy.GetClient(), amp.ObjectMeta)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			return mp
 		}()
 
@@ -143,7 +143,7 @@ func testMachinePoolCordonAndDrain(ctx context.Context, mgmtClusterProxy, worklo
 
 	By("labeling the machine pool nodes with machine pool type and name")
 	ampmls, err := getAzureMachinePoolMachines(ctx, mgmtClusterProxy, workloadClusterProxy, amp)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 	labelNodesWithMachinePoolName(ctx, workloadClusterProxy.GetClient(), amp.Name, ampmls)
 
 	By(fmt.Sprintf("deploying a publicly exposed HTTP service with pod anti-affinity on machine pool: %s/%s", amp.Namespace, amp.Name))

--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -116,7 +116,7 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 		Data: map[string][]byte{"clientSecret": []byte(spClientSecret)},
 	}
 	err := publicClusterProxy.GetClient().Create(ctx, secret)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	identityName := e2eConfig.GetVariable(ClusterIdentityName)
 	os.Setenv("CLUSTER_IDENTITY_NAME", identityName)

--- a/test/e2e/azure_selfhosted.go
+++ b/test/e2e/azure_selfhosted.go
@@ -75,7 +75,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		var err error
 		namespace, cancelWatches, err = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
 
 		spClientSecret := os.Getenv(AzureClientSecret)
@@ -91,7 +91,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 			Data: map[string][]byte{"clientSecret": []byte(spClientSecret)},
 		}
 		err = bootstrapClusterProxy.GetClient().Create(ctx, secret)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		identityName := input.E2EConfig.GetVariable(ClusterIdentityName)
 		Expect(os.Setenv(ClusterIdentityName, identityName)).NotTo(HaveOccurred())

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Workload cluster creation", func() {
 		if err != nil {
 			Logf("Creating cluster identity secret", secret.Name)
 			err = bootstrapClusterProxy.GetClient().Create(ctx, secret)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		} else {
 			Logf("Using existing cluster identity secret")
 		}

--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 		ns := fmt.Sprintf("capz-e2e-identity-%s", util.RandomString(6))
 
 		identityNamespace, err = e2e_namespace.Create(ctx, clientset, ns, map[string]string{})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		spClientSecret := os.Getenv(AzureClientSecret)
 		secret := &corev1.Secret{
@@ -80,7 +80,7 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 			Data: map[string][]byte{"clientSecret": []byte(spClientSecret)},
 		}
 		err = bootstrapClusterProxy.GetClient().Create(ctx, secret)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		identityName := e2eConfig.GetVariable(ClusterIdentityName)
 		Expect(os.Setenv(ClusterIdentityName, identityName)).To(Succeed())
@@ -309,7 +309,7 @@ func getPreInitFunc(ctx context.Context) func(proxy framework.ClusterProxy) {
 			Data: map[string][]byte{"clientSecret": []byte(spClientSecret)},
 		}
 		err := clusterProxy.GetClient().Create(ctx, secret)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		identityName := e2eConfig.GetVariable(ClusterIdentityName)
 		Expect(os.Setenv(ClusterIdentityName, identityName)).NotTo(HaveOccurred())

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Conformance Tests", func() {
 			Data: map[string][]byte{"clientSecret": []byte(spClientSecret)},
 		}
 		err = bootstrapClusterProxy.GetClient().Create(ctx, secret)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		identityName := e2eConfig.GetVariable(ClusterIdentityName)
 		Expect(os.Setenv(ClusterIdentityName, identityName)).NotTo(HaveOccurred())


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Replaces all occurrences of Expect(err).ToNot(HaveOccurred()) with (Expect(err).NotTo(HaveOccurred()) (ToNot -> NotTo)

**Which issue(s) this PR fixes** 
Fixes #1866

**Release note**:
```release-note
NONE
```
