### PR TITLE
Update tiltignore to enable auto-update yaml template in Tilt UI

### DIFF
--- a/.tiltignore
+++ b/.tiltignore
@@ -1,1 +1,5 @@
+# Ignore everything under ./templates
 templates
+
+# Allow only yaml templates under ./templates
+!templates/*.yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
The `.tilgignore` causes that changes to yaml templates don't trigger re-execution of `Tiltfile`. Thus the Tilt UI cannot use updated templates.

This PR changes `.tilgignore` to include only subfolders under `templates` but not `.yaml` in the folder, so that Tilt can watch template files. Then if a yaml template is changed, Tilt will notice it and re-execute `Tiltfile`, thus the new template is used instead of the old one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1766

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
