### PR TITLE
separate AKS control-plane and agentpool versions

### DIFF
--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -130,6 +130,135 @@ func TestManagedControlPlaneScope_Autoscaling(t *testing.T) {
 	}
 }
 
+func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = capiv1exp.AddToScheme(scheme)
+	_ = infrav1.AddToScheme(scheme)
+
+	cases := []struct {
+		Name     string
+		Input    ManagedControlPlaneScopeParams
+		Expected []azure.AgentPoolSpec
+		Err      string
+	}{
+		{
+			Name: "Without Version",
+			Input: ManagedControlPlaneScopeParams{
+				AzureClients: AzureClients{
+					Authorizer: autorest.NullAuthorizer{},
+				},
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+				},
+				ControlPlane: &infrav1.AzureManagedControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+					Spec: infrav1.AzureManagedControlPlaneSpec{
+						SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					},
+				},
+				MachinePool:      getMachinePool("pool0"),
+				InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+				PatchTarget:      getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+			},
+			Expected: []azure.AgentPoolSpec{
+				{
+					Name:     "pool0",
+					SKU:      "Standard_D2s_v3",
+					Replicas: 1,
+					Mode:     "System",
+				},
+			},
+		},
+		{
+			Name: "With Version",
+			Input: ManagedControlPlaneScopeParams{
+				AzureClients: AzureClients{
+					Authorizer: autorest.NullAuthorizer{},
+				},
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+				},
+				ControlPlane: &infrav1.AzureManagedControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+					Spec: infrav1.AzureManagedControlPlaneSpec{
+						Version:        "v1.22.0",
+						SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					},
+				},
+				MachinePool:      getMachinePoolWithVersion("pool0", "v1.21.1"),
+				InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+				PatchTarget:      getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+			},
+			Expected: []azure.AgentPoolSpec{
+				{
+					Name:     "pool0",
+					SKU:      "Standard_D2s_v3",
+					Mode:     "System",
+					Replicas: 1,
+					Version:  to.StringPtr("1.21.1"),
+				},
+			},
+		},
+		{
+			Name: "With bad version",
+			Input: ManagedControlPlaneScopeParams{
+				AzureClients: AzureClients{
+					Authorizer: autorest.NullAuthorizer{},
+				},
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+				},
+				ControlPlane: &infrav1.AzureManagedControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster1",
+						Namespace: "default",
+					},
+					Spec: infrav1.AzureManagedControlPlaneSpec{
+						Version:        "v1.20.1",
+						SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					},
+				},
+				MachinePool:      getMachinePoolWithVersion("pool0", "v1.21.1"),
+				InfraMachinePool: getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+				PatchTarget:      getAzureMachinePool("pool0", infrav1.NodePoolModeSystem),
+			},
+			Err: "MachinePool version cannot be greater than the AzureManagedControlPlane version",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			g := NewWithT(t)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(c.Input.MachinePool, c.Input.InfraMachinePool, c.Input.ControlPlane).Build()
+			c.Input.Client = fakeClient
+			s, err := NewManagedControlPlaneScope(context.TODO(), c.Input)
+			g.Expect(err).To(Succeed())
+			agentPools, err := s.GetAgentPoolSpecs(context.TODO())
+			if err != nil {
+				g.Expect(err.Error()).To(Equal(c.Err))
+			} else {
+				g.Expect(agentPools).To(Equal(c.Expected))
+			}
+		})
+	}
+}
+
 func TestManagedControlPlaneScope_MaxPods(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = capiv1exp.AddToScheme(scheme)
@@ -277,4 +406,10 @@ func getMachinePool(name string) *capiv1exp.MachinePool {
 			ClusterName: "cluster1",
 		},
 	}
+}
+
+func getMachinePoolWithVersion(name, version string) *capiv1exp.MachinePool {
+	machine := getMachinePool(name)
+	machine.Spec.Template.Spec.Version = to.StringPtr(version)
+	return machine
 }

--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -233,15 +233,16 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	for i := range managedClusterSpec.AgentPools {
 		pool := managedClusterSpec.AgentPools[i]
 		profile := containerservice.ManagedClusterAgentPoolProfile{
-			Name:              &pool.Name,
-			VMSize:            &pool.SKU,
-			OsDiskSizeGB:      &pool.OSDiskSizeGB,
-			Count:             &pool.Replicas,
-			Type:              containerservice.AgentPoolTypeVirtualMachineScaleSets,
-			VnetSubnetID:      &managedClusterSpec.VnetSubnetID,
-			Mode:              containerservice.AgentPoolMode(pool.Mode),
-			AvailabilityZones: &pool.AvailabilityZones,
-			MaxPods:           pool.MaxPods,
+			Name:                &pool.Name,
+			VMSize:              &pool.SKU,
+			OsDiskSizeGB:        &pool.OSDiskSizeGB,
+			Count:               &pool.Replicas,
+			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
+			VnetSubnetID:        &managedClusterSpec.VnetSubnetID,
+			Mode:                containerservice.AgentPoolMode(pool.Mode),
+			AvailabilityZones:   &pool.AvailabilityZones,
+			MaxPods:             pool.MaxPods,
+			OrchestratorVersion: pool.Version,
 		}
 		*managedCluster.AgentPoolProfiles = append(*managedCluster.AgentPoolProfiles, profile)
 	}
@@ -313,6 +314,10 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			// AKS.
 			existingMC.NetworkProfile.LoadBalancerProfile.EffectiveOutboundIPs = nil
 		}
+
+		// Avoid changing agent pool profiles through AMCP and just use the existing agent pool profiles
+		// AgentPool changes are managed through AMMP
+		managedCluster.AgentPoolProfiles = existingMC.AgentPoolProfiles
 
 		diff := computeDiffOfNormalizedClusters(managedCluster, existingMC)
 		if diff != "" {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
If `MachinePool` `.spec.template.spec.version` is specified, this PR honours the version for nodepools and also separates the control plane upgrades from the agentpool upgrades. 


**Which issue(s) this PR fixes**:
Fixes #1883


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
control-plane-only upgrades for AKS
```
