### PR TITLE
chore: do not replace pre-created azure-json secret without the cluster name tag key

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -457,7 +457,7 @@ func reconcileAzureSecret(ctx context.Context, log logr.Logger, kubeclient clien
 
 	tag, exists := old.Labels[clusterName]
 
-	if exists && tag != string(infrav1.ResourceLifecycleOwned) {
+	if !exists || tag != string(infrav1.ResourceLifecycleOwned) {
 		log.V(2).Info("returning early from json reconcile, user provided secret already exists")
 		return nil
 	}

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -188,9 +188,11 @@ func TestReconcileAzureSecret(t *testing.T) {
 	g := NewWithT(t)
 
 	cases := map[string]struct {
-		kind       string
-		apiVersion string
-		ownerName  string
+		kind             string
+		apiVersion       string
+		ownerName        string
+		existingSecret   *corev1.Secret
+		expectedNoChange bool
 	}{
 		"azuremachine should reconcile secret successfully": {
 			kind:       "AzureMachine",
@@ -207,6 +209,52 @@ func TestReconcileAzureSecret(t *testing.T) {
 			apiVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
 			ownerName:  "azureMachineTemplateName",
 		},
+		"should not replace the content of the pre-existing unowned secret": {
+			kind:       "AzureMachine",
+			apiVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			ownerName:  "azureMachineName",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "azureMachineName-azure-json",
+					Namespace: "default",
+					Labels:    map[string]string{"testCluster": "foo"},
+				},
+				Data: map[string][]byte{
+					"azure.json": []byte("foobar"),
+				},
+			},
+			expectedNoChange: true,
+		},
+		"should not replace the content of the pre-existing unowned secret without the label": {
+			kind:       "AzureMachine",
+			apiVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			ownerName:  "azureMachineName",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "azureMachineName-azure-json",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"azure.json": []byte("foobar"),
+				},
+			},
+			expectedNoChange: true,
+		},
+		"should replace the content of the pre-existing owned secret": {
+			kind:       "AzureMachine",
+			apiVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			ownerName:  "azureMachineName",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "azureMachineName-azure-json",
+					Namespace: "default",
+					Labels:    map[string]string{"testCluster": string(infrav1.ResourceLifecycleOwned)},
+				},
+				Data: map[string][]byte{
+					"azure.json": []byte("foobar"),
+				},
+			},
+		},
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -217,6 +265,7 @@ func TestReconcileAzureSecret(t *testing.T) {
 
 	cluster.Default()
 	azureCluster.Default()
+	azureCluster.ClusterName = "testCluster"
 
 	scheme := setupScheme(g)
 	kubeclient := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -233,6 +282,14 @@ func TestReconcileAzureSecret(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			if tc.existingSecret != nil {
+				_ = kubeclient.Delete(context.Background(), tc.existingSecret)
+				_ = kubeclient.Create(context.Background(), tc.existingSecret)
+				defer func() {
+					_ = kubeclient.Delete(context.Background(), tc.existingSecret)
+				}()
+			}
+
 			owner := metav1.OwnerReference{
 				APIVersion: tc.apiVersion,
 				Kind:       tc.kind,
@@ -254,8 +311,13 @@ func TestReconcileAzureSecret(t *testing.T) {
 			if err := kubeclient.Get(context.Background(), key, found); err != nil {
 				t.Error(err)
 			}
-			g.Expect(cloudConfig.Data).To(Equal(found.Data))
-			g.Expect(found.OwnerReferences).To(Equal(cloudConfig.OwnerReferences))
+
+			if tc.expectedNoChange {
+				g.Expect(cloudConfig.Data).NotTo(Equal(found.Data))
+			} else {
+				g.Expect(cloudConfig.Data).To(Equal(found.Data))
+				g.Expect(found.OwnerReferences).To(Equal(cloudConfig.OwnerReferences))
+			}
 		})
 	}
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

According to the [doc](https://capz.sigs.k8s.io/topics/cloud-provider-config.html), when the secret `${RESOURCE}-azure-json` already exists in the same namespace as an AzureCluster and does not have the label `"${CLUSTER_NAME}": "owned"`, CAPZ will not generate the default described above. But currently the data in the secret will be replaced by the default values. This PR ensures the behavior aligns with the doc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1902 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
chore: do not replace pre-created azure-json secret without the cluster name tag key
```
