### PR TITLE
fix: MaxPods is an optional AzureManagedMachinePool configuration

### DIFF
--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -193,8 +193,10 @@ func (r *AzureManagedMachinePool) validateLastSystemNodePool(cli client.Client) 
 }
 
 func (r *AzureManagedMachinePool) validateMaxPods() error {
-	if to.Int32(r.Spec.MaxPods) < 10 || to.Int32(r.Spec.MaxPods) > 250 {
-		return errors.New("MaxPods must be between 10 and 250")
+	if r.Spec.MaxPods != nil {
+		if to.Int32(r.Spec.MaxPods) < 10 || to.Int32(r.Spec.MaxPods) > 250 {
+			return errors.New("MaxPods must be between 10 and 250")
+		}
 	}
 
 	return nil

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -258,6 +258,13 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid - optional configuration not present",
+			ammp: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{},
+			},
+			wantErr: false,
+		},
+		{
 			name: "too many MaxPods",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{

--- a/templates/test/ci/cluster-template-prow-aks-multi-tenancy.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-multi-tenancy.yaml
@@ -101,7 +101,6 @@ metadata:
   name: agentpool1
   namespace: default
 spec:
-  maxPods: 24
   mode: User
   osDiskSizeGB: 1024
   sku: ${AZURE_NODE_MACHINE_TYPE}

--- a/templates/test/ci/prow-aks-multi-tenancy/kustomization.yaml
+++ b/templates/test/ci/prow-aks-multi-tenancy/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
 patchesStrategicMerge:
   - ../patches/tags-aks.yaml
   - patches/maxpods-aks-agentpool0.yaml
-  - patches/maxpods-aks-agentpool1.yaml

--- a/templates/test/ci/prow-aks-multi-tenancy/patches/maxpods-aks-agentpool1.yaml
+++ b/templates/test/ci/prow-aks-multi-tenancy/patches/maxpods-aks-agentpool1.yaml
@@ -1,6 +1,0 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AzureManagedMachinePool
-metadata:
-  name: "agentpool1"
-spec:
-  maxPods: 24


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

This PR https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1910 included a bug in the webhook validation for AzureManagedMachinePool create: the `MaxPods` configuration is in fact optional, and we should not throw a validation error if that configuration is not present.

Sorry about that!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
