### PR TITLE
update external cloud-provider-azure versions

### DIFF
--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -408,7 +408,7 @@ data:
           effect: NoSchedule
       containers:
         - name: cloud-controller-manager
-          image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.1}
+          image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.7}
           imagePullPolicy: IfNotPresent
           command: ["cloud-controller-manager"]
           args:
@@ -536,7 +536,7 @@ data:
               effect: NoSchedule
           containers:
             - name: cloud-node-manager
-              image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.1}
+              image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.7}
               imagePullPolicy: IfNotPresent
               command:
                 - cloud-node-manager

--- a/templates/flavors/external-cloud-provider/cloud-controller-manager.yaml
+++ b/templates/flavors/external-cloud-provider/cloud-controller-manager.yaml
@@ -148,7 +148,7 @@ spec:
       effect: NoSchedule
   containers:
     - name: cloud-controller-manager
-      image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.1}
+      image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.7}
       imagePullPolicy: IfNotPresent
       command: ["cloud-controller-manager"]
       args:

--- a/templates/flavors/external-cloud-provider/cloud-node-manager.yaml
+++ b/templates/flavors/external-cloud-provider/cloud-node-manager.yaml
@@ -66,7 +66,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cloud-node-manager
-          image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.1}
+          image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.7}
           imagePullPolicy: IfNotPresent
           command:
             - cloud-node-manager

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -414,7 +414,7 @@ data:
           effect: NoSchedule
       containers:
         - name: cloud-controller-manager
-          image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.1}
+          image: ${AZURE_CLOUD_CONTROLLER_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.7}
           imagePullPolicy: IfNotPresent
           command: ["cloud-controller-manager"]
           args:
@@ -542,7 +542,7 @@ data:
               effect: NoSchedule
           containers:
             - name: cloud-node-manager
-              image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.1}
+              image: ${AZURE_CLOUD_NODE_MANAGER_IMG:=mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.0.7}
               imagePullPolicy: IfNotPresent
               command:
                 - cloud-node-manager


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/area test

**What this PR does / why we need it**:

This PR updates the versions of cloud-controller-manager and cloud-node-manager to v1.0.7. See:

https://github.com/kubernetes-sigs/cloud-provider-azure/releases/tag/v1.0.7

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Note that this change only affects the Kubernetes v1.21 version of external cloud-provider. It's not clear to me how we test v1.20 or v1.22 w/ external cloud-provider.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
