### PR TITLE
Return terminal error when the machine SKU is not found in cache

### DIFF
--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -104,7 +104,7 @@ type MachineCache struct {
 
 // InitMachineCache sets cached information about the machine to be used in the scope.
 func (m *MachineScope) InitMachineCache(ctx context.Context) error {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "azure.machineScope.initMachineCache")
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "azure.MachineScope.InitMachineCache")
 	defer done()
 
 	if m.cache == nil {
@@ -128,13 +128,12 @@ func (m *MachineScope) InitMachineCache(ctx context.Context) error {
 
 		m.cache.VMSKU, err = skuCache.Get(ctx, m.AzureMachine.Spec.VMSize, resourceskus.VirtualMachines)
 		if err != nil {
-			return azure.WithTerminalError(errors.Wrapf(err, "failed to get VM SKU %s in compute api", m.AzureMachine.Spec.VMSize))
+			return errors.Wrapf(err, "failed to get VM SKU %s in compute api", m.AzureMachine.Spec.VMSize)
 		}
 
 		m.cache.availabilitySetSKU, err = skuCache.Get(ctx, string(compute.AvailabilitySetSkuTypesAligned), resourceskus.AvailabilitySets)
 		if err != nil {
-			// TODO: verify error message
-			return azure.WithTerminalError(errors.Wrapf(err, "failed to get availability set SKU %s in compute api", string(compute.AvailabilitySetSkuTypesAligned)))
+			return errors.Wrapf(err, "failed to get availability set SKU %s in compute api", string(compute.AvailabilitySetSkuTypesAligned))
 		}
 	}
 

--- a/azure/services/resourceskus/cache.go
+++ b/azure/services/resourceskus/cache.go
@@ -135,7 +135,7 @@ func (c *Cache) Get(ctx context.Context, name string, kind ResourceType) (SKU, e
 			return SKU(sku), nil
 		}
 	}
-	return SKU{}, fmt.Errorf("resource sku with name '%s' and category '%s' not found in location '%s'", name, string(kind), c.location)
+	return SKU{}, azure.WithTerminalError(fmt.Errorf("resource sku with name '%s' and category '%s' not found in location '%s'", name, string(kind), c.location))
 }
 
 // Map invokes a function over all cached values.

--- a/azure/services/resourceskus/cache_test.go
+++ b/azure/services/resourceskus/cache_test.go
@@ -58,7 +58,7 @@ func TestCacheGet(t *testing.T) {
 					Name: to.StringPtr("other"),
 				},
 			},
-			err: "resource sku with name 'foo' and category 'bar' not found in location 'test'",
+			err: "reconcile error that cannot be recovered occurred: resource sku with name 'foo' and category 'bar' not found in location 'test'. Object will not be requeued",
 		},
 	}
 

--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -287,7 +287,7 @@ func (s *Service) validateSpec(ctx context.Context) error {
 
 	sku, err := s.resourceSKUCache.Get(ctx, spec.Size, resourceskus.VirtualMachines)
 	if err != nil {
-		return azure.WithTerminalError(errors.Wrapf(err, "failed to get SKU %s in compute api", spec.Size))
+		return errors.Wrapf(err, "failed to get SKU %s in compute api", spec.Size)
 	}
 
 	// Checking if the requested VM size has at least 2 vCPUS

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -72,7 +72,7 @@ func TestNewService(t *testing.T) {
 		Cluster: cluster,
 		AzureCluster: &infrav1.AzureCluster{
 			Spec: infrav1.AzureClusterSpec{
-				Location: "test-location",
+				Location:       "test-location",
 				ResourceGroup:  "my-rg",
 				SubscriptionID: "123",
 				NetworkSpec: infrav1.NetworkSpec{
@@ -519,7 +519,7 @@ func TestReconcileVMSS(t *testing.T) {
 		},
 		{
 			name:          "failed to get SKU",
-			expectedError: "reconcile error that cannot be recovered occurred: failed to get SKU INVALID_VM_SIZE in compute api: resource sku with name 'INVALID_VM_SIZE' and category 'virtualMachines' not found in location 'test-location'. Object will not be requeued",
+			expectedError: "failed to get SKU INVALID_VM_SIZE in compute api: reconcile error that cannot be recovered occurred: resource sku with name 'INVALID_VM_SIZE' and category 'virtualMachines' not found in location 'test-location'. Object will not be requeued",
 			expect: func(g *WithT, s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
 				s.ScaleSetSpec().Return(azure.ScaleSetSpec{
 					Name:       defaultVMSSName,

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -268,9 +268,19 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 		return reconcile.Result{}, nil
 	}
 
+	var reconcileError azure.ReconcileError
+
 	// Initialize the cache to be used by the AzureMachine services.
 	err := machineScope.InitMachineCache(ctx)
 	if err != nil {
+		if errors.As(err, &reconcileError) && reconcileError.IsTerminal() {
+			amr.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "SKUNotFound", errors.Wrap(err, "failed to initialize machine cache").Error())
+			log.Error(err, "Failed to initialize machine cache")
+			machineScope.SetFailureReason(capierrors.InvalidConfigurationMachineError)
+			machineScope.SetFailureMessage(err)
+			machineScope.SetNotReady()
+			return reconcile.Result{}, nil
+		}
 		return reconcile.Result{}, errors.Wrap(err, "failed to init machine scope cache")
 	}
 
@@ -292,7 +302,6 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 		}
 
 		// Handle transient and terminal errors
-		var reconcileError azure.ReconcileError
 		if errors.As(err, &reconcileError) {
 			if reconcileError.IsTerminal() {
 				amr.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, "ReconcileError", errors.Wrapf(err, "failed to reconcile AzureMachine").Error())


### PR DESCRIPTION


 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:  Fixes the handling of errors from the Machine cache:
1. when the SKU is not found, return a terminal error. Otherwise, return a normal error.
2. handle the terminal errors from InitCache in the azuremachine controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1828 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Return terminal error when the machine SKU is not found in cache
```
