### PR TITLE
Improve Windows logging and general stability for upstream e2e tests

### DIFF
--- a/templates/addons/windows/containerd-logging/containerd-logger-resource-set.yaml
+++ b/templates/addons/windows/containerd-logging/containerd-logger-resource-set.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: containerd-logger-${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      containerd-logger: enabled
+  resources:
+  - kind: ConfigMap
+    name: containerd-logger-${CLUSTER_NAME}
+  strategy: ApplyOnce

--- a/templates/addons/windows/containerd-logging/containerd-logger.yaml
+++ b/templates/addons/windows/containerd-logging/containerd-logger.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: containerd-logger
+  name: containerd-logger
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: containerd-logger
+  template:
+    metadata:
+      labels:
+        k8s-app: containerd-logger
+    spec:
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\system"
+      hostNetwork: true
+      containers:
+      - image: ghcr.io/kubernetes-sigs/sig-windows/eventflow-logger:v0.1.0
+        args: [ "config.json" ]
+        name: containerd-logger
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: containerd-logger-config
+          mountPath: /config.json
+          subPath: config.json
+      nodeSelector:
+        kubernetes.io/os: windows
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - operator: Exists
+      volumes:
+      - configMap:
+          name: containerd-logger-config
+        name: containerd-logger-config
+  updateStrategy:
+    type: RollingUpdate
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: containerd-logger-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+      "inputs": [
+        {
+          "type": "ETW",
+          "sessionNamePrefix": "containerd",
+          "cleanupOldSessions": true,
+          "reuseExistingSession": true,
+          "providers": [
+            {
+              "providerName": "Microsoft.Virtualization.RunHCS",
+              "providerGuid": "0B52781F-B24D-5685-DDF6-69830ED40EC3",
+              "level": "Verbose"
+            },
+            {
+              "providerName": "ContainerD",
+              "providerGuid": "2acb92c0-eb9b-571a-69cf-8f3410f383ad",
+              "level": "Verbose"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "type": "StdOutput"
+        }
+      ],
+      "schemaVersion": "2016-08-11"
+    }

--- a/templates/addons/windows/containerd-logging/containerd-logger.yaml
+++ b/templates/addons/windows/containerd-logging/containerd-logger.yaml
@@ -69,6 +69,36 @@ data:
           ]
         }
       ],
+      "filters": [
+        {
+            "type": "drop",
+            "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == Stats && hasnoproperty error"
+        },
+        {
+            "type": "drop",
+            "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == hcsshim::LayerID && hasnoproperty error"
+        },
+        {
+            "type": "drop",
+            "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == hcsshim::NameToGuid && hasnoproperty error"
+        },
+        {
+            "type": "drop",
+            "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == containerd.task.v2.Task.Stats && hasnoproperty error"
+        },
+        {
+            "type": "drop",
+            "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == containerd.task.v2.Task.State && hasnoproperty error"
+        },
+        {
+            "type": "drop",
+            "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == HcsGetProcessProperties && hasnoproperty error"
+        },
+        {
+            "type": "drop",
+            "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == HcsGetComputeSystemProperties && hasnoproperty error"
+        }
+      ],
       "outputs": [
         {
           "type": "StdOutput"

--- a/templates/cluster-template-windows-containerd.yaml
+++ b/templates/cluster-template-windows-containerd.yaml
@@ -298,6 +298,7 @@ spec:
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
+            windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/cluster-template-windows-containerd.yaml
+++ b/templates/cluster-template-windows-containerd.yaml
@@ -297,6 +297,7 @@ spec:
             cloud-config: c:/k/azure.json
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
+            v: "2"
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/cluster-template-windows-containerd.yaml
+++ b/templates/cluster-template-windows-containerd.yaml
@@ -286,9 +286,7 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: |-
-          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
-          Set-ItemProperty -Path "HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Type DWord -Name NoAutoUpdate -Value 1
+      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       joinConfiguration:

--- a/templates/cluster-template-windows-containerd.yaml
+++ b/templates/cluster-template-windows-containerd.yaml
@@ -286,7 +286,9 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+      - content: |-
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico-ipam.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       joinConfiguration:

--- a/templates/flavors/windows-containerd/machine-deployment-windows.yaml
+++ b/templates/flavors/windows-containerd/machine-deployment-windows.yaml
@@ -78,3 +78,4 @@ spec:
         permissions: "0744"
         content: |-
           Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico-ipam.exe

--- a/templates/flavors/windows-containerd/machine-deployment-windows.yaml
+++ b/templates/flavors/windows-containerd/machine-deployment-windows.yaml
@@ -64,6 +64,7 @@ spec:
             cloud-config: 'c:/k/azure.json'
             azure-container-registry-config: 'c:/k/azure.json'
             feature-gates: "WindowsHostProcessContainers=true"
+            v: "2"
       files:
       - contentFrom:
           secret:

--- a/templates/flavors/windows-containerd/machine-deployment-windows.yaml
+++ b/templates/flavors/windows-containerd/machine-deployment-windows.yaml
@@ -65,6 +65,7 @@ spec:
             azure-container-registry-config: 'c:/k/azure.json'
             feature-gates: "WindowsHostProcessContainers=true"
             v: "2"
+            windows-priorityclass: "ABOVE_NORMAL_PRIORITY_CLASS"
       files:
       - contentFrom:
           secret:

--- a/templates/flavors/windows-containerd/machine-deployment-windows.yaml
+++ b/templates/flavors/windows-containerd/machine-deployment-windows.yaml
@@ -76,4 +76,3 @@ spec:
         permissions: "0744"
         content: |-
           Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
-          Set-ItemProperty -Path "HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Type DWord -Name NoAutoUpdate -Value 1

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -472,6 +472,7 @@ spec:
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
+            windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     cni: ${CLUSTER_NAME}-calico
+    containerd-logger: enabled
     metrics-server: enabled
   name: ${CLUSTER_NAME}
   namespace: default
@@ -3109,6 +3110,20 @@ spec:
     name: metrics-server-${CLUSTER_NAME}
   strategy: ApplyOnce
 ---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: containerd-logger-${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      containerd-logger: enabled
+  resources:
+  - kind: ConfigMap
+    name: containerd-logger-${CLUSTER_NAME}
+  strategy: ApplyOnce
+---
 apiVersion: v1
 data:
   metrics-server: |
@@ -3316,4 +3331,94 @@ metadata:
   labels:
     type: generated
   name: metrics-server-${CLUSTER_NAME}
+  namespace: default
+---
+apiVersion: v1
+data:
+  containerd-windows-logger: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: containerd-logger
+      name: containerd-logger
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: containerd-logger
+      template:
+        metadata:
+          labels:
+            k8s-app: containerd-logger
+        spec:
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: ghcr.io/kubernetes-sigs/sig-windows/eventflow-logger:v0.1.0
+            args: [ "config.json" ]
+            name: containerd-logger
+            imagePullPolicy: Always
+            volumeMounts:
+            - name: containerd-logger-config
+              mountPath: /config.json
+              subPath: config.json
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: containerd-logger-config
+            name: containerd-logger-config
+      updateStrategy:
+        type: RollingUpdate
+    ---
+    kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: containerd-logger-config
+      namespace: kube-system
+    data:
+      config.json: |
+        {
+          "inputs": [
+            {
+              "type": "ETW",
+              "sessionNamePrefix": "containerd",
+              "cleanupOldSessions": true,
+              "reuseExistingSession": true,
+              "providers": [
+                {
+                  "providerName": "Microsoft.Virtualization.RunHCS",
+                  "providerGuid": "0B52781F-B24D-5685-DDF6-69830ED40EC3",
+                  "level": "Verbose"
+                },
+                {
+                  "providerName": "ContainerD",
+                  "providerGuid": "2acb92c0-eb9b-571a-69cf-8f3410f383ad",
+                  "level": "Verbose"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "type": "StdOutput"
+            }
+          ],
+          "schemaVersion": "2016-08-11"
+        }
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: containerd-logger-${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -429,9 +429,7 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: |-
-          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
-          Set-ItemProperty -Path "HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Type DWord -Name NoAutoUpdate -Value 1
+      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       - content: |

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -403,8 +403,8 @@ spec:
         marketplace:
           offer: capi-windows
           publisher: cncf-upstream
-          sku: k8s-1dot22dot2-windows-2022-containerd
-          version: 2021.10.15
+          sku: k8s-1dot23dot1-windows-2022-containerd
+          version: 2021.12.16
       osDisk:
         diskSizeGB: 128
         managedDisk:
@@ -456,8 +456,8 @@ spec:
 
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess
-          ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+          ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           kubeadm.exe version -o=short
           kubectl.exe version --client=true --short=true

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -430,7 +430,9 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+      - content: |-
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico-ipam.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       - content: |

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -471,6 +471,7 @@ spec:
             cloud-config: c:/k/azure.json
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
+            v: "2"
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START
@@ -3405,6 +3406,36 @@ data:
                   "level": "Verbose"
                 }
               ]
+            }
+          ],
+          "filters": [
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == Stats && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == hcsshim::LayerID && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == hcsshim::NameToGuid && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == containerd.task.v2.Task.Stats && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == containerd.task.v2.Task.State && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == HcsGetProcessProperties && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == HcsGetComputeSystemProperties && hasnoproperty error"
             }
           ],
           "outputs": [

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -472,6 +472,7 @@ spec:
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
+            windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     cni: ${CLUSTER_NAME}-calico
+    containerd-logger: enabled
     metrics-server: enabled
   name: ${CLUSTER_NAME}
   namespace: default
@@ -3109,6 +3110,20 @@ spec:
     name: metrics-server-${CLUSTER_NAME}
   strategy: ApplyOnce
 ---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: containerd-logger-${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      containerd-logger: enabled
+  resources:
+  - kind: ConfigMap
+    name: containerd-logger-${CLUSTER_NAME}
+  strategy: ApplyOnce
+---
 apiVersion: v1
 data:
   metrics-server: |
@@ -3316,4 +3331,94 @@ metadata:
   labels:
     type: generated
   name: metrics-server-${CLUSTER_NAME}
+  namespace: default
+---
+apiVersion: v1
+data:
+  containerd-windows-logger: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        k8s-app: containerd-logger
+      name: containerd-logger
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: containerd-logger
+      template:
+        metadata:
+          labels:
+            k8s-app: containerd-logger
+        spec:
+          securityContext:
+            windowsOptions:
+              hostProcess: true
+              runAsUserName: "NT AUTHORITY\\system"
+          hostNetwork: true
+          containers:
+          - image: ghcr.io/kubernetes-sigs/sig-windows/eventflow-logger:v0.1.0
+            args: [ "config.json" ]
+            name: containerd-logger
+            imagePullPolicy: Always
+            volumeMounts:
+            - name: containerd-logger-config
+              mountPath: /config.json
+              subPath: config.json
+          nodeSelector:
+            kubernetes.io/os: windows
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - operator: Exists
+          volumes:
+          - configMap:
+              name: containerd-logger-config
+            name: containerd-logger-config
+      updateStrategy:
+        type: RollingUpdate
+    ---
+    kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: containerd-logger-config
+      namespace: kube-system
+    data:
+      config.json: |
+        {
+          "inputs": [
+            {
+              "type": "ETW",
+              "sessionNamePrefix": "containerd",
+              "cleanupOldSessions": true,
+              "reuseExistingSession": true,
+              "providers": [
+                {
+                  "providerName": "Microsoft.Virtualization.RunHCS",
+                  "providerGuid": "0B52781F-B24D-5685-DDF6-69830ED40EC3",
+                  "level": "Verbose"
+                },
+                {
+                  "providerName": "ContainerD",
+                  "providerGuid": "2acb92c0-eb9b-571a-69cf-8f3410f383ad",
+                  "level": "Verbose"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "type": "StdOutput"
+            }
+          ],
+          "schemaVersion": "2016-08-11"
+        }
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: containerd-logger-${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -429,9 +429,7 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: |-
-          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
-          Set-ItemProperty -Path "HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Type DWord -Name NoAutoUpdate -Value 1
+      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       - content: |

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -430,7 +430,9 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+      - content: |-
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico-ipam.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       - content: |

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -471,6 +471,7 @@ spec:
             cloud-config: c:/k/azure.json
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
+            v: "2"
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START
@@ -3405,6 +3406,36 @@ data:
                   "level": "Verbose"
                 }
               ]
+            }
+          ],
+          "filters": [
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == Stats && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == hcsshim::LayerID && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == hcsshim::NameToGuid && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == containerd.task.v2.Task.Stats && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == containerd.task.v2.Task.State && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == HcsGetProcessProperties && hasnoproperty error"
+            },
+            {
+                "type": "drop",
+                "include": "ProviderName == Microsoft.Virtualization.RunHCS && name == HcsGetComputeSystemProperties && hasnoproperty error"
             }
           ],
           "outputs": [

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -403,8 +403,8 @@ spec:
         marketplace:
           offer: capi-windows
           publisher: cncf-upstream
-          sku: k8s-1dot22dot1-windows-2019-containerd
-          version: 2021.10.15
+          sku: k8s-1dot23dot1-windows-2019-containerd
+          version: 2021.12.16
       osDisk:
         diskSizeGB: 128
         managedDisk:
@@ -456,8 +456,8 @@ spec:
 
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess
-          ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+          ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+          ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           kubeadm.exe version -o=short
           kubectl.exe version --client=true --short=true

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -419,8 +419,8 @@ spec:
       marketplace:
         offer: capi-windows
         publisher: cncf-upstream
-        sku: k8s-1dot22dot1-windows-2019-containerd
-        version: 2021.10.15
+        sku: k8s-1dot23dot1-windows-2019-containerd
+        version: 2021.12.16
     osDisk:
       diskSizeGB: 30
       managedDisk:
@@ -463,8 +463,8 @@ spec:
 
       # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
       # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess
-      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
       kubectl.exe version --client=true --short=true

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -275,9 +275,7 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: |-
-          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
-          Set-ItemProperty -Path "HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Type DWord -Name NoAutoUpdate -Value 1
+      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       - content: |

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -291,6 +291,7 @@ spec:
             cloud-config: c:/k/azure.json
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
+            v: "2"
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -292,6 +292,7 @@ spec:
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
+            windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -275,7 +275,9 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+      - content: |-
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico-ipam.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       - content: |

--- a/templates/test/ci/patches/windows-containerd-enabled-cluster.yaml
+++ b/templates/test/ci/patches/windows-containerd-enabled-cluster.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  labels:
+    containerd-logger: enabled

--- a/templates/test/ci/prow-ci-version-windows-containerd-2022/patches/windows-image-update.yaml
+++ b/templates/test/ci/prow-ci-version-windows-containerd-2022/patches/windows-image-update.yaml
@@ -12,5 +12,5 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi-windows
-          sku: k8s-1dot22dot2-windows-2022-containerd
-          version: "2021.10.15"
+          sku: k8s-1dot23dot1-windows-2022-containerd
+          version: "2021.12.16"

--- a/templates/test/ci/prow-ci-version/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: default
 resources:
   - ../prow
   - ../../../addons/metrics-server/metrics-server-resource-set.yaml
+  - ../../../addons/windows/containerd-logging/containerd-logger-resource-set.yaml
 patchesStrategicMerge:
   - ../patches/control-plane-image-ci-version.yaml
   - ../patches/controller-manager.yaml
@@ -13,6 +14,7 @@ patchesStrategicMerge:
   - patches/machine-deployment-ci-version-windows.yaml
   - ../patches/metrics-server-enabled-cluster.yaml
   - patches/controller-manager-featuregates.yaml
+  - ../patches/windows-containerd-enabled-cluster.yaml
 patches:
 - target:
     group: bootstrap.cluster.x-k8s.io
@@ -42,6 +44,9 @@ configMapGenerator:
   - name: metrics-server-${CLUSTER_NAME}
     files:
       - metrics-server=../../../addons/metrics-server/metrics-server.yaml
+  - name: containerd-logger-${CLUSTER_NAME}
+    files:
+      - containerd-windows-logger=../../../addons/windows/containerd-logging/containerd-logger.yaml
 generatorOptions:
   disableNameSuffixHash: true
   labels:

--- a/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap-windows.yaml
+++ b/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap-windows.yaml
@@ -18,8 +18,8 @@
 
       # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
       # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess
-      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
       kubectl.exe version --client=true --short=true

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-windows.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-windows.yaml
@@ -6,10 +6,11 @@ spec:
   template:
     spec:
       image:
-        # we use the 1.22.1 image as a workaround there is no published marketplace image for k8s CI versions.
-        # 1.22.1 binaries and images will get replaced to the desired version by the script in this template.
+        # we use the 1.23.1 image as a workaround there is no published marketplace image for k8s CI versions.
+        # 1.23.1 binaries and images will get replaced to the desired version by the script above.
         marketplace:
           publisher: cncf-upstream
           offer: capi-windows
-          sku: k8s-1dot22dot1-windows-2019-containerd
-          version: "2021.10.15"
+          sku: k8s-1dot23dot1-windows-2019-containerd
+          version: "2021.12.16"
+

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/kubeadm-bootstrap-windows.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/kubeadm-bootstrap-windows.yaml
@@ -18,8 +18,8 @@
 
       # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
       # that is applied at at this stage (windows-kubeproxy-ci.yaml)
-      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess
-      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
+      ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess
+      ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
       kubectl.exe version --client=true --short=true

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version-windows.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version-windows.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   template:
     image:
-      # we use the 1.22.1 image as a workaround there is no published marketplace image for k8s CI versions.
-      # 1.22.1 binaries and images will get replaced to the desired version by the script in this template.
+      # we use the 1.23.1 image as a workaround there is no published marketplace image for k8s CI versions.
+      # 1.23.1 binaries and images will get replaced to the desired version by the script in this template.
       marketplace:
         publisher: cncf-upstream
         offer: capi-windows
-        sku: k8s-1dot22dot1-windows-2019-containerd
-        version: "2021.10.15"
+        sku: k8s-1dot23dot1-windows-2019-containerd
+        version: "2021.12.16"

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -364,9 +364,7 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: |-
-          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
-          Set-ItemProperty -Path "HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Type DWord -Name NoAutoUpdate -Value 1
+      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       - content: |

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -380,6 +380,7 @@ spec:
             cloud-config: c:/k/azure.json
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
+            v: "2"
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -381,6 +381,7 @@ spec:
             cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
+            windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -364,7 +364,9 @@ spec:
         owner: root:root
         path: c:/k/azure.json
         permissions: "0644"
-      - content: Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+      - content: |-
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico.exe
+          Add-MpPreference -ExclusionProcess C:/opt/cni/bin/calico-ipam.exe
         path: C:/defender-exclude-calico.ps1
         permissions: "0744"
       - content: |

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -252,6 +252,10 @@ func windowsK8sLogs(execToPathFn func(outputFileName string, command string, arg
 			"kubelet.log",
 			`Get-ChildItem "C:\\var\\log\\kubelet\\"  | ForEach-Object { if ($_ -match 'log.INFO') { write-output "$_";cat "c:\\var\\log\\kubelet\\$_" } }`,
 		),
+		execToPathFn(
+			"cni.log",
+			`Get-Content "C:\\cni.log"`,
+		),
 	}
 }
 

--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -250,7 +250,7 @@ func windowsK8sLogs(execToPathFn func(outputFileName string, command string, arg
 		),
 		execToPathFn(
 			"kubelet.log",
-			`Get-ChildItem "C:\\var\\log\\kubelet\\"  | ForEach-Object { write-output "$_"  ;cat "c:\\var\\log\\kubelet\\$_" }`,
+			`Get-ChildItem "C:\\var\\log\\kubelet\\"  | ForEach-Object { if ($_ -match 'log.INFO') { write-output "$_";cat "c:\\var\\log\\kubelet\\$_" } }`,
 		),
 	}
 }

--- a/test/e2e/data/kubetest/upstream-windows-serial-slow.yaml
+++ b/test/e2e/data/kubetest/upstream-windows-serial-slow.yaml
@@ -8,3 +8,4 @@ ginkgo.trace: true
 ginkgo.v: true
 node-os-distro: windows
 dump-logs-on-failure: true
+prepull-images: true

--- a/test/e2e/data/kubetest/upstream-windows-serial-slow.yaml
+++ b/test/e2e/data/kubetest/upstream-windows-serial-slow.yaml
@@ -7,3 +7,4 @@ ginkgo.flakeAttempts: 0
 ginkgo.trace: true
 ginkgo.v: true
 node-os-distro: windows
+dump-logs-on-failure: true

--- a/test/e2e/data/kubetest/upstream-windows.yaml
+++ b/test/e2e/data/kubetest/upstream-windows.yaml
@@ -8,3 +8,4 @@ ginkgo.trace: true
 ginkgo.v: true
 node-os-distro: windows
 dump-logs-on-failure: true
+prepull-images: true

--- a/test/e2e/data/kubetest/upstream-windows.yaml
+++ b/test/e2e/data/kubetest/upstream-windows.yaml
@@ -7,3 +7,4 @@ ginkgo.flakeAttempts: 0
 ginkgo.trace: true
 ginkgo.v: true
 node-os-distro: windows
+dump-logs-on-failure: true


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The Windows upstream e2e test was randomly flaking across in CI.  I am going to use this PR to run those tests in the CI environment to get to the point of passing consistently as well as improve the general logging story for windows as I go.

The [latest update that turn off windows updates](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1881/commits/3e0a1a9d7f3c7c193851873f13c8e86a586bbb81) seems like it may have improved the tests so far.

The history of the job flaking: https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-staging-containerd-windows

The job was renamed for consistency and the last couple test runs (with windows updates actually turned off) seems to be passing for the few runs we have so far: https://testgrid.k8s.io/sig-windows-master-release#capz-windows-containerd-master

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
