### PR TITLE
Fix extra string in log statement in e2e test suite

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Workload cluster creation", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 		}
 		if err != nil {
-			Logf("Creating cluster identity secret", secret.Name)
+			Logf("Creating cluster identity secret \"%s\"", secret.Name)
 			err = bootstrapClusterProxy.GetClient().Create(ctx, secret)
 			Expect(err).NotTo(HaveOccurred())
 		} else {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: fix logs in test:
```
Dec 16 19:00:28.123: INFO: Creating cluster identity secret
%!(EXTRA string=cluster-identity-secret)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
