### PR TITLE
Fetch latest Nvidia GPU operator chart with a script

### DIFF
--- a/hack/fetch-nvidia-resources.sh
+++ b/hack/fetch-nvidia-resources.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o verbose
+
+root=$(dirname "${BASH_SOURCE[0]}")/..
+gpudir=${root}/templates/flavors/nvidia-gpu
+workdir=${gpudir}/tmp
+namespace=gpu-operator-resources
+# See https://github.com/NVIDIA/gpu-operator/releases for available versions of the gpu-operator chart.
+gpu_operator_version=${1:-1.9.0}  
+
+helm repo add nvidia https://nvidia.github.io/gpu-operator \
+    && helm repo update
+helm template gpu-operator nvidia/gpu-operator \
+    --create-namespace \
+    --include-crds \
+    --namespace ${namespace} \
+    --output-dir "${workdir}" \
+    --version "${gpu_operator_version}"
+cat "${workdir}"/gpu-operator/crds/*.yaml > "${gpudir}"/clusterpolicy-crd.yaml
+cat <<EOF > "${gpudir}"/gpu-operator-components.tmp
+---
+# Source: gpu-operator/templates/resources-namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+  labels:
+    app.kubernetes.io/component: "gpu-operator"
+    openshift.io/cluster-monitoring: "true"
+EOF
+for f in "${workdir}"/gpu-operator/charts/node-feature-discovery/templates/*.yaml "${workdir}"/gpu-operator/templates/*.yaml; do
+    # Ensure that each resource has an explicit namespace.
+    if grep -q '^ *namespace: .*' "${f}"; then
+        cat "${f}" >> "${gpudir}"/gpu-operator-components.tmp
+    else
+        sed -r "s/^( *)name: .*/&\n\1namespace: ${namespace}/" "${f}" >> "${gpudir}"/gpu-operator-components.tmp
+    fi
+done
+mv "${gpudir}"/gpu-operator-components.tmp "${gpudir}"/gpu-operator-components.yaml
+rm -rf "${workdir}"
+
+make -C "${root}" generate-flavors

--- a/templates/cluster-template-nvidia-gpu.yaml
+++ b/templates/cluster-template-nvidia-gpu.yaml
@@ -246,9 +246,9 @@ spec:
 ---
 apiVersion: v1
 data:
-  clusterpolicy-crd.yaml: |
+  clusterpolicy-crd.yaml: |+
     ---
-    # Source: crds/nvidia.com_clusterpolicies_crd.yaml
+    # Source: gpu-operator/crds/nvidia.com_clusterpolicies_crd.yaml
     ---
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
@@ -266,663 +266,97 @@ data:
         singular: clusterpolicy
       scope: Cluster
       versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              description: ClusterPolicy is the Schema for the clusterpolicies API
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterPolicy is the Schema for the clusterpolicies API
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
                   of an object. Servers should convert recognized schemas to the latest
                   internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
                   object represents. Servers may infer this from the endpoint the client
                   submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: ClusterPolicySpec defines the desired state of ClusterPolicy
-                  properties:
-                    dcgmExporter:
-                      description: DCGMExporter spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterPolicySpec defines the desired state of ClusterPolicy
+                properties:
+                  daemonsets:
+                    description: Daemonset defines common configuration for all Daemonsets
+                    properties:
+                      priorityClassName:
+                        type: string
+                      tolerations:
+                        description: 'Optional: Set tolerations'
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
                           properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified, allowed
+                                values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies
+                                to. Empty means match all taint keys. If the key is empty,
+                                operator must be Exists; this combination means to match
+                                all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to
+                                the value. Valid operators are Exists and Equal. Defaults
+                                to Equal. Exists is equivalent to wildcard for value,
+                                so that a pod can tolerate all taints of a particular
+                                category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of
+                                time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the taint
+                                forever (do not evict). Zero and negative values will
+                                be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches
+                                to. If the operator is Exists, the value should be empty,
+                                otherwise just a regular string.
+                              type: string
                           type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
-                            type: string
-                          type: array
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                        type: array
+                    type: object
+                  dcgm:
+                    description: DCGM component spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        description: Enabled indicates if deployment of DCGM hostengine
+                          as a separate pod is enabled.
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -930,1134 +364,321 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        licensingConfig:
-                          description: 'Optional: Licensing configuration for vGPU drivers'
-                          properties:
-                            configMapName:
-                              type: string
-                          type: object
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
                               type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
+                          required:
+                          - name
                           type: object
-                        repoConfig:
-                          description: 'Optional: Custom repo configuration for driver container'
-                          properties:
-                            configMapName:
-                              type: string
-                            destinationDir:
-                              type: string
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
+                        type: array
+                      hostPort:
+                        description: 'HostPort represents host port that needs to be bound
+                          for DCGM engine (Default: 5555)'
+                        format: int32
+                        type: integer
+                      image:
+                        description: DCGM image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
                           type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                        type: array
+                      repository:
+                        description: DCGM image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
+                        type: object
+                      version:
+                        description: DCGM image tag
+                        type: string
+                    type: object
+                  dcgmExporter:
+                    description: DCGMExporter spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
                           type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                    devicePlugin:
-                      description: DevicePlugin component spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
-                          properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
+                        type: array
+                      config:
+                        description: 'Optional: Custom metrics configuration for DCGM
+                          exporter'
+                        properties:
+                          name:
+                            description: ConfigMap name with file dcgm-metrics.csv for
+                              metrics to be collected by DCGM exporter
                             type: string
-                          type: array
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                        type: object
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -2065,1134 +686,307 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        licensingConfig:
-                          description: 'Optional: Licensing configuration for vGPU drivers'
-                          properties:
-                            configMapName:
-                              type: string
-                          type: object
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
                               type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
+                          required:
+                          - name
                           type: object
-                        repoConfig:
-                          description: 'Optional: Custom repo configuration for driver container'
-                          properties:
-                            configMapName:
-                              type: string
-                            destinationDir:
-                              type: string
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
+                        type: array
+                      image:
+                        description: DCGM image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
                           type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                        type: array
+                      repository:
+                        description: DCGM image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
+                        type: object
+                      version:
+                        description: DCGM image tag
+                        type: string
+                    type: object
+                  devicePlugin:
+                    description: DevicePlugin component spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
                           type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                    driver:
-                      description: Driver component spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
+                        type: array
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
                           properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
-                            type: string
-                          type: array
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -3200,1138 +994,318 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        licensingConfig:
-                          description: 'Optional: Licensing configuration for vGPU drivers'
-                          properties:
-                            configMapName:
-                              type: string
-                          type: object
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
                               type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
+                          required:
+                          - name
                           type: object
-                        repoConfig:
-                          description: 'Optional: Custom repo configuration for driver container'
-                          properties:
-                            configMapName:
-                              type: string
-                            destinationDir:
-                              type: string
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
+                        type: array
+                      image:
+                        description: DevicePlugin image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
                           type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                        type: array
+                      repository:
+                        description: DevicePlugin image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
+                        type: object
+                      version:
+                        description: DevicePlugin image tag
+                        type: string
+                    type: object
+                  driver:
+                    description: Driver component spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
                           type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                    gfd:
-                      description: GPUFeatureDiscovery spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
-                          properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
+                        type: array
+                      certConfig:
+                        description: 'Optional: Custom certificates configuration for
+                          driver container'
+                        properties:
+                          name:
                             type: string
-                          type: array
-                        discoveryIntervalSeconds:
-                          description: 'Optional: Discovery Interval for GPU feature discovery
-                          plugin'
-                          type: integer
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                        type: object
+                      enabled:
+                        description: Enabled indicates if deployment of driver through
+                          operator is enabled
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -4339,1163 +1313,486 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Driver image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      licensingConfig:
+                        description: 'Optional: Licensing configuration for vGPU drivers'
+                        properties:
+                          configMapName:
+                            type: string
+                          nlsEnabled:
+                            description: NLSEnabled indicates if NLS is used for licensing.
+                            type: boolean
+                        type: object
+                      manager:
+                        description: Manager represents configuration for driver manager
+                          initContainer
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
                                       - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        migStrategy:
-                          description: 'Optional: MigStrategy for GPU feature discovery
-                          plugin'
-                          enum:
-                            - none
-                            - single
-                            - mixed
-                          type: string
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
                               required:
-                                - type
+                              - name
                               type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
-                          type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                            type: array
+                          image:
+                            description: Image represents Driver-Manager image name
+                            pattern: '[a-zA-Z0-9\-]+'
+                            type: string
+                          imagePullPolicy:
+                            description: Image pull policy
+                            type: string
+                          imagePullSecrets:
+                            description: Image pull secrets
+                            items:
+                              type: string
+                            type: array
+                          repository:
+                            description: Repository represents Driver-Manager repository
+                              path
+                            type: string
+                          version:
+                            description: Version represents Driver-Manager image tag(version)
+                            type: string
+                        type: object
+                      rdma:
+                        description: GPUDirectRDMASpec defines the properties for nv_peer_mem
+                          deployment
+                        properties:
+                          enabled:
+                            description: Enabled indicates if GPUDirect RDMA is enabled
+                              through GPU operator
+                            type: boolean
+                          useHostMofed:
+                            description: UseHostMOFED indicates to use MOFED drivers directly
+                              installed on the host to enable GPUDirect RDMA
+                            type: boolean
+                        type: object
+                      repoConfig:
+                        description: 'Optional: Custom repo configuration for driver container'
+                        properties:
+                          configMapName:
+                            type: string
+                        type: object
+                      repository:
+                        description: Driver image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
-                          type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                    operator:
-                      description: Operator component spec
-                      properties:
-                        defaultRuntime:
-                          description: Runtime defines container runtime type
-                          enum:
-                            - docker
-                            - crio
-                            - containerd
-                          type: string
-                        validator:
-                          description: ValidatorSpec describes configuration options for
-                            validation pod
-                          properties:
-                            image:
-                              pattern: '[a-zA-Z0-9\-]+'
-                              type: string
-                            imagePullPolicy:
-                              description: Image pull policy
-                              type: string
-                            imagePullSecrets:
-                              description: Image pull secrets
-                              items:
-                                type: string
-                              type: array
-                            repository:
-                              pattern: '[a-zA-Z0-9\.\-\/]+'
-                              type: string
-                            version:
-                              pattern: '[a-zA-Z0-9\.-]+'
-                              type: string
-                          type: object
-                      required:
-                        - defaultRuntime
-                      type: object
-                    toolkit:
-                      description: Toolkit component spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
-                          properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
+                        type: object
+                      use_ocp_driver_toolkit:
+                        description: UseOpenShiftDriverToolkit indicates if DriverToolkit
+                          image should be used on OpenShift to build and install driver
+                          modules
+                        type: boolean
+                      version:
+                        description: Driver image tag
+                        type: string
+                      virtualTopology:
+                        description: 'Optional: Virtual Topology Daemon configuration
+                          for vGPU drivers'
+                        properties:
+                          config:
+                            description: 'Optional: Config name representing virtual topology
+                              daemon configuration file nvidia-topologyd.conf'
                             type: string
-                          type: array
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                        type: object
+                    type: object
+                  gfd:
+                    description: GPUFeatureDiscovery spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -5503,528 +1800,2110 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        licensingConfig:
-                          description: 'Optional: Licensing configuration for vGPU drivers'
-                          properties:
-                            configMapName:
-                              type: string
-                          type: object
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
                               type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
+                          required:
+                          - name
                           type: object
-                        repoConfig:
-                          description: 'Optional: Custom repo configuration for driver container'
-                          properties:
-                            configMapName:
-                              type: string
-                            destinationDir:
-                              type: string
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
+                        type: array
+                      image:
+                        description: GFD image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
                           type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                        type: array
+                      repository:
+                        description: GFD image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
+                        type: object
+                      version:
+                        description: GFD image tag
+                        type: string
+                    type: object
+                  mig:
+                    description: MIG spec
+                    properties:
+                      strategy:
+                        description: 'Optional: MIGStrategy to apply for GFD and Device-Plugin'
+                        enum:
+                        - none
+                        - single
+                        - mixed
+                        type: string
+                    type: object
+                  migManager:
+                    description: MIGManager for configuration to deploy MIG Manager
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
                           type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                  required:
-                    - dcgmExporter
-                    - devicePlugin
-                    - driver
-                    - gfd
-                    - operator
-                    - toolkit
-                  type: object
-                status:
-                  description: ClusterPolicyStatus defines the observed state of ClusterPolicy
-                  properties:
-                    state:
-                      enum:
-                        - ignored
-                        - ready
-                        - notReady
-                      type: string
-                  required:
-                    - state
-                  type: object
-              type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                        type: array
+                      config:
+                        description: 'Optional: Custom mig-parted configuration for MIG
+                          Manager container'
+                        properties:
+                          name:
+                            description: ConfigMap name
+                            type: string
+                        type: object
+                      enabled:
+                        description: Enabled indicates if deployment of mig-manager is
+                          enabled
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in the
+                                container and any service environment variables. If a
+                                variable cannot be resolved, the reference in the input
+                                string will be unchanged. The $(VAR_NAME) syntax can be
+                                escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                will never be expanded, regardless of whether the variable
+                                exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
+                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
+                                    resources limits and requests (limits.cpu, limits.memory,
+                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                    and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      gpuClientsConfig:
+                        description: 'Optional: Custom gpu-clients configuration for MIG
+                          Manager container'
+                        properties:
+                          name:
+                            description: ConfigMap name
+                            type: string
+                        type: object
+                      image:
+                        description: mig-manager image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: mig-manager image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
+                          each pod'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
+                              process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag will
+                              be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                  will be applied. Valid options are: \n Localhost - a
+                                  profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile
+                                  should be used. Unconfined - no profile should be applied."
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      version:
+                        description: mig-manager image tag
+                        type: string
+                    type: object
+                  nodeStatusExporter:
+                    description: NodeStatusExporter spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        description: Enabled indicates if deployment of node-status-exporter
+                          is enabled.
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in the
+                                container and any service environment variables. If a
+                                variable cannot be resolved, the reference in the input
+                                string will be unchanged. The $(VAR_NAME) syntax can be
+                                escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                will never be expanded, regardless of whether the variable
+                                exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
+                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
+                                    resources limits and requests (limits.cpu, limits.memory,
+                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                    and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: node-status-exporter image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: node-status-exporter image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
+                          each pod'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
+                              process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag will
+                              be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                  will be applied. Valid options are: \n Localhost - a
+                                  profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile
+                                  should be used. Unconfined - no profile should be applied."
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      version:
+                        description: node-status-exporter image tag
+                        type: string
+                    type: object
+                  operator:
+                    description: Operator component spec
+                    properties:
+                      defaultRuntime:
+                        default: docker
+                        description: Runtime defines container runtime type
+                        enum:
+                        - docker
+                        - crio
+                        - containerd
+                        type: string
+                      initContainer:
+                        description: InitContainerSpec describes configuration for initContainer
+                          image used with all components
+                        properties:
+                          image:
+                            description: Image represents image name
+                            pattern: '[a-zA-Z0-9\-]+'
+                            type: string
+                          imagePullPolicy:
+                            description: Image pull policy
+                            type: string
+                          imagePullSecrets:
+                            description: Image pull secrets
+                            items:
+                              type: string
+                            type: array
+                          repository:
+                            description: Repository represents image repository path
+                            type: string
+                          version:
+                            description: Version represents image tag(version)
+                            type: string
+                        type: object
+                      runtimeClass:
+                        default: nvidia
+                        type: string
+                    required:
+                    - defaultRuntime
+                    type: object
+                  psp:
+                    description: PSP defines spec for handling PodSecurityPolicies
+                    properties:
+                      enabled:
+                        description: Enabled indicates if PodSecurityPolicies needs to
+                          be enabled for all Pods
+                        type: boolean
+                    type: object
+                  toolkit:
+                    description: Toolkit component spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        description: Enabled indicates if deployment of container-toolkit
+                          through operator is enabled
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in the
+                                container and any service environment variables. If a
+                                variable cannot be resolved, the reference in the input
+                                string will be unchanged. The $(VAR_NAME) syntax can be
+                                escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                will never be expanded, regardless of whether the variable
+                                exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
+                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
+                                    resources limits and requests (limits.cpu, limits.memory,
+                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                    and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Toolkit image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: Toolkit image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
+                          each pod'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
+                              process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag will
+                              be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                  will be applied. Valid options are: \n Localhost - a
+                                  profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile
+                                  should be used. Unconfined - no profile should be applied."
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      version:
+                        description: Toolkit image tag
+                        type: string
+                    type: object
+                  validator:
+                    description: Validator defines the spec for operator-validator daemonset
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      cuda:
+                        description: CUDA validator spec
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      driver:
+                        description: Toolkit validator spec
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in the
+                                container and any service environment variables. If a
+                                variable cannot be resolved, the reference in the input
+                                string will be unchanged. The $(VAR_NAME) syntax can be
+                                escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                will never be expanded, regardless of whether the variable
+                                exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
+                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
+                                    resources limits and requests (limits.cpu, limits.memory,
+                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                    and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Validator image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      plugin:
+                        description: Plugin validator spec
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      repository:
+                        description: Validator image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
+                          each pod'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
+                              process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag will
+                              be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                  will be applied. Valid options are: \n Localhost - a
+                                  profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile
+                                  should be used. Unconfined - no profile should be applied."
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      toolkit:
+                        description: Toolkit validator spec
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      version:
+                        description: Validator image tag
+                        type: string
+                    type: object
+                required:
+                - daemonsets
+                - dcgm
+                - dcgmExporter
+                - devicePlugin
+                - driver
+                - gfd
+                - nodeStatusExporter
+                - operator
+                - toolkit
+                type: object
+              status:
+                description: ClusterPolicyStatus defines the observed state of ClusterPolicy
+                properties:
+                  state:
+                    description: State indicates status of ClusterPolicy
+                    enum:
+                    - ignored
+                    - ready
+                    - notReady
+                    type: string
+                required:
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
     status:
       acceptedNames:
         kind: ""
         plural: ""
       conditions: []
       storedVersions: []
+
 kind: ConfigMap
 metadata:
   annotations:
@@ -6036,545 +3915,239 @@ metadata:
 ---
 apiVersion: v1
 data:
-  gpu-operator-components.yaml: |
-    ---
-    # Source: gpu-operator/templates/resources-namespace.yaml
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: gpu-operator-resources
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-        openshift.io/cluster-monitoring: "true"
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: gpu-operator-node-feature-discovery
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-    ---
-    # Source: gpu-operator/templates/serviceaccount.yaml
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: gpu-operator
-      namespace: default
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/configmap.yaml
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: gpu-operator-node-feature-discovery
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-    data:
-      nfd-worker.conf: |
-        sources:
-          pci:
-            deviceLabelFields:
-            - vendor
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/rbac.yaml
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: gpu-operator-node-feature-discovery-master
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        # when using command line flag --resource-labels to create extended resources
-        # you will need to uncomment "- nodes/status"
-        # - nodes/status
-        verbs:
-          - get
-          - patch
-          - update
-    ---
-    # Source: gpu-operator/templates/role.yaml
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      creationTimestamp: null
-      name: gpu-operator
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-    rules:
-      - apiGroups:
-          - config.openshift.io
-        resources:
-          - proxies
-        verbs:
-          - get
-      - apiGroups:
-          - rbac.authorization.k8s.io
-        resources:
-          - roles
-          - rolebindings
-          - clusterroles
-          - clusterrolebindings
-        verbs:
-          - '*'
-      - apiGroups:
-          - ""
-        resources:
-          - pods
-          - services
-          - endpoints
-          - persistentvolumeclaims
-          - events
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - nodes
-        verbs:
-          - '*'
-      - apiGroups:
-          - ""
-        resources:
-          - namespaces
-        verbs:
-          - get
-      - apiGroups:
-          - apps
-        resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-        verbs:
-          - '*'
-      - apiGroups:
-          - monitoring.coreos.com
-        resources:
-          - servicemonitors
-        verbs:
-          - get
-          - list
-          - create
-          - watch
-      - apiGroups:
-          - nvidia.com
-        resources:
-          - '*'
-        verbs:
-          - '*'
-      - apiGroups:
-          - scheduling.k8s.io
-        resources:
-          - priorityclasses
-        verbs:
-          - get
-          - list
-          - watch
-          - create
-      - apiGroups:
-          - security.openshift.io
-        resources:
-          - securitycontextconstraints
-        verbs:
-          - '*'
-      - apiGroups:
-          - config.openshift.io
-        resources:
-          - clusterversions
-        verbs:
-          - get
-          - list
-          - watch
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/rbac.yaml
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: gpu-operator-node-feature-discovery-master
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: gpu-operator-node-feature-discovery-master
-    subjects:
-      - kind: ServiceAccount
-        name: gpu-operator-node-feature-discovery
-        namespace: default
-    ---
-    # Source: gpu-operator/templates/rolebinding.yaml
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: gpu-operator
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-    subjects:
-      - kind: ServiceAccount
-        name: gpu-operator
-        namespace: default
-    roleRef:
-      kind: ClusterRole
-      name: gpu-operator
-      apiGroup: rbac.authorization.k8s.io
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml
-    apiVersion: v1
-    kind: Service
-    metadata:
-      name: gpu-operator-node-feature-discovery
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      type: ClusterIP
-      ports:
-        - name: api
-          port: 8080
-          protocol: TCP
-          targetPort: api
-
-      selector:
-        app.kubernetes.io/component: master
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/daemonset-worker.yaml
-    apiVersion: apps/v1
-    kind: DaemonSet
-    metadata:
-      name: gpu-operator-node-feature-discovery-worker
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: worker
-    spec:
-      selector:
-        matchLabels:
-          app.kubernetes.io/name: node-feature-discovery
-          app.kubernetes.io/instance: gpu-operator
-          app.kubernetes.io/component: worker
-      template:
-        metadata:
-          labels:
-            app.kubernetes.io/name: node-feature-discovery
-            app.kubernetes.io/instance: gpu-operator
-            app.kubernetes.io/component: worker
-        spec:
-          serviceAccountName: gpu-operator-node-feature-discovery
-          securityContext:
-            {}
-          dnsPolicy: ClusterFirstWithHostNet
-          containers:
-            - name: node-feature-discovery-master
-              securityContext:
-                {}
-              image: "quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0"
-              imagePullPolicy: IfNotPresent
-              env:
-                - name: NODE_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-              command:
-                - "nfd-worker"
-              args:
-                - "--sleep-interval=60s"
-                - "--server=gpu-operator-node-feature-discovery:8080"
-              volumeMounts:
-                - name: host-boot
-                  mountPath: "/host-boot"
-                  readOnly: true
-                - name: host-os-release
-                  mountPath: "/host-etc/os-release"
-                  readOnly: true
-                - name: host-sys
-                  mountPath: "/host-sys"
-                - name: source-d
-                  mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
-                - name: features-d
-                  mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
-                - name: nfd-worker-config
-                  mountPath: "/etc/kubernetes/node-feature-discovery/"
-              resources:
-                {}
-
-          volumes:
-            - name: host-boot
-              hostPath:
-                path: "/boot"
-            - name: host-os-release
-              hostPath:
-                path: "/etc/os-release"
-            - name: host-sys
-              hostPath:
-                path: "/sys"
-            - name: source-d
-              hostPath:
-                path: "/etc/kubernetes/node-feature-discovery/source.d/"
-            - name: features-d
-              hostPath:
-                path: "/etc/kubernetes/node-feature-discovery/features.d/"
-            - name: nfd-worker-config
-              configMap:
-                name: gpu-operator-node-feature-discovery
-          tolerations:
-            - effect: NoSchedule
-              key: node-role.kubernetes.io/master
-              operator: Equal
-              value: ""
-            - effect: NoSchedule
-              key: nvidia.com/gpu
-              operator: Equal
-              value: present
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/deployment-master.yaml
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: gpu-operator-node-feature-discovery-master
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: master
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-          app.kubernetes.io/name: node-feature-discovery
-          app.kubernetes.io/instance: gpu-operator
-          app.kubernetes.io/component: master
-      template:
-        metadata:
-          labels:
-            app.kubernetes.io/name: node-feature-discovery
-            app.kubernetes.io/instance: gpu-operator
-            app.kubernetes.io/component: master
-        spec:
-          serviceAccountName: gpu-operator-node-feature-discovery
-          securityContext:
-            {}
-          containers:
-            - name: node-feature-discovery-master
-              securityContext:
-                {}
-              image: "k8s.gcr.io/nfd/node-feature-discovery:v0.9.0"
-              imagePullPolicy: IfNotPresent
-              ports:
-                - name: api
-                  containerPort: 8080
-                  protocol: TCP
-              env:
-                - name: NODE_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-              command:
-                - "nfd-master"
-              args:
-                - --extra-label-ns=nvidia.com
-              resources:
-                {}
-          affinity:
-            nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - preference:
-                    matchExpressions:
-                      - key: node-role.kubernetes.io/master
-                        operator: In
-                        values:
-                          - ""
-                  weight: 1
-          tolerations:
-            - effect: NoSchedule
-              key: node-role.kubernetes.io/master
-              operator: Equal
-              value: ""
-    ---
-    # Source: gpu-operator/templates/operator.yaml
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: gpu-operator
-      namespace: default
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-
-          app.kubernetes.io/component: "gpu-operator"
-      template:
-        metadata:
-          labels:
-
-            app.kubernetes.io/component: "gpu-operator"
-          annotations:
-            openshift.io/scc: restricted-readonly
-        spec:
-          serviceAccountName: gpu-operator
-          containers:
-            - name: gpu-operator
-              image: nvcr.io/nvidia/gpu-operator:1.6.2
-              imagePullPolicy: IfNotPresent
-              command: ["gpu-operator"]
-              args:
-                - "--zap-time-encoding=epoch"
-              env:
-                - name: WATCH_NAMESPACE
-                  value: ""
-                - name: OPERATOR_NAME
-                  value: "gpu-operator"
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-              volumeMounts:
-                - name: host-os-release
-                  mountPath: "/host-etc/os-release"
-                  readOnly: true
-              readinessProbe:
-                exec:
-                  command: ["stat", "/tmp/operator-sdk-ready"]
-                initialDelaySeconds: 4
-                periodSeconds: 10
-                failureThreshold: 1
-              ports:
-                - containerPort: 60000
-                  name: metrics
-          volumes:
-            - name: host-os-release
-              hostPath:
-                path: "/etc/os-release"
-          affinity:
-            nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - preference:
-                    matchExpressions:
-                      - key: node-role.kubernetes.io/master
-                        operator: In
-                        values:
-                          - ""
-                  weight: 1
-          tolerations:
-            - effect: NoSchedule
-              key: node-role.kubernetes.io/master
-              operator: Equal
-              value: ""
-    ---
-    # Source: gpu-operator/templates/clusterpolicy.yaml
-    apiVersion: nvidia.com/v1
-    kind: ClusterPolicy
-    metadata:
-      name: cluster-policy
-      namespace: default
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-    spec:
-      operator:
-        defaultRuntime: containerd
-        validator:
-          repository: nvcr.io/nvidia/k8s
-          image: cuda-sample
-          version: vectoradd-cuda10.2
-          imagePullPolicy: IfNotPresent
-      driver:
-        repository: nvcr.io/nvidia
-        image: driver
-        version: 470.82.01
-        imagePullPolicy: IfNotPresent
-        repoConfig:
-          configMapName: ""
-          destinationDir: ""
-        licensingConfig:
-          configMapName: ""
-        tolerations:
-          - effect: NoSchedule
-            key: nvidia.com/gpu
-            operator: Exists
-        nodeSelector:
-          nvidia.com/gpu.present: "true"
-        securityContext:
-          privileged: true
-          seLinuxOptions:
-            level: s0
-      toolkit:
-        repository: nvcr.io/nvidia/k8s
-        image: container-toolkit
-        version: 1.7.2
-        imagePullPolicy: IfNotPresent
-        tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
-          - effect: NoSchedule
-            key: nvidia.com/gpu
-            operator: Exists
-        nodeSelector:
-          nvidia.com/gpu.present: "true"
-        securityContext:
-          privileged: true
-          seLinuxOptions:
-            level: s0
-      devicePlugin:
-        repository: nvcr.io/nvidia
-        image: k8s-device-plugin
-        version: v0.8.2-ubi8
-        imagePullPolicy: IfNotPresent
-        nodeSelector:
-          nvidia.com/gpu.present: "true"
-        securityContext:
-          privileged: true
-        args:
-          - --mig-strategy=single
-          - --pass-device-specs=true
-          - --fail-on-init-error=true
-          - --device-list-strategy=envvar
-          - --nvidia-driver-root=/run/nvidia/driver
-      dcgmExporter:
-        repository: nvcr.io/nvidia/k8s
-        image: dcgm-exporter
-        version: 2.1.4-2.2.0-ubuntu20.04
-        imagePullPolicy: IfNotPresent
-        args:
-          - -f
-          - /etc/dcgm-exporter/dcp-metrics-included.csv
-      gfd:
-        repository: nvcr.io/nvidia
-        image: gpu-feature-discovery
-        version: v0.4.1
-        imagePullPolicy: IfNotPresent
-        nodeSelector:
-          nvidia.com/gpu.present: "true"
-        migStrategy: single
-        discoveryIntervalSeconds: 60
+  gpu-operator-components.yaml: "---\n# Source: gpu-operator/templates/resources-namespace.yaml\napiVersion:
+    v1\nkind: Namespace\nmetadata:\n  name: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
+    \"gpu-operator\"\n    openshift.io/cluster-monitoring: \"true\"\n---\n# Source:
+    gpu-operator/charts/node-feature-discovery/templates/clusterrole.yaml\napiVersion:
+    rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: gpu-operator-node-feature-discovery\n
+    \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\nrules:\n- apiGroups:\n  - \"\"\n  resources:\n  - nodes\n  # when using
+    command line flag --resource-labels to create extended resources\n  # you will
+    need to uncomment \"- nodes/status\"\n  # - nodes/status\n  verbs:\n  - get\n
+    \ - patch\n  - update\n  - list\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml\napiVersion:
+    rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: gpu-operator-node-feature-discovery\n
+    \ labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n    app.kubernetes.io/name:
+    node-feature-discovery\n    app.kubernetes.io/instance: gpu-operator\n    app.kubernetes.io/version:
+    \"v0.8.2\"\n    app.kubernetes.io/managed-by: Helm\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
+    \ kind: ClusterRole\n  name: gpu-operator-node-feature-discovery\nsubjects:\n-
+    kind: ServiceAccount\n  name: node-feature-discovery\n  namespace: gpu-operator-resources\n---\n#
+    Source: gpu-operator/charts/node-feature-discovery/templates/master.yaml\napiVersion:
+    apps/v1\nkind: Deployment\nmetadata:\n  name:  gpu-operator-node-feature-discovery-master\n
+    \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\n    role: master\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n
+    \     app.kubernetes.io/name: node-feature-discovery\n      app.kubernetes.io/instance:
+    gpu-operator\n      role: master\n  template:\n    metadata:\n      labels:\n
+    \       app.kubernetes.io/name: node-feature-discovery\n        app.kubernetes.io/instance:
+    gpu-operator\n        role: master\n      annotations:\n        {}\n    spec:\n
+    \     serviceAccountName: node-feature-discovery\n      securityContext:\n        {}\n
+    \     containers:\n        - name: master\n          securityContext:\n            allowPrivilegeEscalation:
+    false\n            capabilities:\n              drop:\n              - ALL\n            readOnlyRootFilesystem:
+    true\n            runAsNonRoot: true\n          image: \"k8s.gcr.io/nfd/node-feature-discovery:v0.8.2\"\n
+    \         imagePullPolicy: IfNotPresent\n          ports:\n          - containerPort:
+    8080\n            name: grpc\n            namespace: gpu-operator-resources\n
+    \         env:\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n
+    \               fieldPath: spec.nodeName\n          command:\n            - \"nfd-master\"\n
+    \         resources:\n            {}\n          args:\n            - \"--extra-label-ns=nvidia.com\"\n##
+    Enable TLS authentication\n## The example below assumes having the root certificate
+    named ca.crt stored in\n## a ConfigMap named nfd-ca-cert, and, the TLS authentication
+    credentials stored\n## in a TLS Secret named nfd-master-cert.\n## Additional hardening
+    can be enabled by specifying --verify-node-name in\n## args, in which case node
+    name will be checked against the worker's\n## TLS certificate.\n#            -
+    \"--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt\"\n#            -
+    \"--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key\"\n#            -
+    \"--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt\"\n#          volumeMounts:\n#
+    \           - name: nfd-ca-cert\n#              mountPath: \"/etc/kubernetes/node-feature-discovery/trust\"\n#
+    \             readOnly: true\n#            - name: nfd-master-cert\n#              mountPath:
+    \"/etc/kubernetes/node-feature-discovery/certs\"\n#              readOnly: true\n#
+    \     volumes:\n#        - name: nfd-ca-cert\n#          configMap:\n#            name:
+    nfd-ca-cert\n#        - name: nfd-master-cert\n#          secret:\n#            secretName:
+    nfd-master-cert\n      affinity:\n        nodeAffinity:\n          preferredDuringSchedulingIgnoredDuringExecution:\n
+    \         - preference:\n              matchExpressions:\n              - key:
+    node-role.kubernetes.io/master\n                operator: In\n                values:\n
+    \               - \"\"\n            weight: 1\n      tolerations:\n        - effect:
+    NoSchedule\n          key: node-role.kubernetes.io/master\n          operator:
+    Equal\n          value: \"\"\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml\napiVersion:
+    v1\nkind: ConfigMap\nmetadata:\n  name: nfd-worker-conf\n  namespace: gpu-operator-resources\n
+    \ labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n    app.kubernetes.io/name:
+    node-feature-discovery\n    app.kubernetes.io/instance: gpu-operator\n    app.kubernetes.io/version:
+    \"v0.8.2\"\n    app.kubernetes.io/managed-by: Helm\ndata:\n  nfd-worker.conf:
+    |-\n    sources:\n      pci:\n        deviceLabelFields:\n        - vendor\n---\n#
+    Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml\napiVersion:
+    v1\nkind: Service\nmetadata:\n  name: gpu-operator-node-feature-discovery-master\n
+    \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\n    role: master\nspec:\n  type: ClusterIP\n  ports:\n    - port: 8080\n
+    \     targetPort: grpc\n      protocol: TCP\n      name: grpc\n      namespace:
+    gpu-operator-resources\n  selector:\n    app.kubernetes.io/name: node-feature-discovery\n
+    \   app.kubernetes.io/instance: gpu-operator\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/serviceaccount.yaml\napiVersion:
+    v1\nkind: ServiceAccount\nmetadata:\n  name: node-feature-discovery\n  namespace:
+    gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/worker.yaml\napiVersion:
+    apps/v1\nkind: DaemonSet\nmetadata:\n  name:  gpu-operator-node-feature-discovery-worker\n
+    \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\n    role: worker\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name:
+    node-feature-discovery\n      app.kubernetes.io/instance: gpu-operator\n      role:
+    worker\n  template:\n    metadata:\n      labels:\n        app.kubernetes.io/name:
+    node-feature-discovery\n        app.kubernetes.io/instance: gpu-operator\n        role:
+    worker\n      annotations:\n        {}\n    spec:\n      dnsPolicy: ClusterFirstWithHostNet\n
+    \     securityContext:\n        {}\n      containers:\n      - name: worker\n
+    \       securityContext:\n            allowPrivilegeEscalation: false\n            capabilities:\n
+    \             drop:\n              - ALL\n            readOnlyRootFilesystem:
+    true\n            runAsNonRoot: true\n        image: \"k8s.gcr.io/nfd/node-feature-discovery:v0.8.2\"\n
+    \       imagePullPolicy: IfNotPresent\n        env:\n        - name: NODE_NAME\n
+    \         valueFrom:\n            fieldRef:\n              fieldPath: spec.nodeName\n
+    \       resources:\n            {}\n        command:\n        - \"nfd-worker\"\n
+    \       args:\n        - \"--sleep-interval=60s\"\n        - \"--server=gpu-operator-node-feature-discovery-master:8080\"\n##
+    Enable TLS authentication (1/3)\n## The example below assumes having the root
+    certificate named ca.crt stored in\n## a ConfigMap named nfd-ca-cert, and, the
+    TLS authentication credentials stored\n## in a TLS Secret named nfd-worker-cert\n#
+    \         - \"--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt\"\n#
+    \         - \"--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key\"\n#
+    \         - \"--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt\"\n
+    \       volumeMounts:\n        - name: host-boot\n          mountPath: \"/host-boot\"\n
+    \         readOnly: true\n        - name: host-os-release\n          mountPath:
+    \"/host-etc/os-release\"\n          readOnly: true\n        - name: host-sys\n
+    \         mountPath: \"/host-sys\"\n          readOnly: true\n        - name:
+    source-d\n          mountPath: \"/etc/kubernetes/node-feature-discovery/source.d/\"\n
+    \         readOnly: true\n        - name: features-d\n          mountPath: \"/etc/kubernetes/node-feature-discovery/features.d/\"\n
+    \         readOnly: true\n        - name: nfd-worker-conf\n          mountPath:
+    \"/etc/kubernetes/node-feature-discovery\"\n          readOnly: true\n## Enable
+    TLS authentication (2/3)\n#        - name: nfd-ca-cert\n#          mountPath:
+    \"/etc/kubernetes/node-feature-discovery/trust\"\n#          readOnly: true\n#
+    \       - name: nfd-worker-cert\n#          mountPath: \"/etc/kubernetes/node-feature-discovery/certs\"\n#
+    \         readOnly: true\n      volumes:\n        - name: host-boot\n          hostPath:\n
+    \           path: \"/boot\"\n        - name: host-os-release\n          hostPath:\n
+    \           path: \"/etc/os-release\"\n        - name: host-sys\n          hostPath:\n
+    \           path: \"/sys\"\n        - name: source-d\n          hostPath:\n            path:
+    \"/etc/kubernetes/node-feature-discovery/source.d/\"\n        - name: features-d\n
+    \         hostPath:\n            path: \"/etc/kubernetes/node-feature-discovery/features.d/\"\n
+    \       - name: nfd-worker-conf\n          configMap:\n            name: nfd-worker-conf\n
+    \           namespace: gpu-operator-resources\n            items:\n              -
+    key: nfd-worker.conf\n                path: nfd-worker.conf\n## Enable TLS authentication
+    (3/3)\n#        - name: nfd-ca-cert\n#          configMap:\n#            name:
+    nfd-ca-cert\n#        - name: nfd-worker-cert\n#          secret:\n#            secretName:
+    nfd-worker-cert\n      tolerations:\n        - effect: NoSchedule\n          key:
+    node-role.kubernetes.io/master\n          operator: Equal\n          value: \"\"\n
+    \       - effect: NoSchedule\n          key: nvidia.com/gpu\n          operator:
+    Equal\n          value: present\n---\n# Source: gpu-operator/templates/clusterpolicy.yaml\napiVersion:
+    nvidia.com/v1\nkind: ClusterPolicy\nmetadata:\n  name: cluster-policy\n  namespace:
+    gpu-operator-resources\n  labels:\n    app.kubernetes.io/component: \"gpu-operator\"\n
+    \   \nspec:\n  operator:\n    defaultRuntime: docker\n    runtimeClass: nvidia\n
+    \   initContainer:\n      repository: nvcr.io/nvidia\n      image: cuda\n      version:
+    11.4.2-base-ubi8\n      imagePullPolicy: IfNotPresent\n  daemonsets:\n    tolerations:
+    \n      - effect: NoSchedule\n        key: nvidia.com/gpu\n        operator: Exists\n
+    \   priorityClassName: system-node-critical\n  validator:\n    repository: nvcr.io/nvidia/cloud-native\n
+    \   image: gpu-operator-validator\n    version: v1.9.0\n    imagePullPolicy: IfNotPresent\n
+    \   securityContext: \n      privileged: true\n      seLinuxOptions:\n        level:
+    s0\n    plugin:\n      env: \n        - name: WITH_WORKLOAD\n          value:
+    \"true\"\n  mig:\n    strategy: single\n  psp:\n    enabled: false\n  driver:\n
+    \   enabled: true\n    repository: nvcr.io/nvidia\n    image: driver\n    version:
+    470.82.01\n    imagePullPolicy: IfNotPresent\n    rdma:\n      enabled: false\n
+    \     useHostMofed: false\n    manager:\n      repository: nvcr.io/nvidia/cloud-native\n
+    \     image: k8s-driver-manager\n      version: v0.2.0\n      imagePullPolicy:
+    IfNotPresent\n      env: \n        - name: ENABLE_AUTO_DRAIN\n          value:
+    \"true\"\n        - name: DRAIN_USE_FORCE\n          value: \"false\"\n        -
+    name: DRAIN_POD_SELECTOR_LABEL\n          value: \"\"\n        - name: DRAIN_TIMEOUT_SECONDS\n
+    \         value: 0s\n        - name: DRAIN_DELETE_EMPTYDIR_DATA\n          value:
+    \"false\"\n    repoConfig: \n      configMapName: \"\"\n    certConfig: \n      name:
+    \"\"\n    licensingConfig: \n      configMapName: \"\"\n      nlsEnabled: false\n
+    \   virtualTopology: \n      config: \"\"\n    securityContext: \n      privileged:
+    true\n      seLinuxOptions:\n        level: s0\n  toolkit:\n    enabled: true\n
+    \   repository: nvcr.io/nvidia/k8s\n    image: container-toolkit\n    version:
+    1.7.2-ubuntu18.04\n    imagePullPolicy: IfNotPresent\n    securityContext: \n
+    \     privileged: true\n      seLinuxOptions:\n        level: s0\n  devicePlugin:\n
+    \   repository: nvcr.io/nvidia\n    image: k8s-device-plugin\n    version: v0.10.0-ubi8\n
+    \   imagePullPolicy: IfNotPresent\n    securityContext: \n      privileged: true\n
+    \   env: \n      - name: PASS_DEVICE_SPECS\n        value: \"true\"\n      - name:
+    FAIL_ON_INIT_ERROR\n        value: \"true\"\n      - name: DEVICE_LIST_STRATEGY\n
+    \       value: envvar\n      - name: DEVICE_ID_STRATEGY\n        value: uuid\n
+    \     - name: NVIDIA_VISIBLE_DEVICES\n        value: all\n      - name: NVIDIA_DRIVER_CAPABILITIES\n
+    \       value: all\n  dcgm:\n    enabled: true\n    repository: nvcr.io/nvidia/cloud-native\n
+    \   image: dcgm\n    version: 2.3.1-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
+    \   hostPort: 5555\n  dcgmExporter:\n    repository: nvcr.io/nvidia/k8s\n    image:
+    dcgm-exporter\n    version: 2.3.1-2.6.0-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
+    \   env: \n      - name: DCGM_EXPORTER_LISTEN\n        value: :9400\n      - name:
+    DCGM_EXPORTER_KUBERNETES\n        value: \"true\"\n      - name: DCGM_EXPORTER_COLLECTORS\n
+    \       value: /etc/dcgm-exporter/dcp-metrics-included.csv\n  gfd:\n    repository:
+    nvcr.io/nvidia\n    image: gpu-feature-discovery\n    version: v0.4.1\n    imagePullPolicy:
+    IfNotPresent\n    env: \n      - name: GFD_SLEEP_INTERVAL\n        value: 60s\n
+    \     - name: GFD_FAIL_ON_INIT_ERROR\n        value: \"true\"\n  migManager:\n
+    \   enabled: true\n    repository: nvcr.io/nvidia/cloud-native\n    image: k8s-mig-manager\n
+    \   version: v0.2.0-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n    securityContext:
+    \n      privileged: true\n    env: \n      - name: WITH_REBOOT\n        value:
+    \"false\"\n    config: \n      name: \"\"\n    gpuClientsConfig: \n      name:
+    \"\"\n  nodeStatusExporter:\n    enabled: false\n    repository: nvcr.io/nvidia/cloud-native\n
+    \   image: gpu-operator-validator\n    version: v1.9.0\n    imagePullPolicy: IfNotPresent\n---\n#
+    Source: gpu-operator/templates/operator.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n
+    \ name: gpu-operator\n  namespace: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
+    \"gpu-operator\"\n    \nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n
+    \     \n      app.kubernetes.io/component: \"gpu-operator\"\n      app: \"gpu-operator\"\n
+    \ template:\n    metadata:\n      labels:\n        \n        app.kubernetes.io/component:
+    \"gpu-operator\"\n        app: \"gpu-operator\"\n      annotations:\n        openshift.io/scc:
+    restricted-readonly\n    spec:\n      serviceAccountName: gpu-operator\n      priorityClassName:
+    system-node-critical\n      containers:\n      - name: gpu-operator\n        image:
+    nvcr.io/nvidia/gpu-operator:v1.9.0\n        imagePullPolicy: IfNotPresent\n        command:
+    [\"gpu-operator\"]\n        args:\n        - --leader-elect\n        env:\n        -
+    name: WATCH_NAMESPACE\n          value: \"\"\n        - name: OPERATOR_NAMESPACE\n
+    \         valueFrom:\n            fieldRef:\n              fieldPath: metadata.namespace\n
+    \       volumeMounts:\n          - name: host-os-release\n            mountPath:
+    \"/host-etc/os-release\"\n            readOnly: true\n        livenessProbe:\n
+    \         httpGet:\n            path: /healthz\n            port: 8081\n          initialDelaySeconds:
+    15\n          periodSeconds: 20\n        readinessProbe:\n          httpGet:\n
+    \           path: /readyz\n            port: 8081\n          initialDelaySeconds:
+    5\n          periodSeconds: 10\n        resources:\n          limits:\n            cpu:
+    500m\n            memory: 350Mi\n          requests:\n            cpu: 200m\n
+    \           memory: 100Mi\n        ports:\n          - name: metrics\n            containerPort:
+    8080\n      volumes:\n        - name: host-os-release\n          hostPath:\n            path:
+    \"/etc/os-release\"\n      affinity:\n        nodeAffinity:\n          preferredDuringSchedulingIgnoredDuringExecution:\n
+    \         - preference:\n              matchExpressions:\n              - key:
+    node-role.kubernetes.io/master\n                operator: In\n                values:\n
+    \               - \"\"\n            weight: 1\n      tolerations:\n        - effect:
+    NoSchedule\n          key: node-role.kubernetes.io/master\n          operator:
+    Equal\n          value: \"\"\n---\n# Source: gpu-operator/templates/role.yaml\napiVersion:
+    rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  creationTimestamp:
+    null\n  name: gpu-operator\n  namespace: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
+    \"gpu-operator\"\n    \nrules:\n- apiGroups:\n  - config.openshift.io\n  resources:\n
+    \ - proxies\n  verbs:\n  - get\n- apiGroups:\n  - rbac.authorization.k8s.io\n
+    \ resources:\n  - roles\n  - rolebindings\n  - clusterroles\n  - clusterrolebindings\n
+    \ verbs:\n  - '*'\n- apiGroups:\n  - \"\"\n  resources:\n  - pods\n  - services\n
+    \ - endpoints\n  - persistentvolumeclaims\n  - events\n  - configmaps\n  - secrets\n
+    \ - serviceaccounts\n  - nodes\n  verbs:\n  - '*'\n- apiGroups:\n  - \"\"\n  resources:\n
+    \ - namespaces\n  verbs:\n  - get\n  - list\n  - create\n  - watch\n  - update\n-
+    apiGroups:\n  - apps\n  resources:\n  - deployments\n  - daemonsets\n  - replicasets\n
+    \ - statefulsets\n  verbs:\n  - '*'\n- apiGroups:\n  - monitoring.coreos.com\n
+    \ resources:\n  - servicemonitors\n  - prometheusrules\n  verbs:\n  - get\n  -
+    list\n  - create\n  - watch\n  - update\n- apiGroups:\n  - nvidia.com\n  resources:\n
+    \ - '*'\n  verbs:\n  - '*'\n- apiGroups:\n  - scheduling.k8s.io\n  resources:\n
+    \ - priorityclasses\n  verbs:\n  - get\n  - list\n  - watch\n  - create\n- apiGroups:\n
+    \ - security.openshift.io\n  resources:\n  - securitycontextconstraints\n  verbs:\n
+    \ - '*'\n- apiGroups:\n  - policy\n  resources:\n  - podsecuritypolicies\n  verbs:\n
+    \ - use\n  resourceNames:\n  - gpu-operator-restricted\n- apiGroups:\n  - policy\n
+    \ resources:\n  - podsecuritypolicies\n  verbs:\n  - create\n  - get\n  - update\n
+    \ - list\n- apiGroups:\n  - config.openshift.io\n  resources:\n  - clusterversions\n
+    \ verbs:\n  - get\n  - list\n  - watch\n- apiGroups:\n  - \"\"\n  - coordination.k8s.io\n
+    \ resources:\n  - configmaps\n  - leases\n  verbs:\n  - get\n  - list\n  - watch\n
+    \ - create\n  - update\n  - patch\n  - delete\n- apiGroups:\n  - node.k8s.io\n
+    \ resources:\n  - runtimeclasses\n  verbs:\n  - get\n  - list\n  - create\n  -
+    update\n  - watch\n- apiGroups:\n  - image.openshift.io\n  resources:\n  - imagestreams\n
+    \ verbs:\n  - get\n  - list\n  - watch\n---\n# Source: gpu-operator/templates/rolebinding.yaml\nkind:
+    ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name:
+    gpu-operator\n  labels:\n    app.kubernetes.io/component: \"gpu-operator\"\n    \nsubjects:\n-
+    kind: ServiceAccount\n  name: gpu-operator\n  namespace: gpu-operator-resources\n-
+    kind: ServiceAccount\n  name: node-feature-discovery\n  namespace: gpu-operator-resources\nroleRef:\n
+    \ kind: ClusterRole\n  name: gpu-operator\n  apiGroup: rbac.authorization.k8s.io\n---\n#
+    Source: gpu-operator/templates/serviceaccount.yaml\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
+    \ name: gpu-operator\n  namespace: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
+    \"gpu-operator\"\n"
 kind: ConfigMap
 metadata:
   annotations:

--- a/templates/flavors/nvidia-gpu/clusterpolicy-crd.yaml
+++ b/templates/flavors/nvidia-gpu/clusterpolicy-crd.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: crds/nvidia.com_clusterpolicies_crd.yaml
+# Source: gpu-operator/crds/nvidia.com_clusterpolicies_crd.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -17,663 +17,97 @@ spec:
     singular: clusterpolicy
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: ClusterPolicy is the Schema for the clusterpolicies API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterPolicy is the Schema for the clusterpolicies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterPolicySpec defines the desired state of ClusterPolicy
-              properties:
-                dcgmExporter:
-                  description: DCGMExporter spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterPolicySpec defines the desired state of ClusterPolicy
+            properties:
+              daemonsets:
+                description: Daemonset defines common configuration for all Daemonsets
+                properties:
+                  priorityClassName:
+                    type: string
+                  tolerations:
+                    description: 'Optional: Set tolerations'
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
                       properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
                       type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
-                        type: string
-                      type: array
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
+                    type: array
+                type: object
+              dcgm:
+                description: DCGM component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled indicates if deployment of DCGM hostengine
+                      as a separate pod is enabled.
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
                             using the previous defined environment variables in the
                             container and any service environment variables. If a
                             variable cannot be resolved, the reference in the input
@@ -681,1134 +115,321 @@ spec:
                             escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                             will never be expanded, regardless of whether the variable
                             exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    licensingConfig:
-                      description: 'Optional: Licensing configuration for vGPU drivers'
-                      properties:
-                        configMapName:
-                          type: string
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
                           type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
+                      required:
+                      - name
                       type: object
-                    repoConfig:
-                      description: 'Optional: Custom repo configuration for driver container'
-                      properties:
-                        configMapName:
-                          type: string
-                        destinationDir:
-                          type: string
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
+                    type: array
+                  hostPort:
+                    description: 'HostPort represents host port that needs to be bound
+                      for DCGM engine (Default: 5555)'
+                    format: int32
+                    type: integer
+                  image:
+                    description: DCGM image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
                       type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
+                    type: array
+                  repository:
+                    description: DCGM image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
                       each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
                           resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Optional: Security Context'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
                           process can gain more privileges than its parent process.
                           This bool directly controls if the no_new_privs flag will
                           be set on the container process. AllowPrivilegeEscalation
                           is true always when the container is: 1) run as Privileged
                           2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
                               will be applied. Valid options are: \n Localhost - a
                               profile defined in a file on the node should be used.
                               RuntimeDefault - the container runtime default profile
                               should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
                         properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
                             type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
                             type: string
                         type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
+                    type: object
+                  version:
+                    description: DCGM image tag
+                    type: string
+                type: object
+              dcgmExporter:
+                description: DCGMExporter spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
                       type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-                devicePlugin:
-                  description: DevicePlugin component spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
+                    type: array
+                  config:
+                    description: 'Optional: Custom metrics configuration for DCGM
+                      exporter'
+                    properties:
+                      name:
+                        description: ConfigMap name with file dcgm-metrics.csv for
+                          metrics to be collected by DCGM exporter
                         type: string
-                      type: array
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
+                    type: object
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
                             using the previous defined environment variables in the
                             container and any service environment variables. If a
                             variable cannot be resolved, the reference in the input
@@ -1816,1134 +437,307 @@ spec:
                             escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                             will never be expanded, regardless of whether the variable
                             exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    licensingConfig:
-                      description: 'Optional: Licensing configuration for vGPU drivers'
-                      properties:
-                        configMapName:
-                          type: string
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
                           type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
+                      required:
+                      - name
                       type: object
-                    repoConfig:
-                      description: 'Optional: Custom repo configuration for driver container'
-                      properties:
-                        configMapName:
-                          type: string
-                        destinationDir:
-                          type: string
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
+                    type: array
+                  image:
+                    description: DCGM image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
                       type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
+                    type: array
+                  repository:
+                    description: DCGM image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
                       each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
                           resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Optional: Security Context'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
                           process can gain more privileges than its parent process.
                           This bool directly controls if the no_new_privs flag will
                           be set on the container process. AllowPrivilegeEscalation
                           is true always when the container is: 1) run as Privileged
                           2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
                               will be applied. Valid options are: \n Localhost - a
                               profile defined in a file on the node should be used.
                               RuntimeDefault - the container runtime default profile
                               should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
                         properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
                             type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
                             type: string
                         type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
+                    type: object
+                  version:
+                    description: DCGM image tag
+                    type: string
+                type: object
+              devicePlugin:
+                description: DevicePlugin component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
                       type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-                driver:
-                  description: Driver component spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
+                    type: array
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
-                        type: string
-                      type: array
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
                             using the previous defined environment variables in the
                             container and any service environment variables. If a
                             variable cannot be resolved, the reference in the input
@@ -2951,1138 +745,318 @@ spec:
                             escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                             will never be expanded, regardless of whether the variable
                             exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    licensingConfig:
-                      description: 'Optional: Licensing configuration for vGPU drivers'
-                      properties:
-                        configMapName:
-                          type: string
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
                           type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
+                      required:
+                      - name
                       type: object
-                    repoConfig:
-                      description: 'Optional: Custom repo configuration for driver container'
-                      properties:
-                        configMapName:
-                          type: string
-                        destinationDir:
-                          type: string
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
+                    type: array
+                  image:
+                    description: DevicePlugin image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
                       type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
+                    type: array
+                  repository:
+                    description: DevicePlugin image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
                       each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
                           resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Optional: Security Context'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
                           process can gain more privileges than its parent process.
                           This bool directly controls if the no_new_privs flag will
                           be set on the container process. AllowPrivilegeEscalation
                           is true always when the container is: 1) run as Privileged
                           2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
                               will be applied. Valid options are: \n Localhost - a
                               profile defined in a file on the node should be used.
                               RuntimeDefault - the container runtime default profile
                               should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
                         properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
                             type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
                             type: string
                         type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
+                    type: object
+                  version:
+                    description: DevicePlugin image tag
+                    type: string
+                type: object
+              driver:
+                description: Driver component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
                       type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-                gfd:
-                  description: GPUFeatureDiscovery spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
+                    type: array
+                  certConfig:
+                    description: 'Optional: Custom certificates configuration for
+                      driver container'
+                    properties:
+                      name:
                         type: string
-                      type: array
-                    discoveryIntervalSeconds:
-                      description: 'Optional: Discovery Interval for GPU feature discovery
-                      plugin'
-                      type: integer
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
+                    type: object
+                  enabled:
+                    description: Enabled indicates if deployment of driver through
+                      operator is enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
                             using the previous defined environment variables in the
                             container and any service environment variables. If a
                             variable cannot be resolved, the reference in the input
@@ -4090,1163 +1064,486 @@ spec:
                             escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                             will never be expanded, regardless of whether the variable
                             exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Driver image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  licensingConfig:
+                    description: 'Optional: Licensing configuration for vGPU drivers'
+                    properties:
+                      configMapName:
+                        type: string
+                      nlsEnabled:
+                        description: NLSEnabled indicates if NLS is used for licensing.
+                        type: boolean
+                    type: object
+                  manager:
+                    description: Manager represents configuration for driver manager
+                      initContainer
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
                                   - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    migStrategy:
-                      description: 'Optional: MigStrategy for GPU feature discovery
-                      plugin'
-                      enum:
-                        - none
-                        - single
-                        - mixed
-                      type: string
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
                           required:
-                            - type
+                          - name
                           type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
-                      type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
+                        type: array
+                      image:
+                        description: Image represents Driver-Manager image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: Repository represents Driver-Manager repository
+                          path
+                        type: string
+                      version:
+                        description: Version represents Driver-Manager image tag(version)
+                        type: string
+                    type: object
+                  rdma:
+                    description: GPUDirectRDMASpec defines the properties for nv_peer_mem
+                      deployment
+                    properties:
+                      enabled:
+                        description: Enabled indicates if GPUDirect RDMA is enabled
+                          through GPU operator
+                        type: boolean
+                      useHostMofed:
+                        description: UseHostMOFED indicates to use MOFED drivers directly
+                          installed on the host to enable GPUDirect RDMA
+                        type: boolean
+                    type: object
+                  repoConfig:
+                    description: 'Optional: Custom repo configuration for driver container'
+                    properties:
+                      configMapName:
+                        type: string
+                    type: object
+                  repository:
+                    description: Driver image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
                       each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
                           resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Optional: Security Context'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
                           process can gain more privileges than its parent process.
                           This bool directly controls if the no_new_privs flag will
                           be set on the container process. AllowPrivilegeEscalation
                           is true always when the container is: 1) run as Privileged
                           2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
                               will be applied. Valid options are: \n Localhost - a
                               profile defined in a file on the node should be used.
                               RuntimeDefault - the container runtime default profile
                               should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
                         properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
                             type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
                             type: string
                         type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
-                      type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-                operator:
-                  description: Operator component spec
-                  properties:
-                    defaultRuntime:
-                      description: Runtime defines container runtime type
-                      enum:
-                        - docker
-                        - crio
-                        - containerd
-                      type: string
-                    validator:
-                      description: ValidatorSpec describes configuration options for
-                        validation pod
-                      properties:
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
-                          type: string
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
-                          type: string
-                      type: object
-                  required:
-                    - defaultRuntime
-                  type: object
-                toolkit:
-                  description: Toolkit component spec
-                  properties:
-                    affinity:
-                      description: 'Optional: Set Node affinity'
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    args:
-                      description: 'Optional: List of arguments'
-                      items:
+                    type: object
+                  use_ocp_driver_toolkit:
+                    description: UseOpenShiftDriverToolkit indicates if DriverToolkit
+                      image should be used on OpenShift to build and install driver
+                      modules
+                    type: boolean
+                  version:
+                    description: Driver image tag
+                    type: string
+                  virtualTopology:
+                    description: 'Optional: Virtual Topology Daemon configuration
+                      for vGPU drivers'
+                    properties:
+                      config:
+                        description: 'Optional: Config name representing virtual topology
+                          daemon configuration file nvidia-topologyd.conf'
                         type: string
-                      type: array
-                    env:
-                      description: 'Optional: List of environment variables'
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
+                    type: object
+                type: object
+              gfd:
+                description: GPUFeatureDiscovery spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
                             using the previous defined environment variables in the
                             container and any service environment variables. If a
                             variable cannot be resolved, the reference in the input
@@ -5254,525 +1551,2107 @@ spec:
                             escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                             will never be expanded, regardless of whether the variable
                             exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
                                     optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    image:
-                      pattern: '[a-zA-Z0-9\-]+'
-                      type: string
-                    imagePullPolicy:
-                      description: Image pull policy
-                      type: string
-                    imagePullSecrets:
-                      description: Image pull secrets
-                      items:
-                        type: string
-                      type: array
-                    licensingConfig:
-                      description: 'Optional: Licensing configuration for vGPU drivers'
-                      properties:
-                        configMapName:
-                          type: string
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Node selector to control the selection of nodes (optional)
-                      type: object
-                    podSecurityContext:
-                      description: 'Optional: Pod Security Context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
                           type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
+                      required:
+                      - name
                       type: object
-                    repoConfig:
-                      description: 'Optional: Custom repo configuration for driver container'
-                      properties:
-                        configMapName:
-                          type: string
-                        destinationDir:
-                          type: string
-                      type: object
-                    repository:
-                      pattern: '[a-zA-Z0-9\.\-\/]+'
+                    type: array
+                  image:
+                    description: GFD image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
                       type: string
-                    resources:
-                      description: 'Optional: Define resources requests and limits for
+                    type: array
+                  repository:
+                    description: GFD image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
                       each pod'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
                           resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'Optional: Security Context'
-                      properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Optional: Security Context'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
                           process can gain more privileges than its parent process.
                           This bool directly controls if the no_new_privs flag will
                           be set on the container process. AllowPrivilegeEscalation
                           is true always when the container is: 1) run as Privileged
                           2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by the
-                            container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes in
-                            privileged containers are essentially equivalent to root
-                            on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to use
-                            for the containers. The default is DefaultProcMount which
-                            uses the container runtime defaults for readonly paths and
-                            masked paths. This requires the ProcMountType feature flag
-                            to be enabled.
-                          type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem.
-                            Default is false.
-                          type: boolean
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            PodSecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
                               will be applied. Valid options are: \n Localhost - a
                               profile defined in a file on the node should be used.
                               RuntimeDefault - the container runtime default profile
                               should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    tolerations:
-                      description: 'Optional: Set tolerations'
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
                         properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
                             type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
                             type: string
                         type: object
-                      type: array
-                    version:
-                      pattern: '[a-zA-Z0-9\.-]+'
+                    type: object
+                  version:
+                    description: GFD image tag
+                    type: string
+                type: object
+              mig:
+                description: MIG spec
+                properties:
+                  strategy:
+                    description: 'Optional: MIGStrategy to apply for GFD and Device-Plugin'
+                    enum:
+                    - none
+                    - single
+                    - mixed
+                    type: string
+                type: object
+              migManager:
+                description: MIGManager for configuration to deploy MIG Manager
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
                       type: string
-                  required:
-                    - image
-                    - repository
-                    - version
-                  type: object
-              required:
-                - dcgmExporter
-                - devicePlugin
-                - driver
-                - gfd
-                - operator
-                - toolkit
-              type: object
-            status:
-              description: ClusterPolicyStatus defines the observed state of ClusterPolicy
-              properties:
-                state:
-                  enum:
-                    - ignored
-                    - ready
-                    - notReady
-                  type: string
-              required:
-                - state
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: array
+                  config:
+                    description: 'Optional: Custom mig-parted configuration for MIG
+                      Manager container'
+                    properties:
+                      name:
+                        description: ConfigMap name
+                        type: string
+                    type: object
+                  enabled:
+                    description: Enabled indicates if deployment of mig-manager is
+                      enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  gpuClientsConfig:
+                    description: 'Optional: Custom gpu-clients configuration for MIG
+                      Manager container'
+                    properties:
+                      name:
+                        description: ConfigMap name
+                        type: string
+                    type: object
+                  image:
+                    description: mig-manager image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: mig-manager image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Optional: Security Context'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  version:
+                    description: mig-manager image tag
+                    type: string
+                type: object
+              nodeStatusExporter:
+                description: NodeStatusExporter spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled indicates if deployment of node-status-exporter
+                      is enabled.
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: node-status-exporter image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: node-status-exporter image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Optional: Security Context'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  version:
+                    description: node-status-exporter image tag
+                    type: string
+                type: object
+              operator:
+                description: Operator component spec
+                properties:
+                  defaultRuntime:
+                    default: docker
+                    description: Runtime defines container runtime type
+                    enum:
+                    - docker
+                    - crio
+                    - containerd
+                    type: string
+                  initContainer:
+                    description: InitContainerSpec describes configuration for initContainer
+                      image used with all components
+                    properties:
+                      image:
+                        description: Image represents image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: Repository represents image repository path
+                        type: string
+                      version:
+                        description: Version represents image tag(version)
+                        type: string
+                    type: object
+                  runtimeClass:
+                    default: nvidia
+                    type: string
+                required:
+                - defaultRuntime
+                type: object
+              psp:
+                description: PSP defines spec for handling PodSecurityPolicies
+                properties:
+                  enabled:
+                    description: Enabled indicates if PodSecurityPolicies needs to
+                      be enabled for all Pods
+                    type: boolean
+                type: object
+              toolkit:
+                description: Toolkit component spec
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled indicates if deployment of container-toolkit
+                      through operator is enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Toolkit image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: Toolkit image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Optional: Security Context'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  version:
+                    description: Toolkit image tag
+                    type: string
+                type: object
+              validator:
+                description: Validator defines the spec for operator-validator daemonset
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  cuda:
+                    description: CUDA validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  driver:
+                    description: Toolkit validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Validator image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  plugin:
+                    description: Plugin validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  repository:
+                    description: Validator image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Optional: Security Context'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  toolkit:
+                    description: Toolkit validator spec
+                    properties:
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  version:
+                    description: Validator image tag
+                    type: string
+                type: object
+            required:
+            - daemonsets
+            - dcgm
+            - dcgmExporter
+            - devicePlugin
+            - driver
+            - gfd
+            - nodeStatusExporter
+            - operator
+            - toolkit
+            type: object
+          status:
+            description: ClusterPolicyStatus defines the observed state of ClusterPolicy
+            properties:
+              state:
+                description: State indicates status of ClusterPolicy
+                enum:
+                - ignored
+                - ready
+                - notReady
+                type: string
+            required:
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
   conditions: []
   storedVersions: []
+

--- a/templates/flavors/nvidia-gpu/gpu-operator-components.yaml
+++ b/templates/flavors/nvidia-gpu/gpu-operator-components.yaml
@@ -6,281 +6,296 @@ metadata:
   name: gpu-operator-resources
   labels:
     app.kubernetes.io/component: "gpu-operator"
-
     openshift.io/cluster-monitoring: "true"
 ---
-# Source: gpu-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gpu-operator-node-feature-discovery
-  namespace: default
-  labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
-    app.kubernetes.io/name: node-feature-discovery
-    app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
-    app.kubernetes.io/managed-by: Helm
----
-# Source: gpu-operator/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gpu-operator
-  namespace: default
-  labels:
-    app.kubernetes.io/component: "gpu-operator"
----
-# Source: gpu-operator/charts/node-feature-discovery/templates/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: gpu-operator-node-feature-discovery
-  namespace: default
-  labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
-    app.kubernetes.io/name: node-feature-discovery
-    app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
-    app.kubernetes.io/managed-by: Helm
-data:
-  nfd-worker.conf: |
-    sources:
-      pci:
-        deviceLabelFields:
-        - vendor
----
-# Source: gpu-operator/charts/node-feature-discovery/templates/rbac.yaml
+# Source: gpu-operator/charts/node-feature-discovery/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gpu-operator-node-feature-discovery-master
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    # when using command line flag --resource-labels to create extended resources
-    # you will need to uncomment "- nodes/status"
-    # - nodes/status
-    verbs:
-      - get
-      - patch
-      - update
----
-# Source: gpu-operator/templates/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: gpu-operator
+  name: gpu-operator-node-feature-discovery
+  namespace: gpu-operator-resources
   labels:
-    app.kubernetes.io/component: "gpu-operator"
-
+    helm.sh/chart: node-feature-discovery-0.8.2
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.8.2"
+    app.kubernetes.io/managed-by: Helm
 rules:
-  - apiGroups:
-      - config.openshift.io
-    resources:
-      - proxies
-    verbs:
-      - get
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - roles
-      - rolebindings
-      - clusterroles
-      - clusterrolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - services
-      - endpoints
-      - persistentvolumeclaims
-      - events
-      - configmaps
-      - secrets
-      - serviceaccounts
-      - nodes
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - daemonsets
-      - replicasets
-      - statefulsets
-    verbs:
-      - '*'
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - list
-      - create
-      - watch
-  - apiGroups:
-      - nvidia.com
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - scheduling.k8s.io
-    resources:
-      - priorityclasses
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-  - apiGroups:
-      - security.openshift.io
-    resources:
-      - securitycontextconstraints
-    verbs:
-      - '*'
-  - apiGroups:
-      - config.openshift.io
-    resources:
-      - clusterversions
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  # when using command line flag --resource-labels to create extended resources
+  # you will need to uncomment "- nodes/status"
+  # - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+  - list
 ---
-# Source: gpu-operator/charts/node-feature-discovery/templates/rbac.yaml
+# Source: gpu-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-metadata:
-  name: gpu-operator-node-feature-discovery-master
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: gpu-operator-node-feature-discovery-master
-subjects:
-  - kind: ServiceAccount
-    name: gpu-operator-node-feature-discovery
-    namespace: default
----
-# Source: gpu-operator/templates/rolebinding.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: gpu-operator
-  labels:
-    app.kubernetes.io/component: "gpu-operator"
-
-subjects:
-  - kind: ServiceAccount
-    name: gpu-operator
-    namespace: default
-roleRef:
-  kind: ClusterRole
-  name: gpu-operator
-  apiGroup: rbac.authorization.k8s.io
----
-# Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml
-apiVersion: v1
-kind: Service
 metadata:
   name: gpu-operator-node-feature-discovery
-  namespace: default
   labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
+    helm.sh/chart: node-feature-discovery-0.8.2
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
+    app.kubernetes.io/version: "v0.8.2"
     app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-    - name: api
-      port: 8080
-      protocol: TCP
-      targetPort: api
-
-  selector:
-    app.kubernetes.io/component: master
-    app.kubernetes.io/name: node-feature-discovery
-    app.kubernetes.io/instance: gpu-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gpu-operator-node-feature-discovery
+subjects:
+- kind: ServiceAccount
+  name: node-feature-discovery
+  namespace: gpu-operator-resources
 ---
-# Source: gpu-operator/charts/node-feature-discovery/templates/daemonset-worker.yaml
+# Source: gpu-operator/charts/node-feature-discovery/templates/master.yaml
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
-  name: gpu-operator-node-feature-discovery-worker
-  namespace: default
+  name:  gpu-operator-node-feature-discovery-master
+  namespace: gpu-operator-resources
   labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
+    helm.sh/chart: node-feature-discovery-0.8.2
     app.kubernetes.io/name: node-feature-discovery
     app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
+    app.kubernetes.io/version: "v0.8.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: worker
+    role: master
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: node-feature-discovery
       app.kubernetes.io/instance: gpu-operator
-      app.kubernetes.io/component: worker
+      role: master
   template:
     metadata:
       labels:
         app.kubernetes.io/name: node-feature-discovery
         app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/component: worker
+        role: master
+      annotations:
+        {}
     spec:
-      serviceAccountName: gpu-operator-node-feature-discovery
+      serviceAccountName: node-feature-discovery
       securityContext:
         {}
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - name: node-feature-discovery-master
+        - name: master
           securityContext:
-            {}
-          image: "quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0"
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "k8s.gcr.io/nfd/node-feature-discovery:v0.8.2"
           imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8080
+            name: grpc
+            namespace: gpu-operator-resources
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           command:
-            - "nfd-worker"
-          args:
-            - "--sleep-interval=60s"
-            - "--server=gpu-operator-node-feature-discovery:8080"
-          volumeMounts:
-            - name: host-boot
-              mountPath: "/host-boot"
-              readOnly: true
-            - name: host-os-release
-              mountPath: "/host-etc/os-release"
-              readOnly: true
-            - name: host-sys
-              mountPath: "/host-sys"
-            - name: source-d
-              mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
-            - name: features-d
-              mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
-            - name: nfd-worker-config
-              mountPath: "/etc/kubernetes/node-feature-discovery/"
+            - "nfd-master"
           resources:
             {}
-
+          args:
+            - "--extra-label-ns=nvidia.com"
+## Enable TLS authentication
+## The example below assumes having the root certificate named ca.crt stored in
+## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
+## in a TLS Secret named nfd-master-cert.
+## Additional hardening can be enabled by specifying --verify-node-name in
+## args, in which case node name will be checked against the worker's
+## TLS certificate.
+#            - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
+#            - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+#            - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+#          volumeMounts:
+#            - name: nfd-ca-cert
+#              mountPath: "/etc/kubernetes/node-feature-discovery/trust"
+#              readOnly: true
+#            - name: nfd-master-cert
+#              mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+#              readOnly: true
+#      volumes:
+#        - name: nfd-ca-cert
+#          configMap:
+#            name: nfd-ca-cert
+#        - name: nfd-master-cert
+#          secret:
+#            secretName: nfd-master-cert
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: In
+                values:
+                - ""
+            weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Equal
+          value: ""
+---
+# Source: gpu-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfd-worker-conf
+  namespace: gpu-operator-resources
+  labels:
+    helm.sh/chart: node-feature-discovery-0.8.2
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.8.2"
+    app.kubernetes.io/managed-by: Helm
+data:
+  nfd-worker.conf: |-
+    sources:
+      pci:
+        deviceLabelFields:
+        - vendor
+---
+# Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gpu-operator-node-feature-discovery-master
+  namespace: gpu-operator-resources
+  labels:
+    helm.sh/chart: node-feature-discovery-0.8.2
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.8.2"
+    app.kubernetes.io/managed-by: Helm
+    role: master
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+      namespace: gpu-operator-resources
+  selector:
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+---
+# Source: gpu-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-feature-discovery
+  namespace: gpu-operator-resources
+  labels:
+    helm.sh/chart: node-feature-discovery-0.8.2
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.8.2"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: gpu-operator/charts/node-feature-discovery/templates/worker.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name:  gpu-operator-node-feature-discovery-worker
+  namespace: gpu-operator-resources
+  labels:
+    helm.sh/chart: node-feature-discovery-0.8.2
+    app.kubernetes.io/name: node-feature-discovery
+    app.kubernetes.io/instance: gpu-operator
+    app.kubernetes.io/version: "v0.8.2"
+    app.kubernetes.io/managed-by: Helm
+    role: worker
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-feature-discovery
+      app.kubernetes.io/instance: gpu-operator
+      role: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-feature-discovery
+        app.kubernetes.io/instance: gpu-operator
+        role: worker
+      annotations:
+        {}
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      securityContext:
+        {}
+      containers:
+      - name: worker
+        securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+        image: "k8s.gcr.io/nfd/node-feature-discovery:v0.8.2"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+            {}
+        command:
+        - "nfd-worker"
+        args:
+        - "--sleep-interval=60s"
+        - "--server=gpu-operator-node-feature-discovery-master:8080"
+## Enable TLS authentication (1/3)
+## The example below assumes having the root certificate named ca.crt stored in
+## a ConfigMap named nfd-ca-cert, and, the TLS authentication credentials stored
+## in a TLS Secret named nfd-worker-cert
+#          - "--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt"
+#          - "--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key"
+#          - "--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt"
+        volumeMounts:
+        - name: host-boot
+          mountPath: "/host-boot"
+          readOnly: true
+        - name: host-os-release
+          mountPath: "/host-etc/os-release"
+          readOnly: true
+        - name: host-sys
+          mountPath: "/host-sys"
+          readOnly: true
+        - name: source-d
+          mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+          readOnly: true
+        - name: features-d
+          mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
+          readOnly: true
+        - name: nfd-worker-conf
+          mountPath: "/etc/kubernetes/node-feature-discovery"
+          readOnly: true
+## Enable TLS authentication (2/3)
+#        - name: nfd-ca-cert
+#          mountPath: "/etc/kubernetes/node-feature-discovery/trust"
+#          readOnly: true
+#        - name: nfd-worker-cert
+#          mountPath: "/etc/kubernetes/node-feature-discovery/certs"
+#          readOnly: true
       volumes:
         - name: host-boot
           hostPath:
@@ -297,9 +312,20 @@ spec:
         - name: features-d
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/features.d/"
-        - name: nfd-worker-config
+        - name: nfd-worker-conf
           configMap:
-            name: gpu-operator-node-feature-discovery
+            name: nfd-worker-conf
+            namespace: gpu-operator-resources
+            items:
+              - key: nfd-worker.conf
+                path: nfd-worker.conf
+## Enable TLS authentication (3/3)
+#        - name: nfd-ca-cert
+#          configMap:
+#            name: nfd-ca-cert
+#        - name: nfd-worker-cert
+#          secret:
+#            secretName: nfd-worker-cert
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
@@ -310,126 +336,233 @@ spec:
           operator: Equal
           value: present
 ---
-# Source: gpu-operator/charts/node-feature-discovery/templates/deployment-master.yaml
-apiVersion: apps/v1
-kind: Deployment
+# Source: gpu-operator/templates/clusterpolicy.yaml
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
 metadata:
-  name: gpu-operator-node-feature-discovery-master
-  namespace: default
+  name: cluster-policy
+  namespace: gpu-operator-resources
   labels:
-    helm.sh/chart: node-feature-discovery-2.0.0
-    app.kubernetes.io/name: node-feature-discovery
-    app.kubernetes.io/instance: gpu-operator
-    app.kubernetes.io/version: "0.6.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: master
+    app.kubernetes.io/component: "gpu-operator"
+    
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: node-feature-discovery
-      app.kubernetes.io/instance: gpu-operator
-      app.kubernetes.io/component: master
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/component: master
-    spec:
-      serviceAccountName: gpu-operator-node-feature-discovery
-      securityContext:
-        {}
-      containers:
-        - name: node-feature-discovery-master
-          securityContext:
-            {}
-          image: "k8s.gcr.io/nfd/node-feature-discovery:v0.9.0"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: api
-              containerPort: 8080
-              protocol: TCP
-          env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          command:
-            - "nfd-master"
-          args:
-            - --extra-label-ns=nvidia.com
-          resources:
-            {}
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: In
-                    values:
-                      - ""
-              weight: 1
-      tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: Equal
+  operator:
+    defaultRuntime: docker
+    runtimeClass: nvidia
+    initContainer:
+      repository: nvcr.io/nvidia
+      image: cuda
+      version: 11.4.2-base-ubi8
+      imagePullPolicy: IfNotPresent
+  daemonsets:
+    tolerations: 
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+    priorityClassName: system-node-critical
+  validator:
+    repository: nvcr.io/nvidia/cloud-native
+    image: gpu-operator-validator
+    version: v1.9.0
+    imagePullPolicy: IfNotPresent
+    securityContext: 
+      privileged: true
+      seLinuxOptions:
+        level: s0
+    plugin:
+      env: 
+        - name: WITH_WORKLOAD
+          value: "true"
+  mig:
+    strategy: single
+  psp:
+    enabled: false
+  driver:
+    enabled: true
+    repository: nvcr.io/nvidia
+    image: driver
+    version: 470.82.01
+    imagePullPolicy: IfNotPresent
+    rdma:
+      enabled: false
+      useHostMofed: false
+    manager:
+      repository: nvcr.io/nvidia/cloud-native
+      image: k8s-driver-manager
+      version: v0.2.0
+      imagePullPolicy: IfNotPresent
+      env: 
+        - name: ENABLE_AUTO_DRAIN
+          value: "true"
+        - name: DRAIN_USE_FORCE
+          value: "false"
+        - name: DRAIN_POD_SELECTOR_LABEL
           value: ""
+        - name: DRAIN_TIMEOUT_SECONDS
+          value: 0s
+        - name: DRAIN_DELETE_EMPTYDIR_DATA
+          value: "false"
+    repoConfig: 
+      configMapName: ""
+    certConfig: 
+      name: ""
+    licensingConfig: 
+      configMapName: ""
+      nlsEnabled: false
+    virtualTopology: 
+      config: ""
+    securityContext: 
+      privileged: true
+      seLinuxOptions:
+        level: s0
+  toolkit:
+    enabled: true
+    repository: nvcr.io/nvidia/k8s
+    image: container-toolkit
+    version: 1.7.2-ubuntu18.04
+    imagePullPolicy: IfNotPresent
+    securityContext: 
+      privileged: true
+      seLinuxOptions:
+        level: s0
+  devicePlugin:
+    repository: nvcr.io/nvidia
+    image: k8s-device-plugin
+    version: v0.10.0-ubi8
+    imagePullPolicy: IfNotPresent
+    securityContext: 
+      privileged: true
+    env: 
+      - name: PASS_DEVICE_SPECS
+        value: "true"
+      - name: FAIL_ON_INIT_ERROR
+        value: "true"
+      - name: DEVICE_LIST_STRATEGY
+        value: envvar
+      - name: DEVICE_ID_STRATEGY
+        value: uuid
+      - name: NVIDIA_VISIBLE_DEVICES
+        value: all
+      - name: NVIDIA_DRIVER_CAPABILITIES
+        value: all
+  dcgm:
+    enabled: true
+    repository: nvcr.io/nvidia/cloud-native
+    image: dcgm
+    version: 2.3.1-ubuntu20.04
+    imagePullPolicy: IfNotPresent
+    hostPort: 5555
+  dcgmExporter:
+    repository: nvcr.io/nvidia/k8s
+    image: dcgm-exporter
+    version: 2.3.1-2.6.0-ubuntu20.04
+    imagePullPolicy: IfNotPresent
+    env: 
+      - name: DCGM_EXPORTER_LISTEN
+        value: :9400
+      - name: DCGM_EXPORTER_KUBERNETES
+        value: "true"
+      - name: DCGM_EXPORTER_COLLECTORS
+        value: /etc/dcgm-exporter/dcp-metrics-included.csv
+  gfd:
+    repository: nvcr.io/nvidia
+    image: gpu-feature-discovery
+    version: v0.4.1
+    imagePullPolicy: IfNotPresent
+    env: 
+      - name: GFD_SLEEP_INTERVAL
+        value: 60s
+      - name: GFD_FAIL_ON_INIT_ERROR
+        value: "true"
+  migManager:
+    enabled: true
+    repository: nvcr.io/nvidia/cloud-native
+    image: k8s-mig-manager
+    version: v0.2.0-ubuntu20.04
+    imagePullPolicy: IfNotPresent
+    securityContext: 
+      privileged: true
+    env: 
+      - name: WITH_REBOOT
+        value: "false"
+    config: 
+      name: ""
+    gpuClientsConfig: 
+      name: ""
+  nodeStatusExporter:
+    enabled: false
+    repository: nvcr.io/nvidia/cloud-native
+    image: gpu-operator-validator
+    version: v1.9.0
+    imagePullPolicy: IfNotPresent
 ---
 # Source: gpu-operator/templates/operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gpu-operator
-  namespace: default
+  namespace: gpu-operator-resources
   labels:
     app.kubernetes.io/component: "gpu-operator"
-
+    
 spec:
   replicas: 1
   selector:
     matchLabels:
-
+      
       app.kubernetes.io/component: "gpu-operator"
+      app: "gpu-operator"
   template:
     metadata:
       labels:
-
+        
         app.kubernetes.io/component: "gpu-operator"
+        app: "gpu-operator"
       annotations:
         openshift.io/scc: restricted-readonly
     spec:
       serviceAccountName: gpu-operator
+      priorityClassName: system-node-critical
       containers:
-        - name: gpu-operator
-          image: nvcr.io/nvidia/gpu-operator:1.6.2
-          imagePullPolicy: IfNotPresent
-          command: ["gpu-operator"]
-          args:
-            - "--zap-time-encoding=epoch"
-          env:
-            - name: WATCH_NAMESPACE
-              value: ""
-            - name: OPERATOR_NAME
-              value: "gpu-operator"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          volumeMounts:
-            - name: host-os-release
-              mountPath: "/host-etc/os-release"
-              readOnly: true
-          readinessProbe:
-            exec:
-              command: ["stat", "/tmp/operator-sdk-ready"]
-            initialDelaySeconds: 4
-            periodSeconds: 10
-            failureThreshold: 1
-          ports:
-            - containerPort: 60000
-              name: metrics
+      - name: gpu-operator
+        image: nvcr.io/nvidia/gpu-operator:v1.9.0
+        imagePullPolicy: IfNotPresent
+        command: ["gpu-operator"]
+        args:
+        - --leader-elect
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+          - name: host-os-release
+            mountPath: "/host-etc/os-release"
+            readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 350Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        ports:
+          - name: metrics
+            containerPort: 8080
       volumes:
         - name: host-os-release
           hostPath:
@@ -437,102 +570,193 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: In
-                    values:
-                      - ""
-              weight: 1
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: In
+                values:
+                - ""
+            weight: 1
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Equal
           value: ""
 ---
-# Source: gpu-operator/templates/clusterpolicy.yaml
-apiVersion: nvidia.com/v1
-kind: ClusterPolicy
+# Source: gpu-operator/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: cluster-policy
-  namespace: default
+  creationTimestamp: null
+  name: gpu-operator
+  namespace: gpu-operator-resources
   labels:
     app.kubernetes.io/component: "gpu-operator"
-
-spec:
-  operator:
-    defaultRuntime: containerd
-    validator:
-      repository: nvcr.io/nvidia/k8s
-      image: cuda-sample
-      version: vectoradd-cuda10.2
-      imagePullPolicy: IfNotPresent
-  driver:
-    repository: nvcr.io/nvidia
-    image: driver
-    version: 470.82.01
-    imagePullPolicy: IfNotPresent
-    repoConfig:
-      configMapName: ""
-      destinationDir: ""
-    licensingConfig:
-      configMapName: ""
-    tolerations:
-      - effect: NoSchedule
-        key: nvidia.com/gpu
-        operator: Exists
-    nodeSelector:
-      nvidia.com/gpu.present: "true"
-    securityContext:
-      privileged: true
-      seLinuxOptions:
-        level: s0
-  toolkit:
-    repository: nvcr.io/nvidia/k8s
-    image: container-toolkit
-    version: 1.7.2
-    imagePullPolicy: IfNotPresent
-    tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoSchedule
-        key: nvidia.com/gpu
-        operator: Exists
-    nodeSelector:
-      nvidia.com/gpu.present: "true"
-    securityContext:
-      privileged: true
-      seLinuxOptions:
-        level: s0
-  devicePlugin:
-    repository: nvcr.io/nvidia
-    image: k8s-device-plugin
-    version: v0.8.2-ubi8
-    imagePullPolicy: IfNotPresent
-    nodeSelector:
-      nvidia.com/gpu.present: "true"
-    securityContext:
-      privileged: true
-    args:
-      - --mig-strategy=single
-      - --pass-device-specs=true
-      - --fail-on-init-error=true
-      - --device-list-strategy=envvar
-      - --nvidia-driver-root=/run/nvidia/driver
-  dcgmExporter:
-    repository: nvcr.io/nvidia/k8s
-    image: dcgm-exporter
-    version: 2.1.4-2.2.0-ubuntu20.04
-    imagePullPolicy: IfNotPresent
-    args:
-      - -f
-      - /etc/dcgm-exporter/dcp-metrics-included.csv
-  gfd:
-    repository: nvcr.io/nvidia
-    image: gpu-feature-discovery
-    version: v0.4.1
-    imagePullPolicy: IfNotPresent
-    nodeSelector:
-      nvidia.com/gpu.present: "true"
-    migStrategy: single
-    discoveryIntervalSeconds: 60
+    
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - create
+  - watch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  - prometheusrules
+  verbs:
+  - get
+  - list
+  - create
+  - watch
+  - update
+- apiGroups:
+  - nvidia.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - gpu-operator-restricted
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - create
+  - get
+  - update
+  - list
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: gpu-operator/templates/rolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gpu-operator
+  labels:
+    app.kubernetes.io/component: "gpu-operator"
+    
+subjects:
+- kind: ServiceAccount
+  name: gpu-operator
+  namespace: gpu-operator-resources
+- kind: ServiceAccount
+  name: node-feature-discovery
+  namespace: gpu-operator-resources
+roleRef:
+  kind: ClusterRole
+  name: gpu-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: gpu-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gpu-operator
+  namespace: gpu-operator-resources
+  labels:
+    app.kubernetes.io/component: "gpu-operator"

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -251,9 +251,9 @@ spec:
 ---
 apiVersion: v1
 data:
-  clusterpolicy-crd.yaml: |
+  clusterpolicy-crd.yaml: |+
     ---
-    # Source: crds/nvidia.com_clusterpolicies_crd.yaml
+    # Source: gpu-operator/crds/nvidia.com_clusterpolicies_crd.yaml
     ---
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
@@ -271,663 +271,97 @@ data:
         singular: clusterpolicy
       scope: Cluster
       versions:
-        - name: v1
-          schema:
-            openAPIV3Schema:
-              description: ClusterPolicy is the Schema for the clusterpolicies API
-              properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation
+      - name: v1
+        schema:
+          openAPIV3Schema:
+            description: ClusterPolicy is the Schema for the clusterpolicies API
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
                   of an object. Servers should convert recognized schemas to the latest
                   internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                  type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
                   object represents. Servers may infer this from the endpoint the client
                   submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                metadata:
-                  type: object
-                spec:
-                  description: ClusterPolicySpec defines the desired state of ClusterPolicy
-                  properties:
-                    dcgmExporter:
-                      description: DCGMExporter spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: ClusterPolicySpec defines the desired state of ClusterPolicy
+                properties:
+                  daemonsets:
+                    description: Daemonset defines common configuration for all Daemonsets
+                    properties:
+                      priorityClassName:
+                        type: string
+                      tolerations:
+                        description: 'Optional: Set tolerations'
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
                           properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified, allowed
+                                values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies
+                                to. Empty means match all taint keys. If the key is empty,
+                                operator must be Exists; this combination means to match
+                                all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to
+                                the value. Valid operators are Exists and Equal. Defaults
+                                to Equal. Exists is equivalent to wildcard for value,
+                                so that a pod can tolerate all taints of a particular
+                                category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of
+                                time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the taint
+                                forever (do not evict). Zero and negative values will
+                                be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches
+                                to. If the operator is Exists, the value should be empty,
+                                otherwise just a regular string.
+                              type: string
                           type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
-                            type: string
-                          type: array
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                        type: array
+                    type: object
+                  dcgm:
+                    description: DCGM component spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        description: Enabled indicates if deployment of DCGM hostengine
+                          as a separate pod is enabled.
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -935,1134 +369,321 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        licensingConfig:
-                          description: 'Optional: Licensing configuration for vGPU drivers'
-                          properties:
-                            configMapName:
-                              type: string
-                          type: object
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
                               type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
+                          required:
+                          - name
                           type: object
-                        repoConfig:
-                          description: 'Optional: Custom repo configuration for driver container'
-                          properties:
-                            configMapName:
-                              type: string
-                            destinationDir:
-                              type: string
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
+                        type: array
+                      hostPort:
+                        description: 'HostPort represents host port that needs to be bound
+                          for DCGM engine (Default: 5555)'
+                        format: int32
+                        type: integer
+                      image:
+                        description: DCGM image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
                           type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                        type: array
+                      repository:
+                        description: DCGM image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
+                        type: object
+                      version:
+                        description: DCGM image tag
+                        type: string
+                    type: object
+                  dcgmExporter:
+                    description: DCGMExporter spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
                           type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                    devicePlugin:
-                      description: DevicePlugin component spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
-                          properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
+                        type: array
+                      config:
+                        description: 'Optional: Custom metrics configuration for DCGM
+                          exporter'
+                        properties:
+                          name:
+                            description: ConfigMap name with file dcgm-metrics.csv for
+                              metrics to be collected by DCGM exporter
                             type: string
-                          type: array
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                        type: object
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -2070,1134 +691,307 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        licensingConfig:
-                          description: 'Optional: Licensing configuration for vGPU drivers'
-                          properties:
-                            configMapName:
-                              type: string
-                          type: object
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
                               type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
+                          required:
+                          - name
                           type: object
-                        repoConfig:
-                          description: 'Optional: Custom repo configuration for driver container'
-                          properties:
-                            configMapName:
-                              type: string
-                            destinationDir:
-                              type: string
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
+                        type: array
+                      image:
+                        description: DCGM image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
                           type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                        type: array
+                      repository:
+                        description: DCGM image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
+                        type: object
+                      version:
+                        description: DCGM image tag
+                        type: string
+                    type: object
+                  devicePlugin:
+                    description: DevicePlugin component spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
                           type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                    driver:
-                      description: Driver component spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
+                        type: array
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
                           properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
-                            type: string
-                          type: array
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -3205,1138 +999,318 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        licensingConfig:
-                          description: 'Optional: Licensing configuration for vGPU drivers'
-                          properties:
-                            configMapName:
-                              type: string
-                          type: object
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
                               type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
+                          required:
+                          - name
                           type: object
-                        repoConfig:
-                          description: 'Optional: Custom repo configuration for driver container'
-                          properties:
-                            configMapName:
-                              type: string
-                            destinationDir:
-                              type: string
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
+                        type: array
+                      image:
+                        description: DevicePlugin image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
                           type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                        type: array
+                      repository:
+                        description: DevicePlugin image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
+                        type: object
+                      version:
+                        description: DevicePlugin image tag
+                        type: string
+                    type: object
+                  driver:
+                    description: Driver component spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
                           type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                    gfd:
-                      description: GPUFeatureDiscovery spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
-                          properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
+                        type: array
+                      certConfig:
+                        description: 'Optional: Custom certificates configuration for
+                          driver container'
+                        properties:
+                          name:
                             type: string
-                          type: array
-                        discoveryIntervalSeconds:
-                          description: 'Optional: Discovery Interval for GPU feature discovery
-                          plugin'
-                          type: integer
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                        type: object
+                      enabled:
+                        description: Enabled indicates if deployment of driver through
+                          operator is enabled
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -4344,1163 +1318,486 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Driver image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      licensingConfig:
+                        description: 'Optional: Licensing configuration for vGPU drivers'
+                        properties:
+                          configMapName:
+                            type: string
+                          nlsEnabled:
+                            description: NLSEnabled indicates if NLS is used for licensing.
+                            type: boolean
+                        type: object
+                      manager:
+                        description: Manager represents configuration for driver manager
+                          initContainer
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
                                       - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        migStrategy:
-                          description: 'Optional: MigStrategy for GPU feature discovery
-                          plugin'
-                          enum:
-                            - none
-                            - single
-                            - mixed
-                          type: string
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
                               required:
-                                - type
+                              - name
                               type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
-                          type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                            type: array
+                          image:
+                            description: Image represents Driver-Manager image name
+                            pattern: '[a-zA-Z0-9\-]+'
+                            type: string
+                          imagePullPolicy:
+                            description: Image pull policy
+                            type: string
+                          imagePullSecrets:
+                            description: Image pull secrets
+                            items:
+                              type: string
+                            type: array
+                          repository:
+                            description: Repository represents Driver-Manager repository
+                              path
+                            type: string
+                          version:
+                            description: Version represents Driver-Manager image tag(version)
+                            type: string
+                        type: object
+                      rdma:
+                        description: GPUDirectRDMASpec defines the properties for nv_peer_mem
+                          deployment
+                        properties:
+                          enabled:
+                            description: Enabled indicates if GPUDirect RDMA is enabled
+                              through GPU operator
+                            type: boolean
+                          useHostMofed:
+                            description: UseHostMOFED indicates to use MOFED drivers directly
+                              installed on the host to enable GPUDirect RDMA
+                            type: boolean
+                        type: object
+                      repoConfig:
+                        description: 'Optional: Custom repo configuration for driver container'
+                        properties:
+                          configMapName:
+                            type: string
+                        type: object
+                      repository:
+                        description: Driver image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
-                          type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                    operator:
-                      description: Operator component spec
-                      properties:
-                        defaultRuntime:
-                          description: Runtime defines container runtime type
-                          enum:
-                            - docker
-                            - crio
-                            - containerd
-                          type: string
-                        validator:
-                          description: ValidatorSpec describes configuration options for
-                            validation pod
-                          properties:
-                            image:
-                              pattern: '[a-zA-Z0-9\-]+'
-                              type: string
-                            imagePullPolicy:
-                              description: Image pull policy
-                              type: string
-                            imagePullSecrets:
-                              description: Image pull secrets
-                              items:
-                                type: string
-                              type: array
-                            repository:
-                              pattern: '[a-zA-Z0-9\.\-\/]+'
-                              type: string
-                            version:
-                              pattern: '[a-zA-Z0-9\.-]+'
-                              type: string
-                          type: object
-                      required:
-                        - defaultRuntime
-                      type: object
-                    toolkit:
-                      description: Toolkit component spec
-                      properties:
-                        affinity:
-                          description: 'Optional: Set Node affinity'
-                          properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules for
-                                the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: An empty preferred scheduling term matches
-                                      all objects with implicit weight 0 (i.e. it's a no-op).
-                                      A null preferred scheduling term matches no objects
-                                      (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated with
-                                          the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      weight:
-                                        description: Weight associated with matching the
-                                          corresponding nodeSelectorTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - preference
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from
-                                    its node.
-                                  properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector terms.
-                                        The terms are ORed.
-                                      items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them are
-                                          ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: A node selector requirement is
-                                                a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: The label key that the selector
-                                                    applies to.
-                                                  type: string
-                                                operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn, the
-                                                    values array must be non-empty. If the
-                                                    operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the
-                                                    operator is Gt or Lt, the values array
-                                                    must have a single element, which will
-                                                    be interpreted as an integer. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                        type: object
-                                      type: array
-                                  required:
-                                    - nodeSelectorTerms
-                                  type: object
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the affinity expressions specified
-                                    by this field, but it may choose a node that violates
-                                    one or more of the expressions. The node that is most
-                                    preferred is the one with the greatest sum of weights,
-                                    i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified by
-                                    this field are not met at scheduling time, the pod will
-                                    not be scheduled onto the node. If the affinity requirements
-                                    specified by this field cease to be met at some point
-                                    during pod execution (e.g. due to a pod label update),
-                                    the system may or may not try to eventually evict the
-                                    pod from its node. When there are multiple elements,
-                                    the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule pods
-                                    to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node that
-                                    violates one or more of the expressions. The node that
-                                    is most preferred is the one with the greatest sum of
-                                    weights, i.e. for each node that meets all of the scheduling
-                                    requirements (resource request, requiredDuringScheduling
-                                    anti-affinity expressions, etc.), compute a sum by iterating
-                                    through the elements of this field and adding "weight"
-                                    to the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum are
-                                    the most preferred.
-                                  items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: A label query over a set of resources,
-                                              in this case pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The requirements
-                                                  are ANDed.
-                                                items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label key
-                                                        that the selector applies to.
-                                                      type: string
-                                                    operator:
-                                                      description: operator represents a
-                                                        key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists
-                                                        and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: values is an array of
-                                                        string values. If the operator is
-                                                        In or NotIn, the values array must
-                                                        be non-empty. If the operator is
-                                                        Exists or DoesNotExist, the values
-                                                        array must be empty. This array
-                                                        is replaced during a strategic merge
-                                                        patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: matchLabels is a map of {key,value}
-                                                  pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                          namespaces:
-                                            description: namespaces specifies which namespaces
-                                              the labelSelector applies to (matches against);
-                                              null or empty list means "this pod's namespace"
-                                            items:
-                                              type: string
-                                            type: array
-                                          topologyKey:
-                                            description: This pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with the
-                                              pods matching the labelSelector in the specified
-                                              namespaces, where co-located is defined as
-                                              running on a node whose value of the label
-                                              with key topologyKey matches that of any node
-                                              on which any of the selected pods is running.
-                                              Empty topologyKey is not allowed.
-                                            type: string
-                                        required:
-                                          - topologyKey
-                                        type: object
-                                      weight:
-                                        description: weight associated with matching the
-                                          corresponding podAffinityTerm, in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - podAffinityTerm
-                                      - weight
-                                    type: object
-                                  type: array
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the pod
-                                    will not be scheduled onto the node. If the anti-affinity
-                                    requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod
-                                    label update), the system may or may not try to eventually
-                                    evict the pod from its node. When there are multiple
-                                    elements, the lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: Defines a set of pods (namely those matching
-                                      the labelSelector relative to the given namespace(s))
-                                      that this pod should be co-located (affinity) or not
-                                      co-located (anti-affinity) with, where co-located
-                                      is defined as running on a node whose value of the
-                                      label with key <topologyKey> matches that of any node
-                                      on which a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values, a key,
-                                                and an operator that relates the key and
-                                                values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and
-                                                    DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is
-                                              "In", and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey
-                                          matches that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                        args:
-                          description: 'Optional: List of arguments'
-                          items:
+                        type: object
+                      use_ocp_driver_toolkit:
+                        description: UseOpenShiftDriverToolkit indicates if DriverToolkit
+                          image should be used on OpenShift to build and install driver
+                          modules
+                        type: boolean
+                      version:
+                        description: Driver image tag
+                        type: string
+                      virtualTopology:
+                        description: 'Optional: Virtual Topology Daemon configuration
+                          for vGPU drivers'
+                        properties:
+                          config:
+                            description: 'Optional: Config name representing virtual topology
+                              daemon configuration file nvidia-topologyd.conf'
                             type: string
-                          type: array
-                        env:
-                          description: 'Optional: List of environment variables'
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must be a
-                                  C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
+                        type: object
+                    type: object
+                  gfd:
+                    description: GPUFeatureDiscovery spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in the
                                 container and any service environment variables. If a
                                 variable cannot be resolved, the reference in the input
@@ -5508,528 +1805,2110 @@ data:
                                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references
                                 will never be expanded, regardless of whether the variable
                                 exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports metadata.name,
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
                                     metadata.namespace, `metadata.labels[''<KEY>'']`,
                                     `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                     spec.serviceAccountName, status.hostIP, status.podIP,
                                     status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in the
-                                          specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container: only
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
                                     resources limits and requests (limits.cpu, limits.memory,
                                     limits.ephemeral-storage, requests.cpu, requests.memory
                                     and requests.ephemeral-storage) are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                         optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of the
-                                          exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select from.  Must
-                                          be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         TODO: Add other useful fields. apiVersion, kind,
                                         uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its key
-                                          must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          pattern: '[a-zA-Z0-9\-]+'
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy
-                          type: string
-                        imagePullSecrets:
-                          description: Image pull secrets
-                          items:
-                            type: string
-                          type: array
-                        licensingConfig:
-                          description: 'Optional: Licensing configuration for vGPU drivers'
-                          properties:
-                            configMapName:
-                              type: string
-                          type: object
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Node selector to control the selection of nodes (optional)
-                          type: object
-                        podSecurityContext:
-                          description: 'Optional: Pod Security Context'
-                          properties:
-                            fsGroup:
-                              description: "A special supplemental group that applies to
-                              all containers in a pod. Some volume types allow the Kubelet
-                              to change the ownership of that volume to be owned by the
-                              pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                              bit is set (new files created in the volume will be owned
-                              by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                              \n If unset, the Kubelet will not modify the ownership and
-                              permissions of any volume."
-                              format: int64
-                              type: integer
-                            fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of changing
-                              ownership and permission of the volume before being exposed
-                              inside Pod. This field will only apply to volume types which
-                              support fsGroup based ownership(and permissions). It will
-                              have no effect on ephemeral volume types such as: secret,
-                              configmaps and emptydir. Valid values are "OnRootMismatch"
-                              and "Always". If not specified, "Always" is used.'
-                              type: string
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in SecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence for that container.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to all containers.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
-                                  type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
-                                  type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
                               type: object
-                            seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
-                                  will be applied. Valid options are: \n Localhost - a
-                                  profile defined in a file on the node should be used.
-                                  RuntimeDefault - the container runtime default profile
-                                  should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's primary
-                                GID.  If unspecified, no groups will be added to any container.
-                              items:
-                                format: int64
-                                type: integer
-                              type: array
-                            sysctls:
-                              description: Sysctls hold a list of namespaced sysctls used
-                                for the pod. Pods with unsupported sysctls (by the container
-                                runtime) might fail to launch.
-                              items:
-                                description: Sysctl defines a kernel parameter to be set
-                                properties:
-                                  name:
-                                    description: Name of a property to set
-                                    type: string
-                                  value:
-                                    description: Value of a property to set
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options within a container's
-                                SecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
+                          required:
+                          - name
                           type: object
-                        repoConfig:
-                          description: 'Optional: Custom repo configuration for driver container'
-                          properties:
-                            configMapName:
-                              type: string
-                            destinationDir:
-                              type: string
-                          type: object
-                        repository:
-                          pattern: '[a-zA-Z0-9\.\-\/]+'
+                        type: array
+                      image:
+                        description: GFD image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
                           type: string
-                        resources:
-                          description: 'Optional: Define resources requests and limits for
+                        type: array
+                      repository:
+                        description: GFD image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
                           each pod'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of compute
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
                               resources required. If Requests is omitted for a container,
                               it defaults to Limits if that is explicitly specified, otherwise
                               to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        securityContext:
-                          description: 'Optional: Security Context'
-                          properties:
-                            allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether a
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
                               process can gain more privileges than its parent process.
                               This bool directly controls if the no_new_privs flag will
                               be set on the container process. AllowPrivilegeEscalation
                               is true always when the container is: 1) run as Privileged
                               2) has CAP_SYS_ADMIN'
-                              type: boolean
-                            capabilities:
-                              description: The capabilities to add/drop when running containers.
-                                Defaults to the default set of capabilities granted by the
-                                container runtime.
-                              properties:
-                                add:
-                                  description: Added capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                                drop:
-                                  description: Removed capabilities
-                                  items:
-                                    description: Capability represent POSIX capabilities
-                                      type
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              description: Run container in privileged mode. Processes in
-                                privileged containers are essentially equivalent to root
-                                on the host. Defaults to false.
-                              type: boolean
-                            procMount:
-                              description: procMount denotes the type of proc mount to use
-                                for the containers. The default is DefaultProcMount which
-                                uses the container runtime defaults for readonly paths and
-                                masked paths. This requires the ProcMountType feature flag
-                                to be enabled.
-                              type: string
-                            readOnlyRootFilesystem:
-                              description: Whether this container has a read-only root filesystem.
-                                Default is false.
-                              type: boolean
-                            runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be set
-                                in PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              description: Indicates that the container must run as a non-root
-                                user. If true, the Kubelet will validate the image at runtime
-                                to ensure that it does not run as UID 0 (root) and fail
-                                to start the container if it does. If unset or false, no
-                                such validation will be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              type: boolean
-                            runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata if
-                                unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              description: The SELinux context to be applied to the container.
-                                If unspecified, the container runtime will allocate a random
-                                SELinux context for each container.  May also be set in
-                                PodSecurityContext.  If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              properties:
-                                level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
-                                type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
-                                  type: string
-                                user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod & container
-                                level, the container options override the pod options.
-                              properties:
-                                localhostProfile:
-                                  description: localhostProfile indicates a profile defined
-                                    in a file on the node should be used. The profile must
-                                    be preconfigured on the node to work. Must be a descending
-                                    path, relative to the kubelet's configured seccomp profile
-                                    location. Must only be set if type is "Localhost".
-                                  type: string
-                                type:
-                                  description: "type indicates which kind of seccomp profile
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
                                   will be applied. Valid options are: \n Localhost - a
                                   profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile
                                   should be used. Unconfined - no profile should be applied."
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              description: The Windows specific settings applied to all
-                                containers. If unspecified, the options from the PodSecurityContext
-                                will be used. If set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
-                              properties:
-                                gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA admission
-                                    webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec named
-                                    by the GMSACredentialSpecName field.
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of the
-                                    GMSA credential spec to use.
-                                  type: string
-                                runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set in
-                                    PodSecurityContext. If set in both SecurityContext and
-                                    PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
-                                  type: string
-                              type: object
-                          type: object
-                        tolerations:
-                          description: 'Optional: Set tolerations'
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
                             properties:
-                              effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified, allowed
-                                  values are NoSchedule, PreferNoSchedule and NoExecute.
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                              key:
-                                description: Key is the taint key that the toleration applies
-                                  to. Empty means match all taint keys. If the key is empty,
-                                  operator must be Exists; this combination means to match
-                                  all values and all keys.
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
                                 type: string
-                              operator:
-                                description: Operator represents a key's relationship to
-                                  the value. Valid operators are Exists and Equal. Defaults
-                                  to Equal. Exists is equivalent to wildcard for value,
-                                  so that a pod can tolerate all taints of a particular
-                                  category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period of
-                                  time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the taint
-                                  forever (do not evict). Zero and negative values will
-                                  be treated as 0 (evict immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration matches
-                                  to. If the operator is Exists, the value should be empty,
-                                  otherwise just a regular string.
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 type: string
                             type: object
-                          type: array
-                        version:
-                          pattern: '[a-zA-Z0-9\.-]+'
+                        type: object
+                      version:
+                        description: GFD image tag
+                        type: string
+                    type: object
+                  mig:
+                    description: MIG spec
+                    properties:
+                      strategy:
+                        description: 'Optional: MIGStrategy to apply for GFD and Device-Plugin'
+                        enum:
+                        - none
+                        - single
+                        - mixed
+                        type: string
+                    type: object
+                  migManager:
+                    description: MIGManager for configuration to deploy MIG Manager
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
                           type: string
-                      required:
-                        - image
-                        - repository
-                        - version
-                      type: object
-                  required:
-                    - dcgmExporter
-                    - devicePlugin
-                    - driver
-                    - gfd
-                    - operator
-                    - toolkit
-                  type: object
-                status:
-                  description: ClusterPolicyStatus defines the observed state of ClusterPolicy
-                  properties:
-                    state:
-                      enum:
-                        - ignored
-                        - ready
-                        - notReady
-                      type: string
-                  required:
-                    - state
-                  type: object
-              type: object
-          served: true
-          storage: true
-          subresources:
-            status: {}
+                        type: array
+                      config:
+                        description: 'Optional: Custom mig-parted configuration for MIG
+                          Manager container'
+                        properties:
+                          name:
+                            description: ConfigMap name
+                            type: string
+                        type: object
+                      enabled:
+                        description: Enabled indicates if deployment of mig-manager is
+                          enabled
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in the
+                                container and any service environment variables. If a
+                                variable cannot be resolved, the reference in the input
+                                string will be unchanged. The $(VAR_NAME) syntax can be
+                                escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                will never be expanded, regardless of whether the variable
+                                exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
+                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
+                                    resources limits and requests (limits.cpu, limits.memory,
+                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                    and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      gpuClientsConfig:
+                        description: 'Optional: Custom gpu-clients configuration for MIG
+                          Manager container'
+                        properties:
+                          name:
+                            description: ConfigMap name
+                            type: string
+                        type: object
+                      image:
+                        description: mig-manager image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: mig-manager image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
+                          each pod'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
+                              process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag will
+                              be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                  will be applied. Valid options are: \n Localhost - a
+                                  profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile
+                                  should be used. Unconfined - no profile should be applied."
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      version:
+                        description: mig-manager image tag
+                        type: string
+                    type: object
+                  nodeStatusExporter:
+                    description: NodeStatusExporter spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        description: Enabled indicates if deployment of node-status-exporter
+                          is enabled.
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in the
+                                container and any service environment variables. If a
+                                variable cannot be resolved, the reference in the input
+                                string will be unchanged. The $(VAR_NAME) syntax can be
+                                escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                will never be expanded, regardless of whether the variable
+                                exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
+                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
+                                    resources limits and requests (limits.cpu, limits.memory,
+                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                    and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: node-status-exporter image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: node-status-exporter image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
+                          each pod'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
+                              process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag will
+                              be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                  will be applied. Valid options are: \n Localhost - a
+                                  profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile
+                                  should be used. Unconfined - no profile should be applied."
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      version:
+                        description: node-status-exporter image tag
+                        type: string
+                    type: object
+                  operator:
+                    description: Operator component spec
+                    properties:
+                      defaultRuntime:
+                        default: docker
+                        description: Runtime defines container runtime type
+                        enum:
+                        - docker
+                        - crio
+                        - containerd
+                        type: string
+                      initContainer:
+                        description: InitContainerSpec describes configuration for initContainer
+                          image used with all components
+                        properties:
+                          image:
+                            description: Image represents image name
+                            pattern: '[a-zA-Z0-9\-]+'
+                            type: string
+                          imagePullPolicy:
+                            description: Image pull policy
+                            type: string
+                          imagePullSecrets:
+                            description: Image pull secrets
+                            items:
+                              type: string
+                            type: array
+                          repository:
+                            description: Repository represents image repository path
+                            type: string
+                          version:
+                            description: Version represents image tag(version)
+                            type: string
+                        type: object
+                      runtimeClass:
+                        default: nvidia
+                        type: string
+                    required:
+                    - defaultRuntime
+                    type: object
+                  psp:
+                    description: PSP defines spec for handling PodSecurityPolicies
+                    properties:
+                      enabled:
+                        description: Enabled indicates if PodSecurityPolicies needs to
+                          be enabled for all Pods
+                        type: boolean
+                    type: object
+                  toolkit:
+                    description: Toolkit component spec
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        description: Enabled indicates if deployment of container-toolkit
+                          through operator is enabled
+                        type: boolean
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in the
+                                container and any service environment variables. If a
+                                variable cannot be resolved, the reference in the input
+                                string will be unchanged. The $(VAR_NAME) syntax can be
+                                escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                will never be expanded, regardless of whether the variable
+                                exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
+                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
+                                    resources limits and requests (limits.cpu, limits.memory,
+                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                    and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Toolkit image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      repository:
+                        description: Toolkit image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
+                          each pod'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
+                              process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag will
+                              be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                  will be applied. Valid options are: \n Localhost - a
+                                  profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile
+                                  should be used. Unconfined - no profile should be applied."
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      version:
+                        description: Toolkit image tag
+                        type: string
+                    type: object
+                  validator:
+                    description: Validator defines the spec for operator-validator daemonset
+                    properties:
+                      args:
+                        description: 'Optional: List of arguments'
+                        items:
+                          type: string
+                        type: array
+                      cuda:
+                        description: CUDA validator spec
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      driver:
+                        description: Toolkit validator spec
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      env:
+                        description: 'Optional: List of environment variables'
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a
+                                C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in the
+                                container and any service environment variables. If a
+                                variable cannot be resolved, the reference in the input
+                                string will be unchanged. The $(VAR_NAME) syntax can be
+                                escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                                will never be expanded, regardless of whether the variable
+                                exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name,
+                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only
+                                    resources limits and requests (limits.cpu, limits.memory,
+                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                    and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key
+                                        must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Validator image name
+                        pattern: '[a-zA-Z0-9\-]+'
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets
+                        items:
+                          type: string
+                        type: array
+                      plugin:
+                        description: Plugin validator spec
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      repository:
+                        description: Validator image repository
+                        type: string
+                      resources:
+                        description: 'Optional: Define resources requests and limits for
+                          each pod'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified, otherwise
+                              to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: Security Context'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a
+                              process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag will
+                              be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the
+                              container runtime.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes in
+                              privileged containers are essentially equivalent to root
+                              on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to use
+                              for the containers. The default is DefaultProcMount which
+                              uses the container runtime defaults for readonly paths and
+                              masked paths. This requires the ProcMountType feature flag
+                              to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root filesystem.
+                              Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root
+                              user. If true, the Kubelet will validate the image at runtime
+                              to ensure that it does not run as UID 0 (root) and fail
+                              to start the container if it does. If unset or false, no
+                              such validation will be performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata if
+                              unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random
+                              SELinux context for each container.  May also be set in
+                              PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile must
+                                  be preconfigured on the node to work. Must be a descending
+                                  path, relative to the kubelet's configured seccomp profile
+                                  location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                  will be applied. Valid options are: \n Localhost - a
+                                  profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile
+                                  should be used. Unconfined - no profile should be applied."
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set in
+                                  PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      toolkit:
+                        description: Toolkit validator spec
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are expanded
+                                    using the previous defined environment variables in
+                                    the container and any service environment variables.
+                                    If a variable cannot be resolved, the reference in
+                                    the input string will be unchanged. The $(VAR_NAME)
+                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults to
+                                    "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      version:
+                        description: Validator image tag
+                        type: string
+                    type: object
+                required:
+                - daemonsets
+                - dcgm
+                - dcgmExporter
+                - devicePlugin
+                - driver
+                - gfd
+                - nodeStatusExporter
+                - operator
+                - toolkit
+                type: object
+              status:
+                description: ClusterPolicyStatus defines the observed state of ClusterPolicy
+                properties:
+                  state:
+                    description: State indicates status of ClusterPolicy
+                    enum:
+                    - ignored
+                    - ready
+                    - notReady
+                    type: string
+                required:
+                - state
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
     status:
       acceptedNames:
         kind: ""
         plural: ""
       conditions: []
       storedVersions: []
+
 kind: ConfigMap
 metadata:
   annotations:
@@ -6041,545 +3920,239 @@ metadata:
 ---
 apiVersion: v1
 data:
-  gpu-operator-components.yaml: |
-    ---
-    # Source: gpu-operator/templates/resources-namespace.yaml
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: gpu-operator-resources
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-        openshift.io/cluster-monitoring: "true"
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/serviceaccount.yaml
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: gpu-operator-node-feature-discovery
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-    ---
-    # Source: gpu-operator/templates/serviceaccount.yaml
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: gpu-operator
-      namespace: default
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/configmap.yaml
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: gpu-operator-node-feature-discovery
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-    data:
-      nfd-worker.conf: |
-        sources:
-          pci:
-            deviceLabelFields:
-            - vendor
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/rbac.yaml
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: gpu-operator-node-feature-discovery-master
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        # when using command line flag --resource-labels to create extended resources
-        # you will need to uncomment "- nodes/status"
-        # - nodes/status
-        verbs:
-          - get
-          - patch
-          - update
-    ---
-    # Source: gpu-operator/templates/role.yaml
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      creationTimestamp: null
-      name: gpu-operator
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-    rules:
-      - apiGroups:
-          - config.openshift.io
-        resources:
-          - proxies
-        verbs:
-          - get
-      - apiGroups:
-          - rbac.authorization.k8s.io
-        resources:
-          - roles
-          - rolebindings
-          - clusterroles
-          - clusterrolebindings
-        verbs:
-          - '*'
-      - apiGroups:
-          - ""
-        resources:
-          - pods
-          - services
-          - endpoints
-          - persistentvolumeclaims
-          - events
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - nodes
-        verbs:
-          - '*'
-      - apiGroups:
-          - ""
-        resources:
-          - namespaces
-        verbs:
-          - get
-      - apiGroups:
-          - apps
-        resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-        verbs:
-          - '*'
-      - apiGroups:
-          - monitoring.coreos.com
-        resources:
-          - servicemonitors
-        verbs:
-          - get
-          - list
-          - create
-          - watch
-      - apiGroups:
-          - nvidia.com
-        resources:
-          - '*'
-        verbs:
-          - '*'
-      - apiGroups:
-          - scheduling.k8s.io
-        resources:
-          - priorityclasses
-        verbs:
-          - get
-          - list
-          - watch
-          - create
-      - apiGroups:
-          - security.openshift.io
-        resources:
-          - securitycontextconstraints
-        verbs:
-          - '*'
-      - apiGroups:
-          - config.openshift.io
-        resources:
-          - clusterversions
-        verbs:
-          - get
-          - list
-          - watch
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/rbac.yaml
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: gpu-operator-node-feature-discovery-master
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: gpu-operator-node-feature-discovery-master
-    subjects:
-      - kind: ServiceAccount
-        name: gpu-operator-node-feature-discovery
-        namespace: default
-    ---
-    # Source: gpu-operator/templates/rolebinding.yaml
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: gpu-operator
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-    subjects:
-      - kind: ServiceAccount
-        name: gpu-operator
-        namespace: default
-    roleRef:
-      kind: ClusterRole
-      name: gpu-operator
-      apiGroup: rbac.authorization.k8s.io
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml
-    apiVersion: v1
-    kind: Service
-    metadata:
-      name: gpu-operator-node-feature-discovery
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-    spec:
-      type: ClusterIP
-      ports:
-        - name: api
-          port: 8080
-          protocol: TCP
-          targetPort: api
-
-      selector:
-        app.kubernetes.io/component: master
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/daemonset-worker.yaml
-    apiVersion: apps/v1
-    kind: DaemonSet
-    metadata:
-      name: gpu-operator-node-feature-discovery-worker
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: worker
-    spec:
-      selector:
-        matchLabels:
-          app.kubernetes.io/name: node-feature-discovery
-          app.kubernetes.io/instance: gpu-operator
-          app.kubernetes.io/component: worker
-      template:
-        metadata:
-          labels:
-            app.kubernetes.io/name: node-feature-discovery
-            app.kubernetes.io/instance: gpu-operator
-            app.kubernetes.io/component: worker
-        spec:
-          serviceAccountName: gpu-operator-node-feature-discovery
-          securityContext:
-            {}
-          dnsPolicy: ClusterFirstWithHostNet
-          containers:
-            - name: node-feature-discovery-master
-              securityContext:
-                {}
-              image: "quay.io/kubernetes_incubator/node-feature-discovery:v0.6.0"
-              imagePullPolicy: IfNotPresent
-              env:
-                - name: NODE_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-              command:
-                - "nfd-worker"
-              args:
-                - "--sleep-interval=60s"
-                - "--server=gpu-operator-node-feature-discovery:8080"
-              volumeMounts:
-                - name: host-boot
-                  mountPath: "/host-boot"
-                  readOnly: true
-                - name: host-os-release
-                  mountPath: "/host-etc/os-release"
-                  readOnly: true
-                - name: host-sys
-                  mountPath: "/host-sys"
-                - name: source-d
-                  mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
-                - name: features-d
-                  mountPath: "/etc/kubernetes/node-feature-discovery/features.d/"
-                - name: nfd-worker-config
-                  mountPath: "/etc/kubernetes/node-feature-discovery/"
-              resources:
-                {}
-
-          volumes:
-            - name: host-boot
-              hostPath:
-                path: "/boot"
-            - name: host-os-release
-              hostPath:
-                path: "/etc/os-release"
-            - name: host-sys
-              hostPath:
-                path: "/sys"
-            - name: source-d
-              hostPath:
-                path: "/etc/kubernetes/node-feature-discovery/source.d/"
-            - name: features-d
-              hostPath:
-                path: "/etc/kubernetes/node-feature-discovery/features.d/"
-            - name: nfd-worker-config
-              configMap:
-                name: gpu-operator-node-feature-discovery
-          tolerations:
-            - effect: NoSchedule
-              key: node-role.kubernetes.io/master
-              operator: Equal
-              value: ""
-            - effect: NoSchedule
-              key: nvidia.com/gpu
-              operator: Equal
-              value: present
-    ---
-    # Source: gpu-operator/charts/node-feature-discovery/templates/deployment-master.yaml
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: gpu-operator-node-feature-discovery-master
-      namespace: default
-      labels:
-        helm.sh/chart: node-feature-discovery-2.0.0
-        app.kubernetes.io/name: node-feature-discovery
-        app.kubernetes.io/instance: gpu-operator
-        app.kubernetes.io/version: "0.6.0"
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: master
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-          app.kubernetes.io/name: node-feature-discovery
-          app.kubernetes.io/instance: gpu-operator
-          app.kubernetes.io/component: master
-      template:
-        metadata:
-          labels:
-            app.kubernetes.io/name: node-feature-discovery
-            app.kubernetes.io/instance: gpu-operator
-            app.kubernetes.io/component: master
-        spec:
-          serviceAccountName: gpu-operator-node-feature-discovery
-          securityContext:
-            {}
-          containers:
-            - name: node-feature-discovery-master
-              securityContext:
-                {}
-              image: "k8s.gcr.io/nfd/node-feature-discovery:v0.9.0"
-              imagePullPolicy: IfNotPresent
-              ports:
-                - name: api
-                  containerPort: 8080
-                  protocol: TCP
-              env:
-                - name: NODE_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-              command:
-                - "nfd-master"
-              args:
-                - --extra-label-ns=nvidia.com
-              resources:
-                {}
-          affinity:
-            nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - preference:
-                    matchExpressions:
-                      - key: node-role.kubernetes.io/master
-                        operator: In
-                        values:
-                          - ""
-                  weight: 1
-          tolerations:
-            - effect: NoSchedule
-              key: node-role.kubernetes.io/master
-              operator: Equal
-              value: ""
-    ---
-    # Source: gpu-operator/templates/operator.yaml
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: gpu-operator
-      namespace: default
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-
-          app.kubernetes.io/component: "gpu-operator"
-      template:
-        metadata:
-          labels:
-
-            app.kubernetes.io/component: "gpu-operator"
-          annotations:
-            openshift.io/scc: restricted-readonly
-        spec:
-          serviceAccountName: gpu-operator
-          containers:
-            - name: gpu-operator
-              image: nvcr.io/nvidia/gpu-operator:1.6.2
-              imagePullPolicy: IfNotPresent
-              command: ["gpu-operator"]
-              args:
-                - "--zap-time-encoding=epoch"
-              env:
-                - name: WATCH_NAMESPACE
-                  value: ""
-                - name: OPERATOR_NAME
-                  value: "gpu-operator"
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-              volumeMounts:
-                - name: host-os-release
-                  mountPath: "/host-etc/os-release"
-                  readOnly: true
-              readinessProbe:
-                exec:
-                  command: ["stat", "/tmp/operator-sdk-ready"]
-                initialDelaySeconds: 4
-                periodSeconds: 10
-                failureThreshold: 1
-              ports:
-                - containerPort: 60000
-                  name: metrics
-          volumes:
-            - name: host-os-release
-              hostPath:
-                path: "/etc/os-release"
-          affinity:
-            nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - preference:
-                    matchExpressions:
-                      - key: node-role.kubernetes.io/master
-                        operator: In
-                        values:
-                          - ""
-                  weight: 1
-          tolerations:
-            - effect: NoSchedule
-              key: node-role.kubernetes.io/master
-              operator: Equal
-              value: ""
-    ---
-    # Source: gpu-operator/templates/clusterpolicy.yaml
-    apiVersion: nvidia.com/v1
-    kind: ClusterPolicy
-    metadata:
-      name: cluster-policy
-      namespace: default
-      labels:
-        app.kubernetes.io/component: "gpu-operator"
-
-    spec:
-      operator:
-        defaultRuntime: containerd
-        validator:
-          repository: nvcr.io/nvidia/k8s
-          image: cuda-sample
-          version: vectoradd-cuda10.2
-          imagePullPolicy: IfNotPresent
-      driver:
-        repository: nvcr.io/nvidia
-        image: driver
-        version: 470.82.01
-        imagePullPolicy: IfNotPresent
-        repoConfig:
-          configMapName: ""
-          destinationDir: ""
-        licensingConfig:
-          configMapName: ""
-        tolerations:
-          - effect: NoSchedule
-            key: nvidia.com/gpu
-            operator: Exists
-        nodeSelector:
-          nvidia.com/gpu.present: "true"
-        securityContext:
-          privileged: true
-          seLinuxOptions:
-            level: s0
-      toolkit:
-        repository: nvcr.io/nvidia/k8s
-        image: container-toolkit
-        version: 1.7.2
-        imagePullPolicy: IfNotPresent
-        tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
-          - effect: NoSchedule
-            key: nvidia.com/gpu
-            operator: Exists
-        nodeSelector:
-          nvidia.com/gpu.present: "true"
-        securityContext:
-          privileged: true
-          seLinuxOptions:
-            level: s0
-      devicePlugin:
-        repository: nvcr.io/nvidia
-        image: k8s-device-plugin
-        version: v0.8.2-ubi8
-        imagePullPolicy: IfNotPresent
-        nodeSelector:
-          nvidia.com/gpu.present: "true"
-        securityContext:
-          privileged: true
-        args:
-          - --mig-strategy=single
-          - --pass-device-specs=true
-          - --fail-on-init-error=true
-          - --device-list-strategy=envvar
-          - --nvidia-driver-root=/run/nvidia/driver
-      dcgmExporter:
-        repository: nvcr.io/nvidia/k8s
-        image: dcgm-exporter
-        version: 2.1.4-2.2.0-ubuntu20.04
-        imagePullPolicy: IfNotPresent
-        args:
-          - -f
-          - /etc/dcgm-exporter/dcp-metrics-included.csv
-      gfd:
-        repository: nvcr.io/nvidia
-        image: gpu-feature-discovery
-        version: v0.4.1
-        imagePullPolicy: IfNotPresent
-        nodeSelector:
-          nvidia.com/gpu.present: "true"
-        migStrategy: single
-        discoveryIntervalSeconds: 60
+  gpu-operator-components.yaml: "---\n# Source: gpu-operator/templates/resources-namespace.yaml\napiVersion:
+    v1\nkind: Namespace\nmetadata:\n  name: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
+    \"gpu-operator\"\n    openshift.io/cluster-monitoring: \"true\"\n---\n# Source:
+    gpu-operator/charts/node-feature-discovery/templates/clusterrole.yaml\napiVersion:
+    rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: gpu-operator-node-feature-discovery\n
+    \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\nrules:\n- apiGroups:\n  - \"\"\n  resources:\n  - nodes\n  # when using
+    command line flag --resource-labels to create extended resources\n  # you will
+    need to uncomment \"- nodes/status\"\n  # - nodes/status\n  verbs:\n  - get\n
+    \ - patch\n  - update\n  - list\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/clusterrolebinding.yaml\napiVersion:
+    rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  name: gpu-operator-node-feature-discovery\n
+    \ labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n    app.kubernetes.io/name:
+    node-feature-discovery\n    app.kubernetes.io/instance: gpu-operator\n    app.kubernetes.io/version:
+    \"v0.8.2\"\n    app.kubernetes.io/managed-by: Helm\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n
+    \ kind: ClusterRole\n  name: gpu-operator-node-feature-discovery\nsubjects:\n-
+    kind: ServiceAccount\n  name: node-feature-discovery\n  namespace: gpu-operator-resources\n---\n#
+    Source: gpu-operator/charts/node-feature-discovery/templates/master.yaml\napiVersion:
+    apps/v1\nkind: Deployment\nmetadata:\n  name:  gpu-operator-node-feature-discovery-master\n
+    \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\n    role: master\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n
+    \     app.kubernetes.io/name: node-feature-discovery\n      app.kubernetes.io/instance:
+    gpu-operator\n      role: master\n  template:\n    metadata:\n      labels:\n
+    \       app.kubernetes.io/name: node-feature-discovery\n        app.kubernetes.io/instance:
+    gpu-operator\n        role: master\n      annotations:\n        {}\n    spec:\n
+    \     serviceAccountName: node-feature-discovery\n      securityContext:\n        {}\n
+    \     containers:\n        - name: master\n          securityContext:\n            allowPrivilegeEscalation:
+    false\n            capabilities:\n              drop:\n              - ALL\n            readOnlyRootFilesystem:
+    true\n            runAsNonRoot: true\n          image: \"k8s.gcr.io/nfd/node-feature-discovery:v0.8.2\"\n
+    \         imagePullPolicy: IfNotPresent\n          ports:\n          - containerPort:
+    8080\n            name: grpc\n            namespace: gpu-operator-resources\n
+    \         env:\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n
+    \               fieldPath: spec.nodeName\n          command:\n            - \"nfd-master\"\n
+    \         resources:\n            {}\n          args:\n            - \"--extra-label-ns=nvidia.com\"\n##
+    Enable TLS authentication\n## The example below assumes having the root certificate
+    named ca.crt stored in\n## a ConfigMap named nfd-ca-cert, and, the TLS authentication
+    credentials stored\n## in a TLS Secret named nfd-master-cert.\n## Additional hardening
+    can be enabled by specifying --verify-node-name in\n## args, in which case node
+    name will be checked against the worker's\n## TLS certificate.\n#            -
+    \"--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt\"\n#            -
+    \"--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key\"\n#            -
+    \"--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt\"\n#          volumeMounts:\n#
+    \           - name: nfd-ca-cert\n#              mountPath: \"/etc/kubernetes/node-feature-discovery/trust\"\n#
+    \             readOnly: true\n#            - name: nfd-master-cert\n#              mountPath:
+    \"/etc/kubernetes/node-feature-discovery/certs\"\n#              readOnly: true\n#
+    \     volumes:\n#        - name: nfd-ca-cert\n#          configMap:\n#            name:
+    nfd-ca-cert\n#        - name: nfd-master-cert\n#          secret:\n#            secretName:
+    nfd-master-cert\n      affinity:\n        nodeAffinity:\n          preferredDuringSchedulingIgnoredDuringExecution:\n
+    \         - preference:\n              matchExpressions:\n              - key:
+    node-role.kubernetes.io/master\n                operator: In\n                values:\n
+    \               - \"\"\n            weight: 1\n      tolerations:\n        - effect:
+    NoSchedule\n          key: node-role.kubernetes.io/master\n          operator:
+    Equal\n          value: \"\"\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/nfd-worker-conf.yaml\napiVersion:
+    v1\nkind: ConfigMap\nmetadata:\n  name: nfd-worker-conf\n  namespace: gpu-operator-resources\n
+    \ labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n    app.kubernetes.io/name:
+    node-feature-discovery\n    app.kubernetes.io/instance: gpu-operator\n    app.kubernetes.io/version:
+    \"v0.8.2\"\n    app.kubernetes.io/managed-by: Helm\ndata:\n  nfd-worker.conf:
+    |-\n    sources:\n      pci:\n        deviceLabelFields:\n        - vendor\n---\n#
+    Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml\napiVersion:
+    v1\nkind: Service\nmetadata:\n  name: gpu-operator-node-feature-discovery-master\n
+    \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\n    role: master\nspec:\n  type: ClusterIP\n  ports:\n    - port: 8080\n
+    \     targetPort: grpc\n      protocol: TCP\n      name: grpc\n      namespace:
+    gpu-operator-resources\n  selector:\n    app.kubernetes.io/name: node-feature-discovery\n
+    \   app.kubernetes.io/instance: gpu-operator\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/serviceaccount.yaml\napiVersion:
+    v1\nkind: ServiceAccount\nmetadata:\n  name: node-feature-discovery\n  namespace:
+    gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/worker.yaml\napiVersion:
+    apps/v1\nkind: DaemonSet\nmetadata:\n  name:  gpu-operator-node-feature-discovery-worker\n
+    \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
+    \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
+    gpu-operator\n    app.kubernetes.io/version: \"v0.8.2\"\n    app.kubernetes.io/managed-by:
+    Helm\n    role: worker\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name:
+    node-feature-discovery\n      app.kubernetes.io/instance: gpu-operator\n      role:
+    worker\n  template:\n    metadata:\n      labels:\n        app.kubernetes.io/name:
+    node-feature-discovery\n        app.kubernetes.io/instance: gpu-operator\n        role:
+    worker\n      annotations:\n        {}\n    spec:\n      dnsPolicy: ClusterFirstWithHostNet\n
+    \     securityContext:\n        {}\n      containers:\n      - name: worker\n
+    \       securityContext:\n            allowPrivilegeEscalation: false\n            capabilities:\n
+    \             drop:\n              - ALL\n            readOnlyRootFilesystem:
+    true\n            runAsNonRoot: true\n        image: \"k8s.gcr.io/nfd/node-feature-discovery:v0.8.2\"\n
+    \       imagePullPolicy: IfNotPresent\n        env:\n        - name: NODE_NAME\n
+    \         valueFrom:\n            fieldRef:\n              fieldPath: spec.nodeName\n
+    \       resources:\n            {}\n        command:\n        - \"nfd-worker\"\n
+    \       args:\n        - \"--sleep-interval=60s\"\n        - \"--server=gpu-operator-node-feature-discovery-master:8080\"\n##
+    Enable TLS authentication (1/3)\n## The example below assumes having the root
+    certificate named ca.crt stored in\n## a ConfigMap named nfd-ca-cert, and, the
+    TLS authentication credentials stored\n## in a TLS Secret named nfd-worker-cert\n#
+    \         - \"--ca-file=/etc/kubernetes/node-feature-discovery/trust/ca.crt\"\n#
+    \         - \"--key-file=/etc/kubernetes/node-feature-discovery/certs/tls.key\"\n#
+    \         - \"--cert-file=/etc/kubernetes/node-feature-discovery/certs/tls.crt\"\n
+    \       volumeMounts:\n        - name: host-boot\n          mountPath: \"/host-boot\"\n
+    \         readOnly: true\n        - name: host-os-release\n          mountPath:
+    \"/host-etc/os-release\"\n          readOnly: true\n        - name: host-sys\n
+    \         mountPath: \"/host-sys\"\n          readOnly: true\n        - name:
+    source-d\n          mountPath: \"/etc/kubernetes/node-feature-discovery/source.d/\"\n
+    \         readOnly: true\n        - name: features-d\n          mountPath: \"/etc/kubernetes/node-feature-discovery/features.d/\"\n
+    \         readOnly: true\n        - name: nfd-worker-conf\n          mountPath:
+    \"/etc/kubernetes/node-feature-discovery\"\n          readOnly: true\n## Enable
+    TLS authentication (2/3)\n#        - name: nfd-ca-cert\n#          mountPath:
+    \"/etc/kubernetes/node-feature-discovery/trust\"\n#          readOnly: true\n#
+    \       - name: nfd-worker-cert\n#          mountPath: \"/etc/kubernetes/node-feature-discovery/certs\"\n#
+    \         readOnly: true\n      volumes:\n        - name: host-boot\n          hostPath:\n
+    \           path: \"/boot\"\n        - name: host-os-release\n          hostPath:\n
+    \           path: \"/etc/os-release\"\n        - name: host-sys\n          hostPath:\n
+    \           path: \"/sys\"\n        - name: source-d\n          hostPath:\n            path:
+    \"/etc/kubernetes/node-feature-discovery/source.d/\"\n        - name: features-d\n
+    \         hostPath:\n            path: \"/etc/kubernetes/node-feature-discovery/features.d/\"\n
+    \       - name: nfd-worker-conf\n          configMap:\n            name: nfd-worker-conf\n
+    \           namespace: gpu-operator-resources\n            items:\n              -
+    key: nfd-worker.conf\n                path: nfd-worker.conf\n## Enable TLS authentication
+    (3/3)\n#        - name: nfd-ca-cert\n#          configMap:\n#            name:
+    nfd-ca-cert\n#        - name: nfd-worker-cert\n#          secret:\n#            secretName:
+    nfd-worker-cert\n      tolerations:\n        - effect: NoSchedule\n          key:
+    node-role.kubernetes.io/master\n          operator: Equal\n          value: \"\"\n
+    \       - effect: NoSchedule\n          key: nvidia.com/gpu\n          operator:
+    Equal\n          value: present\n---\n# Source: gpu-operator/templates/clusterpolicy.yaml\napiVersion:
+    nvidia.com/v1\nkind: ClusterPolicy\nmetadata:\n  name: cluster-policy\n  namespace:
+    gpu-operator-resources\n  labels:\n    app.kubernetes.io/component: \"gpu-operator\"\n
+    \   \nspec:\n  operator:\n    defaultRuntime: docker\n    runtimeClass: nvidia\n
+    \   initContainer:\n      repository: nvcr.io/nvidia\n      image: cuda\n      version:
+    11.4.2-base-ubi8\n      imagePullPolicy: IfNotPresent\n  daemonsets:\n    tolerations:
+    \n      - effect: NoSchedule\n        key: nvidia.com/gpu\n        operator: Exists\n
+    \   priorityClassName: system-node-critical\n  validator:\n    repository: nvcr.io/nvidia/cloud-native\n
+    \   image: gpu-operator-validator\n    version: v1.9.0\n    imagePullPolicy: IfNotPresent\n
+    \   securityContext: \n      privileged: true\n      seLinuxOptions:\n        level:
+    s0\n    plugin:\n      env: \n        - name: WITH_WORKLOAD\n          value:
+    \"true\"\n  mig:\n    strategy: single\n  psp:\n    enabled: false\n  driver:\n
+    \   enabled: true\n    repository: nvcr.io/nvidia\n    image: driver\n    version:
+    470.82.01\n    imagePullPolicy: IfNotPresent\n    rdma:\n      enabled: false\n
+    \     useHostMofed: false\n    manager:\n      repository: nvcr.io/nvidia/cloud-native\n
+    \     image: k8s-driver-manager\n      version: v0.2.0\n      imagePullPolicy:
+    IfNotPresent\n      env: \n        - name: ENABLE_AUTO_DRAIN\n          value:
+    \"true\"\n        - name: DRAIN_USE_FORCE\n          value: \"false\"\n        -
+    name: DRAIN_POD_SELECTOR_LABEL\n          value: \"\"\n        - name: DRAIN_TIMEOUT_SECONDS\n
+    \         value: 0s\n        - name: DRAIN_DELETE_EMPTYDIR_DATA\n          value:
+    \"false\"\n    repoConfig: \n      configMapName: \"\"\n    certConfig: \n      name:
+    \"\"\n    licensingConfig: \n      configMapName: \"\"\n      nlsEnabled: false\n
+    \   virtualTopology: \n      config: \"\"\n    securityContext: \n      privileged:
+    true\n      seLinuxOptions:\n        level: s0\n  toolkit:\n    enabled: true\n
+    \   repository: nvcr.io/nvidia/k8s\n    image: container-toolkit\n    version:
+    1.7.2-ubuntu18.04\n    imagePullPolicy: IfNotPresent\n    securityContext: \n
+    \     privileged: true\n      seLinuxOptions:\n        level: s0\n  devicePlugin:\n
+    \   repository: nvcr.io/nvidia\n    image: k8s-device-plugin\n    version: v0.10.0-ubi8\n
+    \   imagePullPolicy: IfNotPresent\n    securityContext: \n      privileged: true\n
+    \   env: \n      - name: PASS_DEVICE_SPECS\n        value: \"true\"\n      - name:
+    FAIL_ON_INIT_ERROR\n        value: \"true\"\n      - name: DEVICE_LIST_STRATEGY\n
+    \       value: envvar\n      - name: DEVICE_ID_STRATEGY\n        value: uuid\n
+    \     - name: NVIDIA_VISIBLE_DEVICES\n        value: all\n      - name: NVIDIA_DRIVER_CAPABILITIES\n
+    \       value: all\n  dcgm:\n    enabled: true\n    repository: nvcr.io/nvidia/cloud-native\n
+    \   image: dcgm\n    version: 2.3.1-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
+    \   hostPort: 5555\n  dcgmExporter:\n    repository: nvcr.io/nvidia/k8s\n    image:
+    dcgm-exporter\n    version: 2.3.1-2.6.0-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
+    \   env: \n      - name: DCGM_EXPORTER_LISTEN\n        value: :9400\n      - name:
+    DCGM_EXPORTER_KUBERNETES\n        value: \"true\"\n      - name: DCGM_EXPORTER_COLLECTORS\n
+    \       value: /etc/dcgm-exporter/dcp-metrics-included.csv\n  gfd:\n    repository:
+    nvcr.io/nvidia\n    image: gpu-feature-discovery\n    version: v0.4.1\n    imagePullPolicy:
+    IfNotPresent\n    env: \n      - name: GFD_SLEEP_INTERVAL\n        value: 60s\n
+    \     - name: GFD_FAIL_ON_INIT_ERROR\n        value: \"true\"\n  migManager:\n
+    \   enabled: true\n    repository: nvcr.io/nvidia/cloud-native\n    image: k8s-mig-manager\n
+    \   version: v0.2.0-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n    securityContext:
+    \n      privileged: true\n    env: \n      - name: WITH_REBOOT\n        value:
+    \"false\"\n    config: \n      name: \"\"\n    gpuClientsConfig: \n      name:
+    \"\"\n  nodeStatusExporter:\n    enabled: false\n    repository: nvcr.io/nvidia/cloud-native\n
+    \   image: gpu-operator-validator\n    version: v1.9.0\n    imagePullPolicy: IfNotPresent\n---\n#
+    Source: gpu-operator/templates/operator.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n
+    \ name: gpu-operator\n  namespace: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
+    \"gpu-operator\"\n    \nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n
+    \     \n      app.kubernetes.io/component: \"gpu-operator\"\n      app: \"gpu-operator\"\n
+    \ template:\n    metadata:\n      labels:\n        \n        app.kubernetes.io/component:
+    \"gpu-operator\"\n        app: \"gpu-operator\"\n      annotations:\n        openshift.io/scc:
+    restricted-readonly\n    spec:\n      serviceAccountName: gpu-operator\n      priorityClassName:
+    system-node-critical\n      containers:\n      - name: gpu-operator\n        image:
+    nvcr.io/nvidia/gpu-operator:v1.9.0\n        imagePullPolicy: IfNotPresent\n        command:
+    [\"gpu-operator\"]\n        args:\n        - --leader-elect\n        env:\n        -
+    name: WATCH_NAMESPACE\n          value: \"\"\n        - name: OPERATOR_NAMESPACE\n
+    \         valueFrom:\n            fieldRef:\n              fieldPath: metadata.namespace\n
+    \       volumeMounts:\n          - name: host-os-release\n            mountPath:
+    \"/host-etc/os-release\"\n            readOnly: true\n        livenessProbe:\n
+    \         httpGet:\n            path: /healthz\n            port: 8081\n          initialDelaySeconds:
+    15\n          periodSeconds: 20\n        readinessProbe:\n          httpGet:\n
+    \           path: /readyz\n            port: 8081\n          initialDelaySeconds:
+    5\n          periodSeconds: 10\n        resources:\n          limits:\n            cpu:
+    500m\n            memory: 350Mi\n          requests:\n            cpu: 200m\n
+    \           memory: 100Mi\n        ports:\n          - name: metrics\n            containerPort:
+    8080\n      volumes:\n        - name: host-os-release\n          hostPath:\n            path:
+    \"/etc/os-release\"\n      affinity:\n        nodeAffinity:\n          preferredDuringSchedulingIgnoredDuringExecution:\n
+    \         - preference:\n              matchExpressions:\n              - key:
+    node-role.kubernetes.io/master\n                operator: In\n                values:\n
+    \               - \"\"\n            weight: 1\n      tolerations:\n        - effect:
+    NoSchedule\n          key: node-role.kubernetes.io/master\n          operator:
+    Equal\n          value: \"\"\n---\n# Source: gpu-operator/templates/role.yaml\napiVersion:
+    rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  creationTimestamp:
+    null\n  name: gpu-operator\n  namespace: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
+    \"gpu-operator\"\n    \nrules:\n- apiGroups:\n  - config.openshift.io\n  resources:\n
+    \ - proxies\n  verbs:\n  - get\n- apiGroups:\n  - rbac.authorization.k8s.io\n
+    \ resources:\n  - roles\n  - rolebindings\n  - clusterroles\n  - clusterrolebindings\n
+    \ verbs:\n  - '*'\n- apiGroups:\n  - \"\"\n  resources:\n  - pods\n  - services\n
+    \ - endpoints\n  - persistentvolumeclaims\n  - events\n  - configmaps\n  - secrets\n
+    \ - serviceaccounts\n  - nodes\n  verbs:\n  - '*'\n- apiGroups:\n  - \"\"\n  resources:\n
+    \ - namespaces\n  verbs:\n  - get\n  - list\n  - create\n  - watch\n  - update\n-
+    apiGroups:\n  - apps\n  resources:\n  - deployments\n  - daemonsets\n  - replicasets\n
+    \ - statefulsets\n  verbs:\n  - '*'\n- apiGroups:\n  - monitoring.coreos.com\n
+    \ resources:\n  - servicemonitors\n  - prometheusrules\n  verbs:\n  - get\n  -
+    list\n  - create\n  - watch\n  - update\n- apiGroups:\n  - nvidia.com\n  resources:\n
+    \ - '*'\n  verbs:\n  - '*'\n- apiGroups:\n  - scheduling.k8s.io\n  resources:\n
+    \ - priorityclasses\n  verbs:\n  - get\n  - list\n  - watch\n  - create\n- apiGroups:\n
+    \ - security.openshift.io\n  resources:\n  - securitycontextconstraints\n  verbs:\n
+    \ - '*'\n- apiGroups:\n  - policy\n  resources:\n  - podsecuritypolicies\n  verbs:\n
+    \ - use\n  resourceNames:\n  - gpu-operator-restricted\n- apiGroups:\n  - policy\n
+    \ resources:\n  - podsecuritypolicies\n  verbs:\n  - create\n  - get\n  - update\n
+    \ - list\n- apiGroups:\n  - config.openshift.io\n  resources:\n  - clusterversions\n
+    \ verbs:\n  - get\n  - list\n  - watch\n- apiGroups:\n  - \"\"\n  - coordination.k8s.io\n
+    \ resources:\n  - configmaps\n  - leases\n  verbs:\n  - get\n  - list\n  - watch\n
+    \ - create\n  - update\n  - patch\n  - delete\n- apiGroups:\n  - node.k8s.io\n
+    \ resources:\n  - runtimeclasses\n  verbs:\n  - get\n  - list\n  - create\n  -
+    update\n  - watch\n- apiGroups:\n  - image.openshift.io\n  resources:\n  - imagestreams\n
+    \ verbs:\n  - get\n  - list\n  - watch\n---\n# Source: gpu-operator/templates/rolebinding.yaml\nkind:
+    ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name:
+    gpu-operator\n  labels:\n    app.kubernetes.io/component: \"gpu-operator\"\n    \nsubjects:\n-
+    kind: ServiceAccount\n  name: gpu-operator\n  namespace: gpu-operator-resources\n-
+    kind: ServiceAccount\n  name: node-feature-discovery\n  namespace: gpu-operator-resources\nroleRef:\n
+    \ kind: ClusterRole\n  name: gpu-operator\n  apiGroup: rbac.authorization.k8s.io\n---\n#
+    Source: gpu-operator/templates/serviceaccount.yaml\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n
+    \ name: gpu-operator\n  namespace: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
+    \"gpu-operator\"\n"
 kind: ConfigMap
 metadata:
   annotations:


### PR DESCRIPTION
**What type of PR is this?**:

/kind cleanup

**What this PR does / why we need it**:

Updates the nvidia-gpu flavor to use the current release of the gpu-operator. Adds a script under `hack/` that automates this by templating and reassembling the helm chart. I ran the script in-place to create the PR.

**Which issue(s) this PR fixes**:

Fixes #1929
Refs #1254

**Special notes for your reviewer**:

I reverse-engineered how we got from the Helm chart to the kustomize-able files we have in the flavor directory. I think the script is doing it correctly and idempotently, but if @shysank can also take a look that would be great.

I tested locally by running the GPU e2e test and things look happy.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
