### PR TITLE
Make network interface reconcile/delete async

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -116,6 +116,8 @@ const (
 	RoleAssignmentReadyCondition clusterv1.ConditionType = "RoleAssignmentReady"
 	// DisksReadyCondition means the disks exist and are ready to be used.
 	DisksReadyCondition clusterv1.ConditionType = "DisksReady"
+	// NetworkInterfaceReadyCondition means the network interfaces exist and are ready to be used.
+	NetworkInterfaceReadyCondition clusterv1.ConditionType = "NetworkInterfacesReady"
 
 	// CreatingReason means the resource is being created.
 	CreatingReason = "Creating"

--- a/azure/services/networkinterfaces/client.go
+++ b/azure/services/networkinterfaces/client.go
@@ -18,25 +18,34 @@ package networkinterfaces
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest"
+	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pkg/errors"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk.
-type Client interface {
-	Get(context.Context, string, string) (network.Interface, error)
-	CreateOrUpdate(context.Context, string, string, network.Interface) error
-	Delete(context.Context, string, string) error
-}
+type (
+	// Client wraps go-sdk.
+	Client interface {
+		Get(context.Context, azure.ResourceSpecGetter) (result interface{}, err error)
+		CreateOrUpdateAsync(context.Context, azure.ResourceSpecGetter, interface{}) (result interface{}, future azureautorest.FutureAPI, err error)
+		DeleteAsync(context.Context, azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error)
+		IsDone(context.Context, azureautorest.FutureAPI) (isDone bool, err error)
+		Result(context.Context, azureautorest.FutureAPI, string) (result interface{}, err error)
+	}
 
-// AzureClient contains the Azure go-sdk Client.
-type AzureClient struct {
-	interfaces network.InterfacesClient
-}
+	// AzureClient contains the Azure go-sdk Client.
+	AzureClient struct {
+		interfaces network.InterfacesClient
+	}
+)
 
 var _ Client = &AzureClient{}
 
@@ -53,44 +62,114 @@ func newInterfacesClient(subscriptionID string, baseURI string, authorizer autor
 	return nicClient
 }
 
-// Get gets information about the specified network interface.
-func (ac *AzureClient) Get(ctx context.Context, resourceGroupName, nicName string) (network.Interface, error) {
+// Get gets the specified network interface.
+func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (result interface{}, err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.Get")
 	defer done()
 
-	return ac.interfaces.Get(ctx, resourceGroupName, nicName, "")
+	return ac.interfaces.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), "")
 }
 
-// CreateOrUpdate creates or updates a network interface.
-func (ac *AzureClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, nicName string, nic network.Interface) error {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.CreateOrUpdate")
+// CreateOrUpdateAsync creates or updates a network interface asynchronously.
+// It sends a PUT request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// progress of the operation.
+func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.CreateOrUpdateAsync")
 	defer done()
 
-	future, err := ac.interfaces.CreateOrUpdate(ctx, resourceGroupName, nicName, nic)
-	if err != nil {
-		return err
+	networkInterface, ok := parameters.(network.Interface)
+	if !ok {
+		return nil, nil, errors.Errorf("%T is not a network.Interface", parameters)
 	}
-	err = future.WaitForCompletionRef(ctx, ac.interfaces.Client)
+
+	createFuture, err := ac.interfaces.CreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), networkInterface)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	_, err = future.Result(ac.interfaces)
-	return err
+
+	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
+	defer cancel()
+
+	err = createFuture.WaitForCompletionRef(ctx, ac.interfaces.Client)
+	if err != nil {
+		// if an error occurs, return the future.
+		// this means the long-running operation didn't finish in the specified timeout.
+		return nil, &createFuture, err
+	}
+
+	result, err = createFuture.Result(ac.interfaces)
+	// if the operation completed, return a nil future
+	return result, nil, err
 }
 
-// Delete deletes the specified network interface.
-func (ac *AzureClient) Delete(ctx context.Context, resourceGroupName, nicName string) error {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.Delete")
+// DeleteAsync deletes a network interface asynchronously. DeleteAsync sends a DELETE
+// request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// progress of the operation.
+func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.DeleteAsync")
 	defer done()
 
-	future, err := ac.interfaces.Delete(ctx, resourceGroupName, nicName)
+	deleteFuture, err := ac.interfaces.Delete(ctx, spec.ResourceGroupName(), spec.ResourceName())
 	if err != nil {
-		return err
+		return nil, err
 	}
-	err = future.WaitForCompletionRef(ctx, ac.interfaces.Client)
+
+	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
+	defer cancel()
+
+	err = deleteFuture.WaitForCompletionRef(ctx, ac.interfaces.Client)
 	if err != nil {
-		return err
+		// if an error occurs, return the future.
+		// this means the long-running operation didn't finish in the specified timeout.
+		return &deleteFuture, err
 	}
-	_, err = future.Result(ac.interfaces)
-	return err
+	_, err = deleteFuture.Result(ac.interfaces)
+	// if the operation completed, return a nil future.
+	return nil, err
+}
+
+// IsDone returns true if the long-running operation has completed.
+func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.IsDone")
+	defer done()
+
+	isDone, err = future.DoneWithContext(ctx, ac.interfaces)
+	if err != nil {
+		return false, errors.Wrap(err, "failed checking if the operation was complete")
+	}
+
+	return isDone, nil
+}
+
+// Result fetches the result of a long-running operation future.
+func (ac *AzureClient) Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error) {
+	_, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.Result")
+	defer done()
+
+	if future == nil {
+		return nil, errors.Errorf("cannot get result from nil future")
+	}
+
+	switch futureType {
+	case infrav1.PutFuture:
+		// Marshal and Unmarshal the future to put it into the correct future type so we can access the Result function.
+		// Unfortunately the FutureAPI can't be casted directly to InterfacesCreateOrUpdateFuture because it is a azureautorest.Future, which doesn't implement the Result function. See PR #1686 for discussion on alternatives.
+		// It was converted back to a generic azureautorest.Future from the CAPZ infrav1.Future type stored in Status: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/converters/futures.go#L49.
+		var createFuture *network.InterfacesCreateOrUpdateFuture
+		jsonData, err := future.MarshalJSON()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to marshal future")
+		}
+		if err := json.Unmarshal(jsonData, &createFuture); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal future data")
+		}
+		return (*createFuture).Result(ac.interfaces)
+
+	case infrav1.DeleteFuture:
+		// Delete does not return a result network interface
+		return nil, nil
+
+	default:
+		return nil, errors.Errorf("unknown future type %q", futureType)
+	}
 }

--- a/azure/services/networkinterfaces/mock_networkinterfaces/client_mock.go
+++ b/azure/services/networkinterfaces/mock_networkinterfaces/client_mock.go
@@ -24,8 +24,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	azure "github.com/Azure/go-autorest/autorest/azure"
 	gomock "github.com/golang/mock/gomock"
+	azure0 "sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // MockClient is a mock of Client interface.
@@ -51,45 +52,78 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreateOrUpdate mocks base method.
-func (m *MockClient) CreateOrUpdate(arg0 context.Context, arg1, arg2 string, arg3 network.Interface) error {
+// CreateOrUpdateAsync mocks base method.
+func (m *MockClient) CreateOrUpdateAsync(arg0 context.Context, arg1 azure0.ResourceSpecGetter, arg2 interface{}) (interface{}, azure.FutureAPI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", arg0, arg1, arg2)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(azure.FutureAPI)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// CreateOrUpdate indicates an expected call of CreateOrUpdate.
-func (mr *MockClientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
+func (mr *MockClientMockRecorder) CreateOrUpdateAsync(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockClient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockClient)(nil).CreateOrUpdateAsync), arg0, arg1, arg2)
 }
 
-// Delete mocks base method.
-func (m *MockClient) Delete(arg0 context.Context, arg1, arg2 string) error {
+// DeleteAsync mocks base method.
+func (m *MockClient) DeleteAsync(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (azure.FutureAPI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "DeleteAsync", arg0, arg1)
+	ret0, _ := ret[0].(azure.FutureAPI)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// Delete indicates an expected call of Delete.
-func (mr *MockClientMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+// DeleteAsync indicates an expected call of DeleteAsync.
+func (mr *MockClientMockRecorder) DeleteAsync(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*MockClient)(nil).DeleteAsync), arg0, arg1)
 }
 
 // Get mocks base method.
-func (m *MockClient) Get(arg0 context.Context, arg1, arg2 string) (network.Interface, error) {
+func (m *MockClient) Get(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
-	ret0, _ := ret[0].(network.Interface)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), arg0, arg1)
+}
+
+// IsDone mocks base method.
+func (m *MockClient) IsDone(arg0 context.Context, arg1 azure.FutureAPI) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDone", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsDone indicates an expected call of IsDone.
+func (mr *MockClientMockRecorder) IsDone(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDone", reflect.TypeOf((*MockClient)(nil).IsDone), arg0, arg1)
+}
+
+// Result mocks base method.
+func (m *MockClient) Result(arg0 context.Context, arg1 azure.FutureAPI, arg2 string) (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Result", arg0, arg1, arg2)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Result indicates an expected call of Result.
+func (mr *MockClientMockRecorder) Result(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Result", reflect.TypeOf((*MockClient)(nil).Result), arg0, arg1, arg2)
 }

--- a/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
+++ b/azure/services/networkinterfaces/mock_networkinterfaces/networkinterfaces_mock.go
@@ -27,6 +27,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
+	v1beta10 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 // MockNICScope is a mock of NICScope interface.
@@ -178,6 +179,18 @@ func (mr *MockNICScopeMockRecorder) ClusterName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterName", reflect.TypeOf((*MockNICScope)(nil).ClusterName))
 }
 
+// DeleteLongRunningOperationState mocks base method.
+func (m *MockNICScope) DeleteLongRunningOperationState(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeleteLongRunningOperationState", arg0, arg1)
+}
+
+// DeleteLongRunningOperationState indicates an expected call of DeleteLongRunningOperationState.
+func (mr *MockNICScopeMockRecorder) DeleteLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockNICScope)(nil).DeleteLongRunningOperationState), arg0, arg1)
+}
+
 // FailureDomains mocks base method.
 func (m *MockNICScope) FailureDomains() []string {
 	m.ctrl.T.Helper()
@@ -190,6 +203,20 @@ func (m *MockNICScope) FailureDomains() []string {
 func (mr *MockNICScopeMockRecorder) FailureDomains() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockNICScope)(nil).FailureDomains))
+}
+
+// GetLongRunningOperationState mocks base method.
+func (m *MockNICScope) GetLongRunningOperationState(arg0, arg1 string) *v1beta1.Future {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLongRunningOperationState", arg0, arg1)
+	ret0, _ := ret[0].(*v1beta1.Future)
+	return ret0
+}
+
+// GetLongRunningOperationState indicates an expected call of GetLongRunningOperationState.
+func (mr *MockNICScopeMockRecorder) GetLongRunningOperationState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockNICScope)(nil).GetLongRunningOperationState), arg0, arg1)
 }
 
 // HashKey mocks base method.
@@ -221,10 +248,10 @@ func (mr *MockNICScopeMockRecorder) Location() *gomock.Call {
 }
 
 // NICSpecs mocks base method.
-func (m *MockNICScope) NICSpecs() []azure.NICSpec {
+func (m *MockNICScope) NICSpecs() []azure.ResourceSpecGetter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NICSpecs")
-	ret0, _ := ret[0].([]azure.NICSpec)
+	ret0, _ := ret[0].([]azure.ResourceSpecGetter)
 	return ret0
 }
 
@@ -246,6 +273,18 @@ func (m *MockNICScope) ResourceGroup() string {
 func (mr *MockNICScopeMockRecorder) ResourceGroup() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockNICScope)(nil).ResourceGroup))
+}
+
+// SetLongRunningOperationState mocks base method.
+func (m *MockNICScope) SetLongRunningOperationState(arg0 *v1beta1.Future) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLongRunningOperationState", arg0)
+}
+
+// SetLongRunningOperationState indicates an expected call of SetLongRunningOperationState.
+func (mr *MockNICScopeMockRecorder) SetLongRunningOperationState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLongRunningOperationState", reflect.TypeOf((*MockNICScope)(nil).SetLongRunningOperationState), arg0)
 }
 
 // SubscriptionID mocks base method.
@@ -274,4 +313,40 @@ func (m *MockNICScope) TenantID() string {
 func (mr *MockNICScopeMockRecorder) TenantID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockNICScope)(nil).TenantID))
+}
+
+// UpdateDeleteStatus mocks base method.
+func (m *MockNICScope) UpdateDeleteStatus(arg0 v1beta10.ConditionType, arg1 string, arg2 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateDeleteStatus", arg0, arg1, arg2)
+}
+
+// UpdateDeleteStatus indicates an expected call of UpdateDeleteStatus.
+func (mr *MockNICScopeMockRecorder) UpdateDeleteStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeleteStatus", reflect.TypeOf((*MockNICScope)(nil).UpdateDeleteStatus), arg0, arg1, arg2)
+}
+
+// UpdatePatchStatus mocks base method.
+func (m *MockNICScope) UpdatePatchStatus(arg0 v1beta10.ConditionType, arg1 string, arg2 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatePatchStatus", arg0, arg1, arg2)
+}
+
+// UpdatePatchStatus indicates an expected call of UpdatePatchStatus.
+func (mr *MockNICScopeMockRecorder) UpdatePatchStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePatchStatus", reflect.TypeOf((*MockNICScope)(nil).UpdatePatchStatus), arg0, arg1, arg2)
+}
+
+// UpdatePutStatus mocks base method.
+func (m *MockNICScope) UpdatePutStatus(arg0 v1beta10.ConditionType, arg1 string, arg2 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatePutStatus", arg0, arg1, arg2)
+}
+
+// UpdatePutStatus indicates an expected call of UpdatePutStatus.
+func (mr *MockNICScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockNICScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
 }

--- a/azure/services/networkinterfaces/spec.go
+++ b/azure/services/networkinterfaces/spec.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkinterfaces
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
+)
+
+// NICSpec defines the specification for a Network Interface.
+type NICSpec struct {
+	Name                      string
+	ResourceGroup             string
+	Location                  string
+	SubscriptionID            string
+	MachineName               string
+	SubnetName                string
+	VNetName                  string
+	VNetResourceGroup         string
+	StaticIPAddress           string
+	PublicLBName              string
+	PublicLBAddressPoolName   string
+	PublicLBNATRuleName       string
+	InternalLBName            string
+	InternalLBAddressPoolName string
+	PublicIPName              string
+	AcceleratedNetworking     *bool
+	IPv6Enabled               bool
+	EnableIPForwarding        bool
+	SKU                       *resourceskus.SKU
+}
+
+// ResourceName returns the name of the network interface.
+func (s *NICSpec) ResourceName() string {
+	return s.Name
+}
+
+// ResourceGroupName returns the name of the resource group.
+func (s *NICSpec) ResourceGroupName() string {
+	return s.ResourceGroup
+}
+
+// OwnerResourceName is a no-op for network interfaces.
+func (s *NICSpec) OwnerResourceName() string {
+	return ""
+}
+
+// Parameters returns the parameters for the network interface.
+func (s *NICSpec) Parameters(existing interface{}) (parameters interface{}, err error) {
+	if existing != nil {
+		if _, ok := existing.(network.Interface); !ok {
+			return nil, errors.Errorf("%T is not a network.Interface", existing)
+		}
+		// network interface already exists
+		return nil, nil
+	}
+
+	nicConfig := &network.InterfaceIPConfigurationPropertiesFormat{}
+
+	subnet := &network.Subnet{
+		ID: to.StringPtr(azure.SubnetID(s.SubscriptionID, s.VNetResourceGroup, s.VNetName, s.SubnetName)),
+	}
+	nicConfig.Subnet = subnet
+
+	nicConfig.PrivateIPAllocationMethod = network.IPAllocationMethodDynamic
+	if s.StaticIPAddress != "" {
+		nicConfig.PrivateIPAllocationMethod = network.IPAllocationMethodStatic
+		nicConfig.PrivateIPAddress = to.StringPtr(s.StaticIPAddress)
+	}
+
+	backendAddressPools := []network.BackendAddressPool{}
+	if s.PublicLBName != "" {
+		if s.PublicLBAddressPoolName != "" {
+			backendAddressPools = append(backendAddressPools,
+				network.BackendAddressPool{
+					ID: to.StringPtr(azure.AddressPoolID(s.SubscriptionID, s.ResourceGroup, s.PublicLBName, s.PublicLBAddressPoolName)),
+				})
+		}
+		if s.PublicLBNATRuleName != "" {
+			nicConfig.LoadBalancerInboundNatRules = &[]network.InboundNatRule{
+				{
+					ID: to.StringPtr(azure.NATRuleID(s.SubscriptionID, s.ResourceGroup, s.PublicLBName, s.PublicLBNATRuleName)),
+				},
+			}
+		}
+	}
+	if s.InternalLBName != "" && s.InternalLBAddressPoolName != "" {
+		backendAddressPools = append(backendAddressPools,
+			network.BackendAddressPool{
+				ID: to.StringPtr(azure.AddressPoolID(s.SubscriptionID, s.ResourceGroup, s.InternalLBName, s.InternalLBAddressPoolName)),
+			})
+	}
+	nicConfig.LoadBalancerBackendAddressPools = &backendAddressPools
+
+	if s.PublicIPName != "" {
+		nicConfig.PublicIPAddress = &network.PublicIPAddress{
+			ID: to.StringPtr(azure.PublicIPID(s.SubscriptionID, s.ResourceGroup, s.PublicIPName)),
+		}
+	}
+
+	if s.AcceleratedNetworking == nil {
+		// set accelerated networking to the capability of the VMSize
+		if s.SKU == nil {
+			return nil, errors.New("unable to get required network interface SKU from machine cache")
+		}
+
+		accelNet := s.SKU.HasCapability(resourceskus.AcceleratedNetworking)
+		s.AcceleratedNetworking = &accelNet
+	}
+
+	ipConfigurations := []network.InterfaceIPConfiguration{
+		{
+			Name:                                     to.StringPtr("pipConfig"),
+			InterfaceIPConfigurationPropertiesFormat: nicConfig,
+		},
+	}
+
+	if s.IPv6Enabled {
+		ipv6Config := network.InterfaceIPConfiguration{
+			Name: to.StringPtr("ipConfigv6"),
+			InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+				PrivateIPAddressVersion: "IPv6",
+				Primary:                 to.BoolPtr(false),
+				Subnet:                  &network.Subnet{ID: subnet.ID},
+			},
+		}
+
+		ipConfigurations = append(ipConfigurations, ipv6Config)
+	}
+
+	return network.Interface{
+		Location: to.StringPtr(s.Location),
+		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+			EnableAcceleratedNetworking: s.AcceleratedNetworking,
+			IPConfigurations:            &ipConfigurations,
+			EnableIPForwarding:          to.BoolPtr(s.EnableIPForwarding),
+		},
+	}, nil
+}

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkinterfaces
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
+)
+
+var (
+	fakeMissingSKUNICSpec = NICSpec{
+		Name:                  "my-net-interface",
+		ResourceGroup:         "my-rg",
+		Location:              "fake-location",
+		SubscriptionID:        "123",
+		MachineName:           "azure-test1",
+		SubnetName:            "my-subnet",
+		VNetName:              "my-vnet",
+		VNetResourceGroup:     "my-rg",
+		PublicLBName:          "my-public-lb",
+		AcceleratedNetworking: nil,
+	}
+	fakeSku = resourceskus.SKU{
+		Name: to.StringPtr("Standard_D2v2"),
+		Kind: to.StringPtr(string(resourceskus.VirtualMachines)),
+		Locations: &[]string{
+			"fake-location",
+		},
+		LocationInfo: &[]compute.ResourceSkuLocationInfo{
+			{
+				Location: to.StringPtr("fake-location"),
+				Zones:    &[]string{"1"},
+			},
+		},
+		Capabilities: &[]compute.ResourceSkuCapabilities{
+			{
+				Name:  to.StringPtr(resourceskus.AcceleratedNetworking),
+				Value: to.StringPtr(string(resourceskus.CapabilitySupported)),
+			},
+		},
+	}
+	fakeStaticPrivateIPNICSpec = NICSpec{
+		Name:                    "my-net-interface",
+		ResourceGroup:           "my-rg",
+		Location:                "fake-location",
+		SubscriptionID:          "123",
+		MachineName:             "azure-test1",
+		SubnetName:              "my-subnet",
+		VNetName:                "my-vnet",
+		VNetResourceGroup:       "my-rg",
+		PublicLBName:            "my-public-lb",
+		PublicLBAddressPoolName: "cluster-name-outboundBackendPool",
+		StaticIPAddress:         "fake.static.ip",
+		AcceleratedNetworking:   nil,
+		SKU:                     &fakeSku,
+	}
+
+	fakeDynamicPrivateIPNICSpec = NICSpec{
+		Name:                    "my-net-interface",
+		ResourceGroup:           "my-rg",
+		Location:                "fake-location",
+		SubscriptionID:          "123",
+		MachineName:             "azure-test1",
+		SubnetName:              "my-subnet",
+		VNetName:                "my-vnet",
+		VNetResourceGroup:       "my-rg",
+		PublicLBName:            "my-public-lb",
+		PublicLBAddressPoolName: "cluster-name-outboundBackendPool",
+		AcceleratedNetworking:   nil,
+		SKU:                     &fakeSku,
+	}
+
+	fakeControlPlaneNICSpec = NICSpec{
+		Name:                      "my-net-interface",
+		ResourceGroup:             "my-rg",
+		Location:                  "fake-location",
+		SubscriptionID:            "123",
+		MachineName:               "azure-test1",
+		SubnetName:                "my-subnet",
+		VNetName:                  "my-vnet",
+		VNetResourceGroup:         "my-rg",
+		PublicLBName:              "my-public-lb",
+		PublicLBAddressPoolName:   "my-public-lb-backendPool",
+		PublicLBNATRuleName:       "azure-test1",
+		InternalLBName:            "my-internal-lb",
+		InternalLBAddressPoolName: "my-internal-lb-backendPool",
+		AcceleratedNetworking:     nil,
+		SKU:                       &fakeSku,
+	}
+
+	fakeAcceleratedNetworkingNICSpec = NICSpec{
+		Name:                  "my-net-interface",
+		ResourceGroup:         "my-rg",
+		Location:              "fake-location",
+		SubscriptionID:        "123",
+		MachineName:           "azure-test1",
+		SubnetName:            "my-subnet",
+		VNetName:              "my-vnet",
+		VNetResourceGroup:     "my-rg",
+		PublicLBName:          "my-public-lb",
+		AcceleratedNetworking: nil,
+		SKU:                   &fakeSku,
+	}
+
+	fakeNonAcceleratedNetworkingNICSpec = NICSpec{
+		Name:                  "my-net-interface",
+		ResourceGroup:         "my-rg",
+		Location:              "fake-location",
+		SubscriptionID:        "123",
+		MachineName:           "azure-test1",
+		SubnetName:            "my-subnet",
+		VNetName:              "my-vnet",
+		VNetResourceGroup:     "my-rg",
+		PublicLBName:          "my-public-lb",
+		AcceleratedNetworking: to.BoolPtr(false),
+	}
+
+	fakeIpv6NICSpec = NICSpec{
+		Name:                  "my-net-interface",
+		ResourceGroup:         "my-rg",
+		Location:              "fake-location",
+		SubscriptionID:        "123",
+		MachineName:           "azure-test1",
+		SubnetName:            "my-subnet",
+		VNetName:              "my-vnet",
+		IPv6Enabled:           true,
+		VNetResourceGroup:     "my-rg",
+		PublicLBName:          "my-public-lb",
+		AcceleratedNetworking: nil,
+		SKU:                   &fakeSku,
+		EnableIPForwarding:    true,
+	}
+)
+
+func TestParameters(t *testing.T) {
+	testcases := []struct {
+		name          string
+		spec          *NICSpec
+		existing      interface{}
+		expect        func(g *WithT, result interface{})
+		expectedError string
+	}{
+		{
+			name:     "error when accelerted networking is nil and no SKU is present",
+			spec:     &fakeMissingSKUNICSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "unable to get required network interface SKU from machine cache",
+		},
+		{
+			name:     "get parameters for network interface with static private IP",
+			spec:     &fakeStaticPrivateIPNICSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
+				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(true),
+						EnableIPForwarding:          to.BoolPtr(false),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
+									PrivateIPAllocationMethod:       network.IPAllocationMethodStatic,
+									PrivateIPAddress:                to.StringPtr("fake.static.ip"),
+									Subnet:                          &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+								},
+							},
+						},
+					},
+				}))
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get parameters for network interface with dynamic private IP",
+			spec:     &fakeDynamicPrivateIPNICSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
+				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(true),
+						EnableIPForwarding:          to.BoolPtr(false),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
+									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
+									Subnet:                          &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+								},
+							},
+						},
+					},
+				}))
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get parameters for control plane network interface",
+			spec:     &fakeControlPlaneNICSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
+				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(true),
+						EnableIPForwarding:          to.BoolPtr(false),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                      &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:   network.IPAllocationMethodDynamic,
+									LoadBalancerInboundNatRules: &[]network.InboundNatRule{{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/inboundNatRules/azure-test1")}},
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{
+										{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/my-public-lb-backendPool")},
+										{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-internal-lb/backendAddressPools/my-internal-lb-backendPool")}},
+								},
+							},
+						},
+					},
+				}))
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get parameters for network interface with accelerated networking",
+			spec:     &fakeAcceleratedNetworkingNICSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
+				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(true),
+						EnableIPForwarding:          to.BoolPtr(false),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                          &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+								},
+							},
+						},
+					},
+				}))
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get parameters for network interface without accelerated networking",
+			spec:     &fakeNonAcceleratedNetworkingNICSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
+				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(false),
+						EnableIPForwarding:          to.BoolPtr(false),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                          &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+								},
+							},
+						},
+					},
+				}))
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get parameters for network interface ipv6",
+			spec:     &fakeIpv6NICSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(network.Interface{}))
+				g.Expect(result.(network.Interface)).To(Equal(network.Interface{
+					Location: to.StringPtr("fake-location"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						EnableAcceleratedNetworking: to.BoolPtr(true),
+						EnableIPForwarding:          to.BoolPtr(true),
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								Name: to.StringPtr("pipConfig"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                          &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									PrivateIPAllocationMethod:       network.IPAllocationMethodDynamic,
+									LoadBalancerBackendAddressPools: &[]network.BackendAddressPool{},
+								},
+							},
+							{
+								Name: to.StringPtr("ipConfigv6"),
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									Subnet:                  &network.Subnet{ID: to.StringPtr("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+									Primary:                 to.BoolPtr(false),
+									PrivateIPAddressVersion: "IPv6",
+								},
+							},
+						},
+					},
+				}))
+			},
+			expectedError: "",
+		},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
+
+			result, err := tc.spec.Parameters(tc.existing)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			tc.expect(g, result)
+		})
+	}
+}

--- a/azure/services/virtualmachines/client.go
+++ b/azure/services/virtualmachines/client.go
@@ -32,8 +32,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// Client wraps go-sdk.
 type (
+	// Client wraps go-sdk.
 	Client interface {
 		Get(context.Context, azure.ResourceSpecGetter) (interface{}, error)
 		CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error)

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -31,6 +31,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async/mock_async"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/availabilitysets/mock_availabilitysets"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/networkinterfaces"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/networkinterfaces/mock_networkinterfaces"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/publicips/mock_publicips"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/virtualmachines/mock_virtualmachines"
@@ -65,6 +66,10 @@ var (
 				},
 			},
 		},
+	}
+	fakeNetworkInterfaceGetterSpec = networkinterfaces.NICSpec{
+		Name:          "nic-1",
+		ResourceGroup: "test-group",
 	}
 	fakeNetworkInterface = network.Interface{
 		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
@@ -114,7 +119,7 @@ func TestReconcileVM(t *testing.T) {
 				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, nil)
 				s.SetProviderID("azure://test-vm-id")
 				s.SetAnnotation("cluster-api-provider-azure", "true")
-				mnic.Get(gomockinternal.AContext(), "test-group", "nic-1").Return(fakeNetworkInterface, nil)
+				mnic.Get(gomockinternal.AContext(), &fakeNetworkInterfaceGetterSpec).Return(fakeNetworkInterface, nil)
 				mpip.Get(gomockinternal.AContext(), "test-group", "pip-1").Return(fakePublicIPs, nil)
 				s.SetAddresses(fakeNodeAddresses)
 				s.SetVMState(infrav1.Succeeded)
@@ -140,7 +145,7 @@ func TestReconcileVM(t *testing.T) {
 				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, nil)
 				s.SetProviderID("azure://test-vm-id")
 				s.SetAnnotation("cluster-api-provider-azure", "true")
-				mnic.Get(gomockinternal.AContext(), "test-group", "nic-1").Return(network.Interface{}, internalError)
+				mnic.Get(gomockinternal.AContext(), &fakeNetworkInterfaceGetterSpec).Return(network.Interface{}, internalError)
 			},
 		},
 		{
@@ -153,7 +158,7 @@ func TestReconcileVM(t *testing.T) {
 				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, nil)
 				s.SetProviderID("azure://test-vm-id")
 				s.SetAnnotation("cluster-api-provider-azure", "true")
-				mnic.Get(gomockinternal.AContext(), "test-group", "nic-1").Return(fakeNetworkInterface, nil)
+				mnic.Get(gomockinternal.AContext(), &fakeNetworkInterfaceGetterSpec).Return(fakeNetworkInterface, nil)
 				mpip.Get(gomockinternal.AContext(), "test-group", "pip-1").Return(network.PublicIPAddress{}, internalError)
 			},
 		},

--- a/azure/types.go
+++ b/azure/types.go
@@ -31,26 +31,6 @@ type PublicIPSpec struct {
 	IsIPv6  bool
 }
 
-// NICSpec defines the specification for a Network Interface.
-type NICSpec struct {
-	Name                      string
-	MachineName               string
-	SubnetName                string
-	VNetName                  string
-	VNetResourceGroup         string
-	StaticIPAddress           string
-	PublicLBName              string
-	PublicLBAddressPoolName   string
-	PublicLBNATRuleName       string
-	InternalLBName            string
-	InternalLBAddressPoolName string
-	PublicIPName              string
-	VMSize                    string
-	AcceleratedNetworking     *bool
-	IPv6Enabled               bool
-	EnableIPForwarding        bool
-}
-
 // SubnetSpec defines the specification for a Subnet.
 type SubnetSpec struct {
 	Name              string


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature
**What this PR does / why we need it**: Implementation of an async service for network interfaces as part of an effort to make all services async. See #1610 and #1541.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1717 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make network interfaces reconcile/delete async
```
