### PR TITLE
Set max pods for the first time creation of ManagedControlplane (AKS) cluster

### DIFF
--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -500,6 +500,7 @@ func (s *ManagedControlPlaneScope) GetAgentPoolSpecs(ctx context.Context) ([]azu
 			Replicas:          1,
 			OSDiskSizeGB:      0,
 			Mode:              pool.Spec.Mode,
+			MaxPods:           pool.Spec.MaxPods,
 			AvailabilityZones: pool.Spec.AvailabilityZones,
 		}
 
@@ -557,6 +558,7 @@ func (s *ManagedControlPlaneScope) AgentPoolSpec() azure.AgentPoolSpec {
 			s.ControlPlane.Spec.VirtualNetwork.Subnet.Name,
 		),
 		Mode:              s.InfraMachinePool.Spec.Mode,
+		MaxPods:           s.InfraMachinePool.Spec.MaxPods,
 		AvailabilityZones: s.InfraMachinePool.Spec.AvailabilityZones,
 	}
 
@@ -568,10 +570,6 @@ func (s *ManagedControlPlaneScope) AgentPoolSpec() azure.AgentPoolSpec {
 		agentPoolSpec.EnableAutoScaling = to.BoolPtr(true)
 		agentPoolSpec.MaxCount = s.InfraMachinePool.Spec.Scaling.MaxSize
 		agentPoolSpec.MinCount = s.InfraMachinePool.Spec.Scaling.MinSize
-	}
-
-	if s.InfraMachinePool.Spec.MaxPods != nil {
-		agentPoolSpec.MaxPods = s.InfraMachinePool.Spec.MaxPods
 	}
 
 	return agentPoolSpec

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -331,7 +331,7 @@ func TestManagedControlPlaneScope_MaxPods(t *testing.T) {
 			Expected: azure.AgentPoolSpec{
 				Name:         "pool1",
 				SKU:          "Standard_D2s_v3",
-				Mode:         "User",
+				Mode:         "System",
 				Cluster:      "cluster1",
 				Replicas:     1,
 				MaxPods:      to.Int32Ptr(12),
@@ -350,6 +350,9 @@ func TestManagedControlPlaneScope_MaxPods(t *testing.T) {
 			g.Expect(err).To(Succeed())
 			agentPool := s.AgentPoolSpec()
 			g.Expect(agentPool).To(Equal(c.Expected))
+			agentPools, err := s.GetAgentPoolSpecs(context.TODO())
+			g.Expect(err).To(Succeed())
+			g.Expect(agentPools[0].MaxPods).To(Equal(c.Expected.MaxPods))
 		})
 	}
 }
@@ -388,7 +391,7 @@ func getAzureMachinePoolWithScaling(name string, min, max int32) *infrav1.AzureM
 }
 
 func getAzureMachinePoolWithMaxPods(name string, maxPods int32) *infrav1.AzureManagedMachinePool {
-	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeUser)
+	managedPool := getAzureMachinePool(name, infrav1.NodePoolModeSystem)
 	managedPool.Spec.MaxPods = to.Int32Ptr(maxPods)
 	return managedPool
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
When creating AKS clusters for first time we create the system agentpool through ManagedClusters and not through `AMMPController`. If we have a system agentpool created by user with `maxPods` value configured. It was being ignored. And later the `AMMPController` is trying to set the maxPods value but as it is immutable it stays in error. 

This PR sets the maxPods for the first time creation also. 

We will have to consider the above path when adding other immutable fields for agentpools also. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
set maxPods for first time creation of clusters
```
