### PR TITLE
Add ManualServicePrincipal to validation string

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -426,7 +426,7 @@ const (
 )
 
 // IdentityType represents different types of identities.
-// +kubebuilder:validation:Enum=ServicePrincipal;UserAssignedMSI
+// +kubebuilder:validation:Enum=ServicePrincipal;ManualServicePrincipal;UserAssignedMSI
 type IdentityType string
 
 const (

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
@@ -429,6 +429,7 @@ spec:
                 description: UserAssignedMSI or Service Principal
                 enum:
                 - ServicePrincipal
+                - ManualServicePrincipal
                 - UserAssignedMSI
                 type: string
             required:


### PR DESCRIPTION
Hopefully, this is the right validation string to add for supporting
ManualServicePrincipal as a valid Azure Cluster Identity type.

Signed-off-by: David ML Brown Jr <dmlb2000@gmail.com>

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug
/kind api-change


**What this PR does / why we need it**:

Adds ManualServicePrincipal to the validation doc strings for Identity in v1beta1 api version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1947

**Special notes for your reviewer**:

Original change to the API spec adding ManualServicePrincipal

https://github.com/kubernetes-sigs/cluster-api-provider-azure/commit/d12d7a93bc960a10b9b9590d0c9ae720174f87a6

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix validation for Azure Cluster Identity of type ManualServicePrincipal.
```
