### PR TITLE
Enable using custom Windows containerd in CI

### DIFF
--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -471,13 +471,15 @@ Optional settings are:
 | `WINDOWS`            | `false` | Run conformance against Windows nodes |
 | `CONFORMANCE_NODES`  | `1` |Number of parallel ginkgo nodes to run     |
 
-With the following environment variables defined, you can build a CAPZ cluster from the HEAD of Kubernetes main branch or release branch, and run the Conformance test suite against it.  This is not enabled for Windows currently.
+With the following environment variables defined, you can build a CAPZ cluster from the HEAD of Kubernetes main branch or release branch, and run the Conformance test suite against it.
 
 | Environment Variable | Value  |
 |----------------------|--------|
 | `E2E_ARGS`           | `-kubetest.use-ci-artifacts` |
 | `KUBERNETES_VERSION` | `latest` - extract Kubernetes version from https://dl.k8s.io/ci/latest.txt (main's HEAD)<br>`latest-1.21` - extract Kubernetes version from https://dl.k8s.io/ci/latest-1.21.txt (release branch's HEAD) |
-
+| `WINDOWS_FLAVOR`     | Optional, can be `containerd` or `containerd-2022`, when not specified dockershim is used |
+| `KUBETEST_WINDOWS_CONFIG`     | Optional, can be `upstream-windows-serial-slow.yaml`, when not specified `upstream-windows.yaml` is used |
+| `WINDOWS_CONTAINERD_URL`     | Optional, can be any url to a `tar.gz` file containing binaries for containerd in the same format as upstream package |
 
 With the following environment variables defined, CAPZ runs `./scripts/ci-build-kubernetes.sh` as part of `./scripts/ci-conformance.sh`, which allows developers to build Kubernetes from source and run the Kubernetes Conformance test suite against a CAPZ cluster based on the custom build:
 

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -454,6 +454,17 @@ spec:
             }
           }
 
+          $$CONTAINERD_URL="${WINDOWS_CONTAINERD_URL}"
+          if($$CONTAINERD_URL -ne ""){
+            Stop-Service containerd -Force
+            echo "downloading containerd: $$CONTAINERD_URL"
+            curl.exe --retry 10 --retry-delay 5 -L "$$CONTAINERD_URL" --output "c:/k/containerd.tar.gz"
+            cmd /c tar -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
+            containerd.exe --version
+            containerd-shim-runhcs-v1.exe --version
+            Start-Service containerd
+          }
+
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
           ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -454,6 +454,17 @@ spec:
             }
           }
 
+          $$CONTAINERD_URL="${WINDOWS_CONTAINERD_URL}"
+          if($$CONTAINERD_URL -ne ""){
+            Stop-Service containerd -Force
+            echo "downloading containerd: $$CONTAINERD_URL"
+            curl.exe --retry 10 --retry-delay 5 -L "$$CONTAINERD_URL" --output "c:/k/containerd.tar.gz"
+            cmd /c tar -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
+            containerd.exe --version
+            containerd-shim-runhcs-v1.exe --version
+            Start-Service containerd
+          }
+
           # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
           # that is applied at at this stage (windows-kubeproxy-ci.yaml)
           ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess

--- a/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap-windows.yaml
+++ b/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap-windows.yaml
@@ -16,6 +16,17 @@
         }
       }
 
+      $$CONTAINERD_URL="${WINDOWS_CONTAINERD_URL}"
+      if($$CONTAINERD_URL -ne ""){
+        Stop-Service containerd -Force
+        echo "downloading containerd: $$CONTAINERD_URL"
+        curl.exe --retry 10 --retry-delay 5 -L "$$CONTAINERD_URL" --output "c:/k/containerd.tar.gz"
+        cmd /c tar -zxvf c:/k/containerd.tar.gz -C "c:/Program Files/containerd" --strip-components 1
+        containerd.exe --version
+        containerd-shim-runhcs-v1.exe --version
+        Start-Service containerd
+      }
+
       # Tag it to the ci version.  The image knows how to use the copy locally with the configmap
       # that is applied at at this stage (windows-kubeproxy-ci.yaml)
       ctr.exe -n k8s.io images pull docker.io/sigwindowstools/kube-proxy:v1.22.1-calico-hostprocess

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -198,6 +198,7 @@ variables:
   INIT_WITH_PROVIDERS_CONTRACT: "v1alpha3"
   INIT_WITH_KUBERNETES_VERSION: "v1.21.2"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
+  WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:

/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

We need to be able to run windows nightly containerd jobs in ci to catch breaking changes to contianerd/hcsshim early.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1859

**Special notes for your reviewer**:


_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig windows