### PR TITLE
Add version info to manager and userAgent in Tilt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,18 @@ endif
 $(KUBE_APISERVER) $(ETCD): ## install test asset kubectl, kube-apiserver, etcd
 	source ./scripts/fetch_ext_bins.sh && fetch_tools
 
+.PHONY: env-info # Temporary target to get additional logs in prow tests
+env-info:
+	@echo "Working dir is $(shell pwd)"
+	@echo "Working dir contents:"
+	ls -la || echo ""
+	@echo "Root dir contents:"
+	ls -la / || echo ""
+	@echo "Workspace contents are:"
+	ls -la /workspace || echo ""
+	@echo "Output of /hack/version.sh:"
+	./hack/version.sh || echo ""
+
 ## --------------------------------------
 ## Binaries
 ## --------------------------------------
@@ -406,7 +418,7 @@ docker-pull-prerequisites:
 	docker pull gcr.io/distroless/static:latest
 
 .PHONY: docker-build
-docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
+docker-build: docker-pull-prerequisites env-info ## Build the docker image for controller-manager
 	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg ldflags="$(LDFLAGS)" . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/default/manager_pull_policy.yaml"

--- a/Tiltfile
+++ b/Tiltfile
@@ -177,10 +177,12 @@ def capz():
             yaml = str(encode_yaml_stream(yaml_dict))
             yaml = fixup_yaml_empty_arrays(yaml)
 
+    ldflags = str(local("hack/version.sh"))
+
     # Set up a local_resource build of the provider's manager binary.
     local_resource(
         "manager",
-        cmd = 'mkdir -p .tiltbuild;CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \'-extldflags "-static"\' -o .tiltbuild/manager',
+        cmd = 'mkdir -p .tiltbuild;CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags  \'-extldflags "-static" ' + ldflags + "' -o .tiltbuild/manager",
         deps = ["api", "azure", "config", "controllers", "exp", "feature", "pkg", "util", "go.mod", "go.sum", "main.go"],
         labels = ["cluster-api"],
     )

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -43,6 +43,8 @@ version::get_version_vars() {
             # We have distance to base tag (v1.1.0-1-gCommitHash)
             # shellcheck disable=SC2001
             GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/-\1/")
+            # TODO: What should the output of this command look like?
+            # For example, v1.1.0-32-gfeb4736460af8f maps to v1.1.0-32-f, do we want the trailing "-f" or not?
         fi
         if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
             # git describe --dirty only considers changes to existing files, but


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind bug

**What this PR does / why we need it**: The version info added in #639 is not passed in when CAPZ is started using Tilt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1949 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add version info to Tilt
```
