### PR TITLE
Set Control Plane Endpoint Optionally

### DIFF
--- a/api/v1beta1/azurecluster_types.go
+++ b/api/v1beta1/azurecluster_types.go
@@ -45,7 +45,8 @@ type AzureClusterSpec struct {
 
 	Location string `json:"location"`
 
-	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane. It is not recommended to set
+	// this when creating an AzureCluster as CAPZ will set this for you. However, if it is set, CAPZ will not change it.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint,omitempty"`
 

--- a/api/v1beta1/azurecluster_webhook.go
+++ b/api/v1beta1/azurecluster_webhook.go
@@ -75,6 +75,20 @@ func (c *AzureCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
+	if old.Spec.ControlPlaneEndpoint.Host != "" && c.Spec.ControlPlaneEndpoint.Host != old.Spec.ControlPlaneEndpoint.Host {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "ControlPlaneEndpoint", "Host"),
+				c.Spec.ControlPlaneEndpoint.Host, "field is immutable"),
+		)
+	}
+
+	if old.Spec.ControlPlaneEndpoint.Port != 0 && c.Spec.ControlPlaneEndpoint.Port != old.Spec.ControlPlaneEndpoint.Port {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "ControlPlaneEndpoint", "Port"),
+				c.Spec.ControlPlaneEndpoint.Port, "field is immutable"),
+		)
+	}
+
 	if !reflect.DeepEqual(c.Spec.AzureEnvironment, old.Spec.AzureEnvironment) {
 		// The equality failure could be because of default mismatch between v1alpha3 and v1beta1. This happens because
 		// the new object `r` will have run through the default webhooks but the old object `old` would not have so.

--- a/api/v1beta1/azurecluster_webhook_test.go
+++ b/api/v1beta1/azurecluster_webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 func TestAzureCluster_ValidateCreate(t *testing.T) {
@@ -34,6 +35,18 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 			name: "azurecluster with pre-existing vnet - valid spec",
 			cluster: func() *AzureCluster {
 				return createValidCluster()
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "azurecluster with pre-existing control plane endpoint - valid spec",
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+					Host: "apiserver.example.com",
+					Port: 8443,
+				}
+				return cluster
 			}(),
 			wantErr: false,
 		},
@@ -105,6 +118,41 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		cluster    *AzureCluster
 		wantErr    bool
 	}{
+		{
+			name: "azurecluster with pre-existing control plane endpoint - valid spec",
+			oldCluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+					Host: "apiserver.example.com",
+					Port: 8443,
+				}
+				return cluster
+			}(),
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+					Host: "apiserver.example.io",
+					Port: 6443,
+				}
+				return cluster
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "azurecluster with no control plane endpoint - valid spec",
+			oldCluster: func() *AzureCluster {
+				return createValidCluster()
+			}(),
+			cluster: func() *AzureCluster {
+				cluster := createValidCluster()
+				cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+					Host: "apiserver.example.com",
+					Port: 8443,
+				}
+				return cluster
+			}(),
+			wantErr: false,
+		},
 		{
 			name: "azurecluster with pre-existing vnet - valid spec",
 			oldCluster: func() *AzureCluster {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -1574,7 +1574,9 @@ spec:
                 type: object
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to
-                  communicate with the control plane.
+                  communicate with the control plane. It is not recommended to set
+                  this when creating an AzureCluster as CAPZ will set this for you.
+                  However, if it is set, CAPZ will not change it.
                 properties:
                   host:
                     description: The hostname on which the API server is serving.

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -240,9 +240,11 @@ func (acr *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 	}
 
 	// Set APIEndpoints so the Cluster API Cluster Controller can pull them
-	azureCluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
-		Host: clusterScope.APIServerHost(),
-		Port: clusterScope.APIServerPort(),
+	if azureCluster.Spec.ControlPlaneEndpoint.Host == "" {
+		azureCluster.Spec.ControlPlaneEndpoint.Host = clusterScope.APIServerHost()
+	}
+	if azureCluster.Spec.ControlPlaneEndpoint.Port == 0 {
+		azureCluster.Spec.ControlPlaneEndpoint.Port = clusterScope.APIServerPort()
 	}
 
 	// No errors, so mark us ready so the Cluster API Cluster Controller can pull it


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This sets the Control Plane Endpoint optionally if it's not already
set and makes sure the Host and Port can be set independently.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1977

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow Control Plane Endpoint to be set by user.
```
