### PR TITLE
bump kubebuilder-tools to 1.20.2

### DIFF
--- a/scripts/fetch_ext_bins.sh
+++ b/scripts/fetch_ext_bins.sh
@@ -26,7 +26,7 @@ if [[ -n "${TRACE}" ]]; then
   set -x
 fi
 
-k8s_version=1.16.4
+k8s_version=1.20.2
 goarch=amd64
 goos="unknown"
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
we are seeing tests fails in local dev environments with macOS 12:

```
Panic [0.458 seconds]
[BeforeSuite] BeforeSuite
/Users/cerobert/go/src/sigs.k8s.io/cluster-api-provider-azure/controllers/suite_test.go:48

  Test Panicked
  unable to start control plane itself: failed to start the controlplane. retried 5 times: timeout waiting for process etcd to start successfully (it may have failed to start, or stopped unexpectedly before becoming ready)
  /Users/cerobert/go/src/sigs.k8s.io/cluster-api-provider-azure/internal/test/env/env.go:107
```

which is caused by etcd failing to start up
```
❯ hack/tools/bin/etcd                                                                                                                                                                                                                      
fatal error: runtime: bsdthread_register error

runtime stack:
runtime.throw(0x1bed3fa, 0x21)
	/usr/local/go/src/runtime/panic.go:616 +0x81 fp=0x7ff7bfeff378 sp=0x7ff7bfeff358 pc=0x102a871
runtime.goenvs()
	/usr/local/go/src/runtime/os_darwin.go:129 +0x83 fp=0x7ff7bfeff3a8 sp=0x7ff7bfeff378 pc=0x10283f3
runtime.schedinit()
	/usr/local/go/src/runtime/proc.go:501 +0xd6 fp=0x7ff7bfeff410 sp=0x7ff7bfeff3a8 pc=0x102d166
runtime.rt0_go(0x7ff7bfeff440, 0x1, 0x7ff7bfeff440, 0x1000000, 0x1, 0x7ff7bfeff650, 0x0, 0x7ff7bfeff664, 0x7ff7bfeff6a0, 0x7ff7bfeff6e2, ...)
	/usr/local/go/src/runtime/asm_amd64.s:252 +0x1f4 fp=0x7ff7bfeff418 sp=0x7ff7bfeff410 pc=0x1056474
```

which can be root caused to https://github.com/golang/go/wiki/MacOS12BSDThreadRegisterIssue

This PR proposes to bump the etcd version that is installed via kubebuilder-tools, we cannot go to the latest as we hit another unresolved issue https://github.com/kubernetes-sigs/controller-runtime/issues/1571


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
