### PR TITLE
chore(golangci-lint): add unparam linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
     - structcheck
     - typecheck
     - unconvert
+    - unparam
     - unused
     - varcheck
     - whitespace

--- a/api/v1beta1/azuremachine_default_test.go
+++ b/api/v1beta1/azuremachine_default_test.go
@@ -35,8 +35,8 @@ func TestAzureMachineSpec_SetDefaultSSHPublicKey(t *testing.T) {
 	}
 
 	existingPublicKey := "testpublickey"
-	publicKeyExistTest := test{machine: createMachineWithSSHPublicKey(t, existingPublicKey)}
-	publicKeyNotExistTest := test{machine: createMachineWithSSHPublicKey(t, "")}
+	publicKeyExistTest := test{machine: createMachineWithSSHPublicKey(existingPublicKey)}
+	publicKeyNotExistTest := test{machine: createMachineWithSSHPublicKey("")}
 
 	err := publicKeyExistTest.machine.Spec.SetDefaultSSHPublicKey()
 	g.Expect(err).To(BeNil())
@@ -250,12 +250,12 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 	}
 }
 
-func createMachineWithSSHPublicKey(t *testing.T, sshPublicKey string) *AzureMachine {
+func createMachineWithSSHPublicKey(sshPublicKey string) *AzureMachine {
 	machine := hardcodedAzureMachineWithSSHKey(sshPublicKey)
 	return machine
 }
 
-func createMachineWithUserAssignedIdentities(t *testing.T, identitiesList []UserAssignedIdentity) *AzureMachine {
+func createMachineWithUserAssignedIdentities(identitiesList []UserAssignedIdentity) *AzureMachine {
 	machine := hardcodedAzureMachineWithSSHKey(generateSSHPublicKey(true))
 	machine.Spec.Identity = VMIdentityUserAssigned
 	machine.Spec.UserAssignedIdentities = identitiesList

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -41,67 +41,67 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 	}{
 		{
 			name:    "azuremachine with marketplace image - full",
-			machine: createMachineWithtMarketPlaceImage(t, "PUB1234", "OFFER1234", "SKU1234", "1.0.0"),
+			machine: createMachineWithtMarketPlaceImage("PUB1234", "OFFER1234", "SKU1234", "1.0.0"),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with marketplace image - missing publisher",
-			machine: createMachineWithtMarketPlaceImage(t, "", "OFFER1234", "SKU1234", "1.0.0"),
+			machine: createMachineWithtMarketPlaceImage("", "OFFER1235", "SKU1235", "2.0.0"),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with shared gallery image - full",
-			machine: createMachineWithSharedImage(t, "SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0"),
+			machine: createMachineWithSharedImage("SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0"),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with marketplace image - missing subscription",
-			machine: createMachineWithSharedImage(t, "", "RG123", "NAME123", "GALLERY1", "1.0.0"),
+			machine: createMachineWithSharedImage("", "RG124", "NAME124", "GALLERY1", "2.0.0"),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with image by - with id",
-			machine: createMachineWithImageByID(t, "ID123"),
+			machine: createMachineWithImageByID("ID123"),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with image by - without id",
-			machine: createMachineWithImageByID(t, ""),
+			machine: createMachineWithImageByID(""),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with valid SSHPublicKey",
-			machine: createMachineWithSSHPublicKey(t, validSSHPublicKey),
+			machine: createMachineWithSSHPublicKey(validSSHPublicKey),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine without SSHPublicKey",
-			machine: createMachineWithSSHPublicKey(t, ""),
+			machine: createMachineWithSSHPublicKey(""),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with invalid SSHPublicKey",
-			machine: createMachineWithSSHPublicKey(t, "invalid ssh key"),
+			machine: createMachineWithSSHPublicKey("invalid ssh key"),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with list of user-assigned identities",
-			machine: createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:///123"}, {ProviderID: "azure:///456"}}),
+			machine: createMachineWithUserAssignedIdentities([]UserAssignedIdentity{{ProviderID: "azure:///123"}, {ProviderID: "azure:///456"}}),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with empty list of user-assigned identities",
-			machine: createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{}),
+			machine: createMachineWithUserAssignedIdentities([]UserAssignedIdentity{}),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with valid osDisk cache type",
-			machine: createMachineWithOsDiskCacheType(t, string(compute.PossibleCachingTypesValues()[1])),
+			machine: createMachineWithOsDiskCacheType(string(compute.PossibleCachingTypesValues()[1])),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with invalid osDisk cache type",
-			machine: createMachineWithOsDiskCacheType(t, "invalid_cache_type"),
+			machine: createMachineWithOsDiskCacheType("invalid_cache_type"),
 			wantErr: true,
 		},
 	}
@@ -531,8 +531,8 @@ func TestAzureMachine_Default(t *testing.T) {
 	}
 
 	existingPublicKey := validSSHPublicKey
-	publicKeyExistTest := test{machine: createMachineWithSSHPublicKey(t, existingPublicKey)}
-	publicKeyNotExistTest := test{machine: createMachineWithSSHPublicKey(t, "")}
+	publicKeyExistTest := test{machine: createMachineWithSSHPublicKey(existingPublicKey)}
+	publicKeyNotExistTest := test{machine: createMachineWithSSHPublicKey("")}
 
 	publicKeyExistTest.machine.Default()
 	g.Expect(publicKeyExistTest.machine.Spec.SSHPublicKey).To(Equal(existingPublicKey))
@@ -551,7 +551,7 @@ func TestAzureMachine_Default(t *testing.T) {
 	}
 }
 
-func createMachineWithSharedImage(t *testing.T, subscriptionID, resourceGroup, name, gallery, version string) *AzureMachine {
+func createMachineWithSharedImage(subscriptionID, resourceGroup, name, gallery, version string) *AzureMachine {
 	image := &Image{
 		SharedGallery: &AzureSharedGalleryImage{
 			SubscriptionID: subscriptionID,
@@ -571,7 +571,7 @@ func createMachineWithSharedImage(t *testing.T, subscriptionID, resourceGroup, n
 	}
 }
 
-func createMachineWithtMarketPlaceImage(t *testing.T, publisher, offer, sku, version string) *AzureMachine {
+func createMachineWithtMarketPlaceImage(publisher, offer, sku, version string) *AzureMachine {
 	image := &Image{
 		Marketplace: &AzureMarketplaceImage{
 			Publisher: publisher,
@@ -590,7 +590,7 @@ func createMachineWithtMarketPlaceImage(t *testing.T, publisher, offer, sku, ver
 	}
 }
 
-func createMachineWithImageByID(t *testing.T, imageID string) *AzureMachine {
+func createMachineWithImageByID(imageID string) *AzureMachine {
 	image := &Image{
 		ID: &imageID,
 	}
@@ -604,7 +604,7 @@ func createMachineWithImageByID(t *testing.T, imageID string) *AzureMachine {
 	}
 }
 
-func createMachineWithOsDiskCacheType(t *testing.T, cacheType string) *AzureMachine {
+func createMachineWithOsDiskCacheType(cacheType string) *AzureMachine {
 	machine := &AzureMachine{
 		Spec: AzureMachineSpec{
 			SSHPublicKey: validSSHPublicKey,

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -36,91 +36,91 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 		{
 			name: "azuremachinetemplate with marketplane image - full",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithtMarketPlaceImage(t, "PUB1234", "OFFER1234", "SKU1234", "1.0.0"),
+				createMachineWithtMarketPlaceImage("PUB1234", "OFFER1234", "SKU1234", "1.0.0"),
 			),
 			wantErr: false,
 		},
 		{
 			name: "azuremachinetemplate with marketplace image - missing publisher",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithtMarketPlaceImage(t, "", "OFFER1234", "SKU1234", "1.0.0"),
+				createMachineWithtMarketPlaceImage("", "OFFER1234", "SKU1234", "1.0.0"),
 			),
 			wantErr: true,
 		},
 		{
 			name: "azuremachinetemplate with shared gallery image - full",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithSharedImage(t, "SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0"),
+				createMachineWithSharedImage("SUB123", "RG123", "NAME123", "GALLERY1", "1.0.0"),
 			),
 			wantErr: false,
 		},
 		{
 			name: "azuremachinetemplate with marketplace image - missing subscription",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithSharedImage(t, "", "RG123", "NAME123", "GALLERY1", "1.0.0"),
+				createMachineWithSharedImage("", "RG123", "NAME123", "GALLERY2", "1.0.0"),
 			),
 			wantErr: true,
 		},
 		{
 			name: "azuremachinetemplate with image by - with id",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithImageByID(t, "ID123"),
+				createMachineWithImageByID("ID123"),
 			),
 			wantErr: false,
 		},
 		{
 			name: "azuremachinetemplate with image by - without id",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithImageByID(t, ""),
+				createMachineWithImageByID(""),
 			),
 			wantErr: true,
 		},
 		{
 			name: "azuremachinetemplate with valid SSHPublicKey",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithSSHPublicKey(t, validSSHPublicKey),
+				createMachineWithSSHPublicKey(validSSHPublicKey),
 			),
 			wantErr: false,
 		},
 		{
 			name: "azuremachinetemplate without SSHPublicKey",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithSSHPublicKey(t, ""),
+				createMachineWithSSHPublicKey(""),
 			),
 			wantErr: true,
 		},
 		{
 			name: "azuremachinetemplate with invalid SSHPublicKey",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithSSHPublicKey(t, "invalid ssh key"),
+				createMachineWithSSHPublicKey("invalid ssh key"),
 			),
 			wantErr: true,
 		},
 		{
 			name: "azuremachinetemplate with list of user-assigned identities",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{{ProviderID: "azure:///123"}, {ProviderID: "azure:///456"}}),
+				createMachineWithUserAssignedIdentities([]UserAssignedIdentity{{ProviderID: "azure:///123"}, {ProviderID: "azure:///456"}}),
 			),
 			wantErr: false,
 		},
 		{
 			name: "azuremachinetemplate with empty list of user-assigned identities",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithUserAssignedIdentities(t, []UserAssignedIdentity{}),
+				createMachineWithUserAssignedIdentities([]UserAssignedIdentity{}),
 			),
 			wantErr: true,
 		},
 		{
 			name: "azuremachinetemplate with valid osDisk cache type",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithOsDiskCacheType(t, string(compute.PossibleCachingTypesValues()[1])),
+				createMachineWithOsDiskCacheType(string(compute.PossibleCachingTypesValues()[1])),
 			),
 			wantErr: false,
 		},
 		{
 			name: "azuremachinetemplate with invalid osDisk cache type",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				createMachineWithOsDiskCacheType(t, "invalid_cache_type"),
+				createMachineWithOsDiskCacheType("invalid_cache_type"),
 			),
 			wantErr: true,
 		},

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -265,7 +265,7 @@ func TestReconcileVMSS(t *testing.T) {
 				s.ScaleSetSpec().Return(defaultSpec).AnyTimes()
 				createdVMSS := newDefaultVMSS("VM_SIZE")
 				instances := newDefaultInstances()
-				_ = setupDefaultVMSSInProgressOperationDoneExpectations(s, m, createdVMSS, instances)
+				setupDefaultVMSSInProgressOperationDoneExpectations(s, m, createdVMSS, instances)
 				s.DeleteLongRunningOperationState(defaultSpec.Name, scope.ScalesetsServiceName)
 			},
 		},
@@ -277,7 +277,7 @@ func TestReconcileVMSS(t *testing.T) {
 				s.ScaleSetSpec().Return(defaultSpec).AnyTimes()
 				createdVMSS := newDefaultWindowsVMSS()
 				instances := newDefaultInstances()
-				_ = setupDefaultVMSSInProgressOperationDoneExpectations(s, m, createdVMSS, instances)
+				setupDefaultVMSSInProgressOperationDoneExpectations(s, m, createdVMSS, instances)
 				s.DeleteLongRunningOperationState(defaultSpec.Name, scope.ScalesetsServiceName)
 			},
 		},
@@ -1194,7 +1194,7 @@ func newDefaultInstances() []compute.VirtualMachineScaleSetVM {
 	}
 }
 
-func setupDefaultVMSSInProgressOperationDoneExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder, createdVMSS compute.VirtualMachineScaleSet, instances []compute.VirtualMachineScaleSetVM) compute.VirtualMachineScaleSet {
+func setupDefaultVMSSInProgressOperationDoneExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder, createdVMSS compute.VirtualMachineScaleSet, instances []compute.VirtualMachineScaleSetVM) {
 	createdVMSS.ID = to.StringPtr("vmss-id")
 	createdVMSS.ProvisioningState = to.StringPtr(string(infrav1.Succeeded))
 	setupDefaultVMSSExpectations(s)
@@ -1210,7 +1210,6 @@ func setupDefaultVMSSInProgressOperationDoneExpectations(s *mock_scalesets.MockS
 	s.MaxSurge().Return(1, nil)
 	s.SetVMSSState(gomock.Any())
 	s.SetProviderID(azure.ProviderIDPrefix + *createdVMSS.ID)
-	return createdVMSS
 }
 
 func setupDefaultVMSSStartCreatingExpectations(s *mock_scalesets.MockScaleSetScopeMockRecorder, m *mock_scalesets.MockClientMockRecorder) {

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -85,9 +85,9 @@ func TestGetCloudProviderConfig(t *testing.T) {
 
 	cluster := newCluster("foo")
 	cluster.Default()
-	azureCluster := newAzureCluster("foo", "bar")
+	azureCluster := newAzureCluster("bar")
 	azureCluster.Default()
-	azureClusterCustomVnet := newAzureClusterWithCustomVnet("foo", "bar")
+	azureClusterCustomVnet := newAzureClusterWithCustomVnet("bar")
 	azureClusterCustomVnet.Default()
 
 	cases := map[string]struct {
@@ -253,7 +253,7 @@ func TestReconcileAzureSecret(t *testing.T) {
 	}
 
 	cluster := newCluster("foo")
-	azureCluster := newAzureCluster("foo", "bar")
+	azureCluster := newAzureCluster("bar")
 
 	cluster.Default()
 	azureCluster.Default()
@@ -354,7 +354,7 @@ func newCluster(name string) *clusterv1.Cluster {
 	}
 }
 
-func newAzureCluster(name, location string) *infrav1.AzureCluster {
+func newAzureCluster(location string) *infrav1.AzureCluster {
 	return &infrav1.AzureCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -405,7 +405,7 @@ func withbackOffConfig(ac infrav1.AzureCluster) *infrav1.AzureCluster {
 	return &ac
 }
 
-func newAzureClusterWithCustomVnet(name, location string) *infrav1.AzureCluster {
+func newAzureClusterWithCustomVnet(location string) *infrav1.AzureCluster {
 	return &infrav1.AzureCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",

--- a/exp/api/v1beta1/azuremanagedcontrolplane_default_test.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_default_test.go
@@ -30,8 +30,8 @@ func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
 	}
 
 	existingPublicKey := "testpublickey"
-	publicKeyExistTest := test{r: createAzureManagedControlPlaneWithSSHPublicKey(t, existingPublicKey)}
-	publicKeyNotExistTest := test{r: createAzureManagedControlPlaneWithSSHPublicKey(t, "")}
+	publicKeyExistTest := test{r: createAzureManagedControlPlaneWithSSHPublicKey(existingPublicKey)}
+	publicKeyNotExistTest := test{r: createAzureManagedControlPlaneWithSSHPublicKey("")}
 
 	err := publicKeyExistTest.r.setDefaultSSHPublicKey()
 	g.Expect(err).To(BeNil())
@@ -42,7 +42,7 @@ func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
 	g.Expect(publicKeyNotExistTest.r.Spec.SSHPublicKey).NotTo(BeEmpty())
 }
 
-func createAzureManagedControlPlaneWithSSHPublicKey(t *testing.T, sshPublicKey string) *AzureManagedControlPlane {
+func createAzureManagedControlPlaneWithSSHPublicKey(sshPublicKey string) *AzureManagedControlPlane {
 	return hardcodedAzureManagedControlPlaneWithSSHKey(sshPublicKey)
 }
 

--- a/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -279,25 +279,25 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:     "invalid DNSServiceIP",
-			amcp:     createAzureManagedControlPlane(t, "192.168.0.0.3", "v1.18.0", generateSSHPublicKey(true)),
+			amcp:     createAzureManagedControlPlane("192.168.0.0.3", "v1.18.0", generateSSHPublicKey(true)),
 			wantErr:  true,
 			errorLen: 1,
 		},
 		{
 			name:     "invalid sshKey",
-			amcp:     createAzureManagedControlPlane(t, "192.168.0.0", "v1.18.0", generateSSHPublicKey(false)),
+			amcp:     createAzureManagedControlPlane("192.168.0.0", "v1.18.0", generateSSHPublicKey(false)),
 			wantErr:  true,
 			errorLen: 1,
 		},
 		{
 			name:     "invalid sshKey with a simple text and invalid DNSServiceIP",
-			amcp:     createAzureManagedControlPlane(t, "192.168.0.0.3", "v1.18.0", "invalid_sshkey_honk"),
+			amcp:     createAzureManagedControlPlane("192.168.0.0.3", "v1.18.0", "invalid_sshkey_honk"),
 			wantErr:  true,
 			errorLen: 2,
 		},
 		{
 			name:     "invalid version",
-			amcp:     createAzureManagedControlPlane(t, "192.168.0.0", "honk.version", generateSSHPublicKey(true)),
+			amcp:     createAzureManagedControlPlane("192.168.0.0", "honk.version", generateSSHPublicKey(true)),
 			wantErr:  true,
 			errorLen: 1,
 		},
@@ -326,26 +326,26 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 	}{
 		{
 			name:    "AzureManagedControlPlane with valid SSHPublicKey",
-			oldAMCP: createAzureManagedControlPlane(t, "192.168.0.0", "v1.18.0", ""),
-			amcp:    createAzureManagedControlPlane(t, "192.168.0.0", "v1.18.0", generateSSHPublicKey(true)),
+			oldAMCP: createAzureManagedControlPlane("192.168.0.0", "v1.18.0", ""),
+			amcp:    createAzureManagedControlPlane("192.168.0.0", "v1.18.0", generateSSHPublicKey(true)),
 			wantErr: false,
 		},
 		{
 			name:    "AzureManagedControlPlane with invalid SSHPublicKey",
-			oldAMCP: createAzureManagedControlPlane(t, "192.168.0.0", "v1.18.0", ""),
-			amcp:    createAzureManagedControlPlane(t, "192.168.0.0", "v1.18.0", generateSSHPublicKey(false)),
+			oldAMCP: createAzureManagedControlPlane("192.168.0.0", "v1.18.0", ""),
+			amcp:    createAzureManagedControlPlane("192.168.0.0", "v1.18.0", generateSSHPublicKey(false)),
 			wantErr: true,
 		},
 		{
 			name:    "AzureManagedControlPlane with invalid serviceIP",
-			oldAMCP: createAzureManagedControlPlane(t, "", "v1.18.0", ""),
-			amcp:    createAzureManagedControlPlane(t, "192.168.0.0.3", "v1.18.0", generateSSHPublicKey(true)),
+			oldAMCP: createAzureManagedControlPlane("", "v1.18.0", ""),
+			amcp:    createAzureManagedControlPlane("192.168.0.0.3", "v1.18.0", generateSSHPublicKey(true)),
 			wantErr: true,
 		},
 		{
 			name:    "AzureManagedControlPlane with invalid version",
-			oldAMCP: createAzureManagedControlPlane(t, "", "v1.18.0", ""),
-			amcp:    createAzureManagedControlPlane(t, "192.168.0.0", "1.999.9", generateSSHPublicKey(true)),
+			oldAMCP: createAzureManagedControlPlane("", "v1.18.0", ""),
+			amcp:    createAzureManagedControlPlane("192.168.0.0", "1.999.9", generateSSHPublicKey(true)),
 			wantErr: true,
 		},
 		{
@@ -737,7 +737,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 	}
 }
 
-func createAzureManagedControlPlane(t *testing.T, serviceIP, version, sshKey string) *AzureManagedControlPlane {
+func createAzureManagedControlPlane(serviceIP, version, sshKey string) *AzureManagedControlPlane {
 	return &AzureManagedControlPlane{
 		Spec: AzureManagedControlPlaneSpec{
 			SSHPublicKey: sshKey,

--- a/exp/controllers/azuremachinepool_controller_unit_test.go
+++ b/exp/controllers/azuremachinepool_controller_unit_test.go
@@ -38,7 +38,7 @@ func Test_newAzureMachinePoolService(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	cluster := newAzureCluster("foo")
+	cluster := newAzureCluster("fakeCluster")
 	cluster.Spec.ResourceGroup = "resourceGroup"
 	cluster.Spec.Location = "test-location"
 	cluster.Spec.ResourceGroup = "my-rg"
@@ -52,11 +52,11 @@ func Test_newAzureMachinePoolService(t *testing.T) {
 	clusterMock.EXPECT().BaseURI().AnyTimes()
 	clusterMock.EXPECT().Authorizer().AnyTimes()
 	clusterMock.EXPECT().Location().Return(cluster.Spec.Location)
-	clusterMock.EXPECT().HashKey().Return("foo")
+	clusterMock.EXPECT().HashKey().Return("fakeCluster")
 
 	mps := &scope.MachinePoolScope{
 		ClusterScoper: clusterMock,
-		MachinePool:   newMachinePool("foo", "poolName"),
+		MachinePool:   newMachinePool("fakeCluster", "poolName"),
 		AzureMachinePool: &infrav1exp.AzureMachinePool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "poolName",

--- a/exp/controllers/helpers_test.go
+++ b/exp/controllers/helpers_test.go
@@ -561,7 +561,7 @@ func Test_azureClusterToAzureMachinePoolsFunc(t *testing.T) {
 		{
 			Name: "NotAnAzureCluster",
 			MapObjectFactory: func(g *GomegaWithT) client.Object {
-				return newMachinePool("foo", "bar")
+				return newMachinePool("fakeCluster", "bar")
 			},
 			Setup: func(g *GomegaWithT, t *testing.T) (*mock_log.MockLogger, *gomock.Controller, client.Client) {
 				mockCtrl := gomock.NewController(t)

--- a/main.go
+++ b/main.go
@@ -313,7 +313,7 @@ func main() {
 
 	registerControllers(ctx, mgr)
 
-	registerWebhooks(ctx, mgr)
+	registerWebhooks(mgr)
 
 	// +kubebuilder:scaffold:builder
 	setupLog.Info("starting manager", "version", version.Get().String())
@@ -473,7 +473,7 @@ func registerControllers(ctx context.Context, mgr manager.Manager) {
 	}
 }
 
-func registerWebhooks(ctx context.Context, mgr manager.Manager) {
+func registerWebhooks(mgr manager.Manager) {
 	if err := (&infrav1beta1.AzureCluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureCluster")
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: Ashutosh Kumar <sonasingh46@gmail.com>

/kind cleanup

**What this PR does / why we need it**:
This PR adds `unparam` linter 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Reference umbrella issue: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1982

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
