### PR TITLE
skip updating the AKS agentpoolprofile count if autoscaling is enabled (managed clusters)

### DIFF
--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
 
 	infrav1alpha4 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -133,10 +134,16 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			},
 		}
 
+		if profile.EnableAutoScaling != nil && *profile.EnableAutoScaling {
+			// unset the nodepool count if autoscaling is enabled
+			normalizedProfile.Count = nil
+			existingProfile.Count = nil
+		}
+
 		// Diff and check if we require an update
 		diff := cmp.Diff(normalizedProfile, existingProfile)
 		if diff != "" {
-			log.V(2).Info(fmt.Sprintf("Update required (+new -old):\n%s", diff))
+			klog.V(2).Info(fmt.Sprintf("Update required (+new -old):\n%s", diff))
 			err = s.Client.CreateOrUpdate(ctx, agentPoolSpec.ResourceGroup, agentPoolSpec.Cluster, agentPoolSpec.Name, profile)
 			if err != nil {
 				return errors.Wrap(err, "failed to create or update agent pool")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
when autoscaling is enabled for AKS we are still trying to update the agentpoolprofile with initial `replicas`.
autoscaling can continuously change the count of agentpool, so we should skip updating the count if autoscaling is enabled. 
Otherwise, we are updating the agentpool on each reconcile. 

Also doing a cleanup to use `klog` to print diff for any changes in agentpool

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
