### PR TITLE
Add a subnet role for bastions and enum validation

### DIFF
--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -35,6 +35,8 @@ const (
 	DefaultAzureBastionSubnetCIDR = "10.255.255.224/27"
 	// DefaultAzureBastionSubnetName is the default Subnet Name for AzureBastion.
 	DefaultAzureBastionSubnetName = "AzureBastionSubnet"
+	// DefaultAzureBastionSubnetRole is the default Subnet role for AzureBastion.
+	DefaultAzureBastionSubnetRole = SubnetBastion
 	// DefaultInternalLBIPAddress is the default internal load balancer ip address.
 	DefaultInternalLBIPAddress = "10.0.0.100"
 	// DefaultOutboundRuleIdleTimeoutInMinutes is the default for IdleTimeoutInMinutes for the load balancer.
@@ -314,6 +316,9 @@ func (c *AzureCluster) setBastionDefaults() {
 		}
 		if len(c.Spec.BastionSpec.AzureBastion.Subnet.CIDRBlocks) == 0 {
 			c.Spec.BastionSpec.AzureBastion.Subnet.CIDRBlocks = []string{DefaultAzureBastionSubnetCIDR}
+		}
+		if c.Spec.BastionSpec.AzureBastion.Subnet.Role == "" {
+			c.Spec.BastionSpec.AzureBastion.Subnet.Role = DefaultAzureBastionSubnetRole
 		}
 		// Ensure defaults for the PublicIP settings.
 		if c.Spec.BastionSpec.AzureBastion.PublicIP.Name == "" {

--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -1559,6 +1559,7 @@ func TestBastionDefault(t *testing.T) {
 							Subnet: SubnetSpec{
 								Name:       "AzureBastionSubnet",
 								CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
+								Role:       DefaultAzureBastionSubnetRole,
 							},
 							PublicIP: PublicIPSpec{
 								Name: "foo-azure-bastion-pip",
@@ -1592,6 +1593,7 @@ func TestBastionDefault(t *testing.T) {
 							Subnet: SubnetSpec{
 								Name:       "AzureBastionSubnet",
 								CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
+								Role:       DefaultAzureBastionSubnetRole,
 							},
 							PublicIP: PublicIPSpec{
 								Name: "foo-azure-bastion-pip",
@@ -1625,6 +1627,7 @@ func TestBastionDefault(t *testing.T) {
 							Subnet: SubnetSpec{
 								Name:       "AzureBastionSubnet",
 								CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
+								Role:       DefaultAzureBastionSubnetRole,
 							},
 							PublicIP: PublicIPSpec{
 								Name: "foo-azure-bastion-pip",
@@ -1661,6 +1664,7 @@ func TestBastionDefault(t *testing.T) {
 							Subnet: SubnetSpec{
 								Name:       "my-superfancy-name",
 								CIDRBlocks: []string{"10.10.0.0/16"},
+								Role:       DefaultAzureBastionSubnetRole,
 							},
 							PublicIP: PublicIPSpec{
 								Name: "foo-azure-bastion-pip",
@@ -1696,6 +1700,7 @@ func TestBastionDefault(t *testing.T) {
 							Subnet: SubnetSpec{
 								Name:       "AzureBastionSubnet",
 								CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
+								Role:       DefaultAzureBastionSubnetRole,
 							},
 							PublicIP: PublicIPSpec{
 								Name: "my-ultrafancy-pip-name",

--- a/api/v1beta1/tags.go
+++ b/api/v1beta1/tags.go
@@ -126,7 +126,7 @@ const (
 	ControlPlaneOutboundRole = "controlPlaneOutbound"
 
 	// BastionRole describes the value for the bastion role.
-	BastionRole = "bastion"
+	BastionRole = Bastion
 
 	// CommonRole describes the value for the common role.
 	CommonRole = "common"

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -26,6 +26,8 @@ const (
 	ControlPlane string = "control-plane"
 	// Node machine label.
 	Node string = "node"
+	// Bastion subnet label.
+	Bastion string = "bastion"
 )
 
 // Futures is a slice of Future.
@@ -514,11 +516,15 @@ const (
 
 	// SubnetControlPlane defines a Kubernetes control plane node role.
 	SubnetControlPlane = SubnetRole(ControlPlane)
+
+	// SubnetBastion defines a Bastion subnet role.
+	SubnetBastion = SubnetRole(Bastion)
 )
 
 // SubnetSpec configures an Azure subnet.
 type SubnetSpec struct {
 	// Role defines the subnet role (eg. Node, ControlPlane)
+	// +kubebuilder:validation:Enum=node;control-plane;bastion
 	Role SubnetRole `json:"role"`
 
 	// ID is the Azure resource ID of the subnet.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -1366,6 +1366,10 @@ spec:
                             type: object
                           role:
                             description: Role defines the subnet role (eg. Node, ControlPlane)
+                            enum:
+                            - node
+                            - control-plane
+                            - bastion
                             type: string
                           routeTable:
                             description: RouteTable defines the route table that should
@@ -1838,6 +1842,10 @@ spec:
                           type: object
                         role:
                           description: Role defines the subnet role (eg. Node, ControlPlane)
+                          enum:
+                          - node
+                          - control-plane
+                          - bastion
                           type: string
                         routeTable:
                           description: RouteTable defines the route table that should

--- a/templates/test/ci/prow-private/patches/bastion.yaml
+++ b/templates/test/ci/prow-private/patches/bastion.yaml
@@ -12,4 +12,4 @@ spec:
         cidrBlocks:
         - ${AZURE_BASTION_SUBNET_CIDR}
         name: AzureBastionSubnet
-        role: "bastion"
+        role: bastion


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Currently there is no role for AzureBastions. It would make sense to define a role similar to how it's done for node and control plane subnets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2000 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a subnet role for bastions
```
