### PR TITLE
Update private cluster cleanup to use the right API version for private DNS

### DIFF
--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -28,6 +29,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	azuresdk "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
@@ -441,6 +443,9 @@ func getAPIVersion(resourceID string) (string, error) {
 
 	switch parsed.Provider {
 	case "Microsoft.Network":
+		if parsed.ResourceType == "privateDnsZones" {
+			return getAPIVersionFromUserAgent(privatedns.UserAgent()), nil
+		}
 		return getAPIVersionFromUserAgent(network.UserAgent()), nil
 	case "Microsoft.Compute":
 		return getAPIVersionFromUserAgent(compute.UserAgent()), nil


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Private DNS resources are in the Microsoft.Network provider but not in the `network` sdk service and have their own API version. Using the wrong API version was causing a flake when the resource group list was still showing a DNS zone but the GET would return 404 (ref https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1507/files#diff-a18d58ea4b72ff83f83e62ae5a6500ea0de4759cdf9da9cdefa97b3b728d03b6R395)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2002 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
