### PR TITLE
Increase wait for service timeout in e2e

### DIFF
--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -221,6 +221,6 @@ intervals:
   default/wait-deployment: ["15m", "10s"]
   default/wait-deployment-available: ["15m", "10s"]
   default/wait-job: ["5m", "10s"]
-  default/wait-service: ["5m", "10s"]
+  default/wait-service: ["15m", "10s"]
   default/wait-machine-pool-nodes: ["30m", "10s"]
   node-drain/wait-machine-deleted: [ "10m", "10s" ]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Been seeing a few flakes lately that failed with `Timed out after 300.023s. Service default/webxc1v0w-elb failed`.

I looked into a specific one and it looks we're just not waiting long enough:

```
Jan 25 23:27:17.969: INFO: starting to create an external Load Balancer service
Jan 25 23:27:18.045: INFO: waiting for service default/webxc1v0w-elb to be available
```

which means we timed out at exactly `23:32:18.045`, with an interval of 10s (checking again every 10 seconds).

But, the service status was just patched 6 seconds before that:

```
I0125 23:32:12.614654       1 controller.go:953] Patching status for service default/webxc1v0w-elb
I0125 23:32:12.615238       1 event.go:291] "Event occurred" object="default/webxc1v0w-elb" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
```

which means we might have timed out right when the service became available. Increasing the timeout to 10 minutes to see if it will get rid of most flakes.

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/2001/pull-cluster-api-provider-azure-e2e/1486114202694193152
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/2001/pull-cluster-api-provider-azure-e2e/1486114202694193152/artifacts/clusters/capz-e2e-5rasb4-ha/kube-system/kube-controller-manager-capz-e2e-5rasb4-ha-control-plane-h7j2m/kube-controller-manager.log

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
