### PR TITLE
Capture NSSM log output files in e2e for windows

### DIFF
--- a/test/e2e/azure_logcollector.go
+++ b/test/e2e/azure_logcollector.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -250,7 +251,7 @@ func windowsK8sLogs(execToPathFn func(outputFileName string, command string, arg
 		),
 		execToPathFn(
 			"kubelet.log",
-			`Get-ChildItem "C:\\var\\log\\kubelet\\"  | ForEach-Object { if ($_ -match 'log.INFO') { write-output "$_";cat "c:\\var\\log\\kubelet\\$_" } }`,
+			`Get-ChildItem "C:\\var\\log\\kubelet\\"  | ForEach-Object { if ($_ -match 'log.INFO|err.*.log') { write-output "$_";cat "c:\\var\\log\\kubelet\\$_" } }`,
 		),
 		execToPathFn(
 			"cni.log",


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change

/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
With the f[ix that went into Image builder to use nssm for log rotation](https://github.com/kubernetes-sigs/image-builder/pull/762) on Windows, the log naming is slightly different. This updates to use either format.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
