### PR TITLE
Fix the custom vnet test template to provide the route table and nsg names

### DIFF
--- a/docs/book/src/topics/custom-vnet.md
+++ b/docs/book/src/topics/custom-vnet.md
@@ -17,10 +17,16 @@ spec:
       resourceGroup: custom-vnet
       name: my-vnet
     subnets:
-      - name: control-plane-subnet
+      - name: my-control-plane-subnet
         role: control-plane
-      - name: node-subnet
+        securityGroup:
+          name: my-control-plane-nsg
+      - name: my-node-subnet
         role: node
+        routeTable:
+          name: my-node-routetable
+        securityGroup:
+          name: my-node-nsg
   resourceGroup: cluster-byo-vnet
   ```
 

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -38,8 +38,14 @@ spec:
     subnets:
     - name: ${AZURE_CUSTOM_VNET_NAME}-controlplane-subnet
       role: control-plane
+      securityGroup:
+        name: control-plane-nsg
     - name: ${AZURE_CUSTOM_VNET_NAME}-node-subnet
       role: node
+      routeTable:
+        name: node-routetable
+      securityGroup:
+        name: node-nsg
     vnet:
       name: ${AZURE_CUSTOM_VNET_NAME}
       resourceGroup: ${AZURE_RESOURCE_GROUP}

--- a/templates/test/ci/prow-custom-vnet/patches/custom-vnet.yaml
+++ b/templates/test/ci/prow-custom-vnet/patches/custom-vnet.yaml
@@ -10,5 +10,11 @@ spec:
     subnets:
       - name: ${AZURE_CUSTOM_VNET_NAME}-controlplane-subnet
         role: control-plane
+        securityGroup:
+          name: control-plane-nsg
       - name: ${AZURE_CUSTOM_VNET_NAME}-node-subnet
         role: node
+        routeTable:
+          name: node-routetable
+        securityGroup:
+          name: node-nsg

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -141,7 +142,7 @@ var _ = Describe("Workload cluster creation", func() {
 
 	if os.Getenv("LOCAL_ONLY") != "true" {
 		Context("Creating a private cluster", func() {
-			It("Creates a public management cluster in the same vnet", func() {
+			It("Creates a public management cluster a custom vnet", func() {
 				clusterName = getClusterName(clusterNamePrefix, "public-custom-vnet")
 				Context("Creating a custom virtual network", func() {
 					Expect(os.Setenv(AzureCustomVNetName, "custom-vnet")).NotTo(HaveOccurred())

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Workload cluster creation", func() {
 
 	if os.Getenv("LOCAL_ONLY") != "true" {
 		Context("Creating a private cluster", func() {
-			It("Creates a public management cluster a custom vnet", func() {
+			It("Creates a public management cluster in a custom vnet", func() {
 				clusterName = getClusterName(clusterNamePrefix, "public-custom-vnet")
 				Context("Creating a custom virtual network", func() {
 					Expect(os.Setenv(AzureCustomVNetName, "custom-vnet")).NotTo(HaveOccurred())


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This is fixing the flake observed in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/1994/pull-cluster-api-provider-azure-e2e/1486169658842157056. We were creating a custom vnet with subnets and route table + nsg out of band, but not setting the route table and NSG name in the template. This caused CAPZ to skip reconciliation for route tables and NSGs, but then to pass default RT and NSG names to the cloud provider, and cloud provider would create the route table with default name to use it instead of the one we created. The flake was caused by the fact that the extra route table didn't get properly deleted which caused the cleanup step to fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
