### PR TITLE
Remove deprecated cloud-config and cloud-provider from kubelet configs

### DIFF
--- a/docs/book/src/topics/machinepools.md
+++ b/docs/book/src/topics/machinepools.md
@@ -173,8 +173,5 @@ spec:
     permissions: "0644"
   joinConfiguration:
     nodeRegistration:
-      kubeletExtraArgs:
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
 ```

--- a/templates/cluster-template-aad.yaml
+++ b/templates/cluster-template-aad.yaml
@@ -111,15 +111,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -213,8 +209,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       useExperimentalRetryJoin: true
 ---

--- a/templates/cluster-template-azure-bastion.yaml
+++ b/templates/cluster-template-azure-bastion.yaml
@@ -108,15 +108,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -207,8 +203,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---

--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -106,15 +106,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -211,8 +207,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---

--- a/templates/cluster-template-external-cloud-provider.yaml
+++ b/templates/cluster-template-external-cloud-provider.yaml
@@ -107,15 +107,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -206,8 +202,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -126,8 +126,6 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
           cluster-dns: fd00::10
           node-ip: '::'
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -139,8 +137,6 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
           cluster-dns: fd00::10
           node-ip: '::'
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -268,8 +264,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
             cluster-dns: '[fd00::10]'
             node-ip: '::'
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-machinepool-multiple-subnets.yaml
+++ b/templates/cluster-template-machinepool-multiple-subnets.yaml
@@ -110,15 +110,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -214,8 +210,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -297,6 +291,4 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-machinepool-system-assigned-identity.yaml
+++ b/templates/cluster-template-machinepool-system-assigned-identity.yaml
@@ -102,15 +102,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -206,6 +202,4 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-machinepool-user-assigned-identity.yaml
+++ b/templates/cluster-template-machinepool-user-assigned-identity.yaml
@@ -102,15 +102,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -208,6 +204,4 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-machinepool-windows-containerd.yaml
+++ b/templates/cluster-template-machinepool-windows-containerd.yaml
@@ -108,15 +108,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -211,8 +207,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -293,8 +287,6 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         azure-container-registry-config: c:/k/azure.json
-        cloud-config: c:/k/azure.json
-        cloud-provider: azure
         feature-gates: WindowsHostProcessContainers=true
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -119,15 +119,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -247,8 +243,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
@@ -310,7 +304,7 @@ spec:
     owner: root:root
     path: c:/k/azure.json
     permissions: "0644"
-  - content: |-
+  - content: |
       # required as a work around for Flannel and Wins bugs
       # https://github.com/coreos/flannel/issues/1359
       # https://github.com/kubernetes-sigs/sig-windows-tools/issues/103#issuecomment-709426828
@@ -322,8 +316,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: c:/k/azure.json
-        cloud-config: c:/k/azure.json
-        cloud-provider: azure
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:1.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -106,15 +106,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -209,8 +205,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-nvidia-gpu.yaml
+++ b/templates/cluster-template-nvidia-gpu.yaml
@@ -107,15 +107,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -224,8 +220,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-private.yaml
+++ b/templates/cluster-template-private.yaml
@@ -115,15 +115,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -219,8 +215,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---

--- a/templates/cluster-template-system-assigned-identity.yaml
+++ b/templates/cluster-template-system-assigned-identity.yaml
@@ -102,15 +102,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -203,7 +199,5 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/cluster-template-user-assigned-identity.yaml
+++ b/templates/cluster-template-user-assigned-identity.yaml
@@ -102,15 +102,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -207,7 +203,5 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/cluster-template-windows-containerd.yaml
+++ b/templates/cluster-template-windows-containerd.yaml
@@ -108,15 +108,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -207,8 +203,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---
@@ -296,8 +290,6 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -119,15 +119,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -235,8 +231,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
@@ -318,8 +312,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -106,15 +106,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -205,8 +201,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---

--- a/templates/flavors/aad/machine-deployment.yaml
+++ b/templates/flavors/aad/machine-deployment.yaml
@@ -49,8 +49,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            cloud-provider: azure
-            cloud-config: /etc/kubernetes/azure.json
             azure-container-registry-config: /etc/kubernetes/azure.json
       files:
       - contentFrom:

--- a/templates/flavors/aad/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/aad/patches/kubeadm-controlplane.yaml
@@ -9,15 +9,11 @@ spec:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'
         kubeletExtraArgs:
-          cloud-provider: azure
-          cloud-config: /etc/kubernetes/azure.json
           azure-container-registry-config: /etc/kubernetes/azure.json
     joinConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'
         kubeletExtraArgs:
-          cloud-provider: azure
-          cloud-config: /etc/kubernetes/azure.json
           azure-container-registry-config: /etc/kubernetes/azure.json
     clusterConfiguration:
       apiServer:

--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -53,15 +53,11 @@ spec:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'
         kubeletExtraArgs:
-          cloud-provider: azure
-          cloud-config: /etc/kubernetes/azure.json
           azure-container-registry-config: /etc/kubernetes/azure.json
     joinConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'
         kubeletExtraArgs:
-          cloud-provider: azure
-          cloud-config: /etc/kubernetes/azure.json
           azure-container-registry-config: /etc/kubernetes/azure.json
     clusterConfiguration:
       apiServer:

--- a/templates/flavors/default/machine-deployment.yaml
+++ b/templates/flavors/default/machine-deployment.yaml
@@ -47,8 +47,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            cloud-provider: azure
-            cloud-config: /etc/kubernetes/azure.json
             azure-container-registry-config: /etc/kubernetes/azure.json
       files:
       - contentFrom:

--- a/templates/flavors/external-cloud-provider/patches/external-cloud-provider.yaml
+++ b/templates/flavors/external-cloud-provider/patches/external-cloud-provider.yaml
@@ -16,12 +16,10 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          cloud-provider: external
           azure-container-registry-config: /etc/kubernetes/azure.json
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          cloud-provider: external
           azure-container-registry-config: /etc/kubernetes/azure.json
     clusterConfiguration:
       apiServer:
@@ -41,5 +39,4 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: external
             azure-container-registry-config: /etc/kubernetes/azure.json

--- a/templates/flavors/ipv6/machine-deployment.yaml
+++ b/templates/flavors/ipv6/machine-deployment.yaml
@@ -54,8 +54,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            cloud-provider: azure
-            cloud-config: /etc/kubernetes/azure.json
             azure-container-registry-config: /etc/kubernetes/azure.json
             node-ip: "::"
             cluster-dns: "[fd00::10]"

--- a/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
@@ -14,8 +14,6 @@ spec:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'
         kubeletExtraArgs:
-          cloud-provider: azure
-          cloud-config: /etc/kubernetes/azure.json
           azure-container-registry-config: /etc/kubernetes/azure.json
           node-ip: "::"
           cluster-dns: "fd00::10"
@@ -26,8 +24,6 @@ spec:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'
         kubeletExtraArgs:
-          cloud-provider: azure
-          cloud-config: /etc/kubernetes/azure.json
           azure-container-registry-config: /etc/kubernetes/azure.json
           node-ip: "::"
           cluster-dns: "fd00::10"

--- a/templates/flavors/machinepool-multiple-subnets/machine-pool-deployment.yaml
+++ b/templates/flavors/machinepool-multiple-subnets/machine-pool-deployment.yaml
@@ -51,8 +51,6 @@ spec:
     nodeRegistration:
       name: '{{ ds.meta_data["local_hostname"] }}'
       kubeletExtraArgs:
-        cloud-provider: azure
-        cloud-config: /etc/kubernetes/azure.json
         azure-container-registry-config: /etc/kubernetes/azure.json
   files:
   - contentFrom:

--- a/templates/flavors/machinepool-system-assigned-identity/machine-pool-deployment.yaml
+++ b/templates/flavors/machinepool-system-assigned-identity/machine-pool-deployment.yaml
@@ -50,8 +50,6 @@ spec:
     nodeRegistration:
       name: '{{ ds.meta_data["local_hostname"] }}'
       kubeletExtraArgs:
-        cloud-provider: azure
-        cloud-config: /etc/kubernetes/azure.json
         azure-container-registry-config: /etc/kubernetes/azure.json
   files:
   - contentFrom:

--- a/templates/flavors/machinepool-user-assigned-identity/machine-pool-deployment.yaml
+++ b/templates/flavors/machinepool-user-assigned-identity/machine-pool-deployment.yaml
@@ -50,8 +50,6 @@ spec:
     nodeRegistration:
       name: '{{ ds.meta_data["local_hostname"] }}'
       kubeletExtraArgs:
-        cloud-provider: azure
-        cloud-config: /etc/kubernetes/azure.json
         azure-container-registry-config: /etc/kubernetes/azure.json
   files:
   - contentFrom:

--- a/templates/flavors/machinepool-windows-containerd/machine-pool-deployment-windows.yaml
+++ b/templates/flavors/machinepool-windows-containerd/machine-pool-deployment-windows.yaml
@@ -57,8 +57,6 @@ spec:
       name: '{{ ds.meta_data["local_hostname"] }}'
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
-        cloud-provider: azure
-        cloud-config: 'c:/k/azure.json'
         azure-container-registry-config: 'c:/k/azure.json'
         pod-infra-container-image: "mcr.microsoft.com/oss/kubernetes/pause:3.4.1"
         feature-gates: "WindowsHostProcessContainers=true"

--- a/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
+++ b/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
@@ -55,8 +55,6 @@ spec:
     nodeRegistration:
       name: '{{ ds.meta_data["local_hostname"] }}'
       kubeletExtraArgs:
-        cloud-provider: azure
-        cloud-config: 'c:/k/azure.json'
         azure-container-registry-config: 'c:/k/azure.json'
         pod-infra-container-image: "mcr.microsoft.com/oss/kubernetes/pause:1.4.1"
   files:

--- a/templates/flavors/machinepool-windows/machine-pool-deployment.yaml
+++ b/templates/flavors/machinepool-windows/machine-pool-deployment.yaml
@@ -41,20 +41,18 @@ metadata:
   name: "${CLUSTER_NAME}-mp-0"
 spec:
   postKubeadmCommands:
-    # Azures vnet MTU is 1400. 
-    # When using Flannel VXLAN to avoid packet fragmentation 
+    # Azures vnet MTU is 1400.
+    # When using Flannel VXLAN to avoid packet fragmentation
     # that results dropped packets on Windows we need to match.
     # Flannel will automatically choose eth0 - 50
     - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
     - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
-    - netplan apply 
+    - netplan apply
   useExperimentalRetryJoin: true
   joinConfiguration:
     nodeRegistration:
       name: '{{ ds.meta_data["local_hostname"] }}'
       kubeletExtraArgs:
-        cloud-provider: azure
-        cloud-config: /etc/kubernetes/azure.json
         azure-container-registry-config: /etc/kubernetes/azure.json
   files:
   - contentFrom:

--- a/templates/flavors/machinepool/machine-pool-deployment.yaml
+++ b/templates/flavors/machinepool/machine-pool-deployment.yaml
@@ -50,8 +50,6 @@ spec:
     nodeRegistration:
       name: '{{ ds.meta_data["local_hostname"] }}'
       kubeletExtraArgs:
-        cloud-provider: azure
-        cloud-config: /etc/kubernetes/azure.json
         azure-container-registry-config: /etc/kubernetes/azure.json
   files:
   - contentFrom:

--- a/templates/flavors/nvidia-gpu/machine-deployment.yaml
+++ b/templates/flavors/nvidia-gpu/machine-deployment.yaml
@@ -48,8 +48,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            cloud-provider: azure
-            cloud-config: /etc/kubernetes/azure.json
             azure-container-registry-config: /etc/kubernetes/azure.json
       files:
         - contentFrom:

--- a/templates/flavors/windows-containerd/machine-deployment-windows.yaml
+++ b/templates/flavors/windows-containerd/machine-deployment-windows.yaml
@@ -60,8 +60,6 @@ spec:
           name: '{{ ds.meta_data["local_hostname"] }}'
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
-            cloud-provider: azure
-            cloud-config: 'c:/k/azure.json'
             azure-container-registry-config: 'c:/k/azure.json'
             feature-gates: "WindowsHostProcessContainers=true"
             v: "2"

--- a/templates/flavors/windows/machine-deployment-windows.yaml
+++ b/templates/flavors/windows/machine-deployment-windows.yaml
@@ -62,8 +62,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            cloud-provider: azure
-            cloud-config: 'c:/k/azure.json'
             azure-container-registry-config: 'c:/k/azure.json'
       files:
       - contentFrom:

--- a/templates/flavors/windows/machine-deployment.yaml
+++ b/templates/flavors/windows/machine-deployment.yaml
@@ -46,20 +46,18 @@ spec:
     spec:
       preKubeadmCommands: []
       postKubeadmCommands:
-        # Azures vnet MTU is 1400. 
-        # When using Flannel VXLAN to avoid packet fragmentation 
+        # Azures vnet MTU is 1400.
+        # When using Flannel VXLAN to avoid packet fragmentation
         # that results dropped packets on Windows we need to match.
         # Flannel will automatically choose eth0 - 50
         - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
         - sed -i -e "s/MACADDRESS/$${mac}/g" /etc/netplan/60-eth0.yaml
-        - netplan apply 
+        - netplan apply
       useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            cloud-provider: azure
-            cloud-config: /etc/kubernetes/azure.json
             azure-container-registry-config: /etc/kubernetes/azure.json
       files:
       - contentFrom:
@@ -81,4 +79,3 @@ spec:
                 match:
                   macaddress: MACADDRESS
                 set-name: eth0
-      

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -181,15 +181,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -361,8 +357,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
       - bash -c /tmp/kubeadm-bootstrap.sh
@@ -482,8 +476,6 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS

--- a/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
@@ -190,15 +190,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -384,8 +380,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
@@ -503,8 +497,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -181,15 +181,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -361,8 +357,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
       - bash -c /tmp/kubeadm-bootstrap.sh
@@ -482,8 +476,6 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -110,15 +110,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -211,8 +207,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---

--- a/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-external-cloud-provider.yaml
@@ -113,15 +113,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: external
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -212,8 +208,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -131,8 +131,6 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
           cluster-dns: fd00::10
           node-ip: '::'
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -144,8 +142,6 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
           cluster-dns: fd00::10
           node-ip: '::'
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -273,8 +269,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
             cluster-dns: '[fd00::10]'
             node-ip: '::'
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -179,15 +179,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -361,8 +357,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
   preKubeadmCommands:
   - bash -c /tmp/kubeadm-bootstrap.sh
@@ -476,8 +470,6 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         azure-container-registry-config: c:/k/azure.json
-        cloud-config: c:/k/azure.json
-        cloud-provider: azure
         feature-gates: WindowsHostProcessContainers=true
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
@@ -124,15 +124,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -252,8 +248,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
@@ -315,7 +309,7 @@ spec:
     owner: root:root
     path: c:/k/azure.json
     permissions: "0644"
-  - content: |-
+  - content: |
       # required as a work around for Flannel and Wins bugs
       # https://github.com/coreos/flannel/issues/1359
       # https://github.com/kubernetes-sigs/sig-windows-tools/issues/103#issuecomment-709426828
@@ -332,8 +326,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: c:/k/azure.json
-        cloud-config: c:/k/azure.json
-        cloud-provider: azure
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:1.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -113,15 +113,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -216,8 +212,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -298,8 +292,6 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         azure-container-registry-config: c:/k/azure.json
-        cloud-config: c:/k/azure.json
-        cloud-provider: azure
         feature-gates: WindowsHostProcessContainers=true
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -112,15 +112,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -229,8 +225,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -138,15 +138,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -242,8 +238,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -124,15 +124,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -239,8 +235,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
@@ -326,8 +320,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -112,15 +112,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -213,8 +209,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---
@@ -290,8 +284,6 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -165,15 +165,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -304,8 +300,6 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         azure-container-registry-config: /etc/kubernetes/azure.json
-        cloud-config: /etc/kubernetes/azure.json
-        cloud-provider: azure
       name: '{{ ds.meta_data["local_hostname"] }}'
   preKubeadmCommands:
   - bash -c /tmp/replace-k8s-binaries.sh
@@ -388,8 +382,6 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         azure-container-registry-config: c:/k/azure.json
-        cloud-config: c:/k/azure.json
-        cloud-provider: azure
         feature-gates: WindowsHostProcessContainers=true
         pod-infra-container-image: mcr.microsoft.com/oss/kubernetes/pause:3.4.1
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/dev/cluster-template-custom-builds-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-windows.yaml
@@ -176,15 +176,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -327,8 +323,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - mac=$(ip -o link | grep eth0 | grep ether | awk '{ print $17 }')
@@ -448,8 +442,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       postKubeadmCommands:
       - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -164,15 +164,11 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -301,8 +297,6 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
       - bash -c /tmp/replace-k8s-binaries.sh
@@ -379,8 +373,6 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
             feature-gates: WindowsHostProcessContainers=true
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

This PR removes the `cloud-provider` and `cloud-config` configurations from kubeadm config interfaces, as both of these are deprecated (and will be removed in 1.23). Reference:

https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
