### PR TITLE
Update nvidia GPU operator to v1.9.1

### DIFF
--- a/hack/fetch-nvidia-resources.sh
+++ b/hack/fetch-nvidia-resources.sh
@@ -24,7 +24,7 @@ gpudir=${root}/templates/flavors/nvidia-gpu
 workdir=${gpudir}/tmp
 namespace=gpu-operator-resources
 # See https://github.com/NVIDIA/gpu-operator/releases for available versions of the gpu-operator chart.
-gpu_operator_version=${1:-1.9.0}  
+gpu_operator_version=${1:-1.9.1}  
 
 helm repo add nvidia https://nvidia.github.io/gpu-operator \
     && helm repo update

--- a/templates/cluster-template-nvidia-gpu.yaml
+++ b/templates/cluster-template-nvidia-gpu.yaml
@@ -3975,8 +3975,9 @@ data:
     \ labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n    app.kubernetes.io/name:
     node-feature-discovery\n    app.kubernetes.io/instance: gpu-operator\n    app.kubernetes.io/version:
     \"v0.8.2\"\n    app.kubernetes.io/managed-by: Helm\ndata:\n  nfd-worker.conf:
-    |-\n    sources:\n      pci:\n        deviceLabelFields:\n        - vendor\n---\n#
-    Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml\napiVersion:
+    |-\n    sources:\n      pci:\n        deviceClassWhitelist:\n        - \"02\"\n
+    \       - \"0200\"\n        - \"0207\"\n        - \"0300\"\n        - \"0302\"\n
+    \       deviceLabelFields:\n        - vendor\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml\napiVersion:
     v1\nkind: Service\nmetadata:\n  name: gpu-operator-node-feature-discovery-master\n
     \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
     \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
@@ -4046,7 +4047,7 @@ data:
     11.4.2-base-ubi8\n      imagePullPolicy: IfNotPresent\n  daemonsets:\n    tolerations:
     \n      - effect: NoSchedule\n        key: nvidia.com/gpu\n        operator: Exists\n
     \   priorityClassName: system-node-critical\n  validator:\n    repository: nvcr.io/nvidia/cloud-native\n
-    \   image: gpu-operator-validator\n    version: v1.9.0\n    imagePullPolicy: IfNotPresent\n
+    \   image: gpu-operator-validator\n    version: v1.9.1\n    imagePullPolicy: IfNotPresent\n
     \   securityContext: \n      privileged: true\n      seLinuxOptions:\n        level:
     s0\n    plugin:\n      env: \n        - name: WITH_WORKLOAD\n          value:
     \"true\"\n  mig:\n    strategy: single\n  psp:\n    enabled: false\n  driver:\n
@@ -4071,10 +4072,10 @@ data:
     FAIL_ON_INIT_ERROR\n        value: \"true\"\n      - name: DEVICE_LIST_STRATEGY\n
     \       value: envvar\n      - name: DEVICE_ID_STRATEGY\n        value: uuid\n
     \     - name: NVIDIA_VISIBLE_DEVICES\n        value: all\n      - name: NVIDIA_DRIVER_CAPABILITIES\n
-    \       value: all\n  dcgm:\n    enabled: true\n    repository: nvcr.io/nvidia/cloud-native\n
+    \       value: all\n  dcgm:\n    enabled: false\n    repository: nvcr.io/nvidia/cloud-native\n
     \   image: dcgm\n    version: 2.3.1-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
     \   hostPort: 5555\n  dcgmExporter:\n    repository: nvcr.io/nvidia/k8s\n    image:
-    dcgm-exporter\n    version: 2.3.1-2.6.0-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
+    dcgm-exporter\n    version: 2.3.1-2.6.1-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
     \   env: \n      - name: DCGM_EXPORTER_LISTEN\n        value: :9400\n      - name:
     DCGM_EXPORTER_KUBERNETES\n        value: \"true\"\n      - name: DCGM_EXPORTER_COLLECTORS\n
     \       value: /etc/dcgm-exporter/dcp-metrics-included.csv\n  gfd:\n    repository:
@@ -4086,7 +4087,7 @@ data:
     \n      privileged: true\n    env: \n      - name: WITH_REBOOT\n        value:
     \"false\"\n    config: \n      name: \"\"\n    gpuClientsConfig: \n      name:
     \"\"\n  nodeStatusExporter:\n    enabled: false\n    repository: nvcr.io/nvidia/cloud-native\n
-    \   image: gpu-operator-validator\n    version: v1.9.0\n    imagePullPolicy: IfNotPresent\n---\n#
+    \   image: gpu-operator-validator\n    version: v1.9.1\n    imagePullPolicy: IfNotPresent\n---\n#
     Source: gpu-operator/templates/operator.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n
     \ name: gpu-operator\n  namespace: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
     \"gpu-operator\"\n    \nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n
@@ -4095,7 +4096,7 @@ data:
     \"gpu-operator\"\n        app: \"gpu-operator\"\n      annotations:\n        openshift.io/scc:
     restricted-readonly\n    spec:\n      serviceAccountName: gpu-operator\n      priorityClassName:
     system-node-critical\n      containers:\n      - name: gpu-operator\n        image:
-    nvcr.io/nvidia/gpu-operator:v1.9.0\n        imagePullPolicy: IfNotPresent\n        command:
+    nvcr.io/nvidia/gpu-operator:v1.9.1\n        imagePullPolicy: IfNotPresent\n        command:
     [\"gpu-operator\"]\n        args:\n        - --leader-elect\n        env:\n        -
     name: WATCH_NAMESPACE\n          value: \"\"\n        - name: OPERATOR_NAMESPACE\n
     \         valueFrom:\n            fieldRef:\n              fieldPath: metadata.namespace\n

--- a/templates/flavors/nvidia-gpu/gpu-operator-components.yaml
+++ b/templates/flavors/nvidia-gpu/gpu-operator-components.yaml
@@ -168,6 +168,12 @@ data:
   nfd-worker.conf: |-
     sources:
       pci:
+        deviceClassWhitelist:
+        - "02"
+        - "0200"
+        - "0207"
+        - "0300"
+        - "0302"
         deviceLabelFields:
         - vendor
 ---
@@ -363,7 +369,7 @@ spec:
   validator:
     repository: nvcr.io/nvidia/cloud-native
     image: gpu-operator-validator
-    version: v1.9.0
+    version: v1.9.1
     imagePullPolicy: IfNotPresent
     securityContext: 
       privileged: true
@@ -446,7 +452,7 @@ spec:
       - name: NVIDIA_DRIVER_CAPABILITIES
         value: all
   dcgm:
-    enabled: true
+    enabled: false
     repository: nvcr.io/nvidia/cloud-native
     image: dcgm
     version: 2.3.1-ubuntu20.04
@@ -455,7 +461,7 @@ spec:
   dcgmExporter:
     repository: nvcr.io/nvidia/k8s
     image: dcgm-exporter
-    version: 2.3.1-2.6.0-ubuntu20.04
+    version: 2.3.1-2.6.1-ubuntu20.04
     imagePullPolicy: IfNotPresent
     env: 
       - name: DCGM_EXPORTER_LISTEN
@@ -493,7 +499,7 @@ spec:
     enabled: false
     repository: nvcr.io/nvidia/cloud-native
     image: gpu-operator-validator
-    version: v1.9.0
+    version: v1.9.1
     imagePullPolicy: IfNotPresent
 ---
 # Source: gpu-operator/templates/operator.yaml
@@ -525,7 +531,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: gpu-operator
-        image: nvcr.io/nvidia/gpu-operator:v1.9.0
+        image: nvcr.io/nvidia/gpu-operator:v1.9.1
         imagePullPolicy: IfNotPresent
         command: ["gpu-operator"]
         args:

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -3980,8 +3980,9 @@ data:
     \ labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n    app.kubernetes.io/name:
     node-feature-discovery\n    app.kubernetes.io/instance: gpu-operator\n    app.kubernetes.io/version:
     \"v0.8.2\"\n    app.kubernetes.io/managed-by: Helm\ndata:\n  nfd-worker.conf:
-    |-\n    sources:\n      pci:\n        deviceLabelFields:\n        - vendor\n---\n#
-    Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml\napiVersion:
+    |-\n    sources:\n      pci:\n        deviceClassWhitelist:\n        - \"02\"\n
+    \       - \"0200\"\n        - \"0207\"\n        - \"0300\"\n        - \"0302\"\n
+    \       deviceLabelFields:\n        - vendor\n---\n# Source: gpu-operator/charts/node-feature-discovery/templates/service.yaml\napiVersion:
     v1\nkind: Service\nmetadata:\n  name: gpu-operator-node-feature-discovery-master\n
     \ namespace: gpu-operator-resources\n  labels:\n    helm.sh/chart: node-feature-discovery-0.8.2\n
     \   app.kubernetes.io/name: node-feature-discovery\n    app.kubernetes.io/instance:
@@ -4051,7 +4052,7 @@ data:
     11.4.2-base-ubi8\n      imagePullPolicy: IfNotPresent\n  daemonsets:\n    tolerations:
     \n      - effect: NoSchedule\n        key: nvidia.com/gpu\n        operator: Exists\n
     \   priorityClassName: system-node-critical\n  validator:\n    repository: nvcr.io/nvidia/cloud-native\n
-    \   image: gpu-operator-validator\n    version: v1.9.0\n    imagePullPolicy: IfNotPresent\n
+    \   image: gpu-operator-validator\n    version: v1.9.1\n    imagePullPolicy: IfNotPresent\n
     \   securityContext: \n      privileged: true\n      seLinuxOptions:\n        level:
     s0\n    plugin:\n      env: \n        - name: WITH_WORKLOAD\n          value:
     \"true\"\n  mig:\n    strategy: single\n  psp:\n    enabled: false\n  driver:\n
@@ -4076,10 +4077,10 @@ data:
     FAIL_ON_INIT_ERROR\n        value: \"true\"\n      - name: DEVICE_LIST_STRATEGY\n
     \       value: envvar\n      - name: DEVICE_ID_STRATEGY\n        value: uuid\n
     \     - name: NVIDIA_VISIBLE_DEVICES\n        value: all\n      - name: NVIDIA_DRIVER_CAPABILITIES\n
-    \       value: all\n  dcgm:\n    enabled: true\n    repository: nvcr.io/nvidia/cloud-native\n
+    \       value: all\n  dcgm:\n    enabled: false\n    repository: nvcr.io/nvidia/cloud-native\n
     \   image: dcgm\n    version: 2.3.1-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
     \   hostPort: 5555\n  dcgmExporter:\n    repository: nvcr.io/nvidia/k8s\n    image:
-    dcgm-exporter\n    version: 2.3.1-2.6.0-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
+    dcgm-exporter\n    version: 2.3.1-2.6.1-ubuntu20.04\n    imagePullPolicy: IfNotPresent\n
     \   env: \n      - name: DCGM_EXPORTER_LISTEN\n        value: :9400\n      - name:
     DCGM_EXPORTER_KUBERNETES\n        value: \"true\"\n      - name: DCGM_EXPORTER_COLLECTORS\n
     \       value: /etc/dcgm-exporter/dcp-metrics-included.csv\n  gfd:\n    repository:
@@ -4091,7 +4092,7 @@ data:
     \n      privileged: true\n    env: \n      - name: WITH_REBOOT\n        value:
     \"false\"\n    config: \n      name: \"\"\n    gpuClientsConfig: \n      name:
     \"\"\n  nodeStatusExporter:\n    enabled: false\n    repository: nvcr.io/nvidia/cloud-native\n
-    \   image: gpu-operator-validator\n    version: v1.9.0\n    imagePullPolicy: IfNotPresent\n---\n#
+    \   image: gpu-operator-validator\n    version: v1.9.1\n    imagePullPolicy: IfNotPresent\n---\n#
     Source: gpu-operator/templates/operator.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n
     \ name: gpu-operator\n  namespace: gpu-operator-resources\n  labels:\n    app.kubernetes.io/component:
     \"gpu-operator\"\n    \nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n
@@ -4100,7 +4101,7 @@ data:
     \"gpu-operator\"\n        app: \"gpu-operator\"\n      annotations:\n        openshift.io/scc:
     restricted-readonly\n    spec:\n      serviceAccountName: gpu-operator\n      priorityClassName:
     system-node-critical\n      containers:\n      - name: gpu-operator\n        image:
-    nvcr.io/nvidia/gpu-operator:v1.9.0\n        imagePullPolicy: IfNotPresent\n        command:
+    nvcr.io/nvidia/gpu-operator:v1.9.1\n        imagePullPolicy: IfNotPresent\n        command:
     [\"gpu-operator\"]\n        args:\n        - --leader-elect\n        env:\n        -
     name: WATCH_NAMESPACE\n          value: \"\"\n        - name: OPERATOR_NAMESPACE\n
     \         valueFrom:\n            fieldRef:\n              fieldPath: metadata.namespace\n


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

See https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/release-notes.html

Updates nvidia-gpu-operator to [v1.9.1](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/release-notes.html#id1). Not a major update, but it validates that the `./hack/fetch-nvidia-resources.sh` script is working.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
