### PR TITLE
Support passing custom headers to AKS Managed Cluster and Node Pool create/update requests

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -84,6 +84,14 @@ const (
 	ProviderIDPrefix = "azure://"
 )
 
+const (
+	// CustomHeaderPrefix is the prefix of annotations that enable additional cluster / node pool features.
+	// Whatever follows the prefix will be passed as a header to cluster/node pool creation/update requests.
+	// E.g. add `"infrastructure.cluster.x-k8s.io/custom-header-UseGPUDedicatedVHD": "true"` annotation to
+	// AzureManagedMachinePool CR to enable creating GPU nodes by the node pool.
+	CustomHeaderPrefix = "infrastructure.cluster.x-k8s.io/custom-header-"
+)
+
 var (
 	// LinuxBootstrapExtensionCommand is the command the VM bootstrap extension will execute to verify Linux nodes bootstrap completes successfully.
 	LinuxBootstrapExtensionCommand = fmt.Sprintf("for i in $(seq 1 %d); do test -f %s && break; if [ $i -eq %d ]; then return 1; else sleep %d; fi; done", bootstrapExtensionRetries, bootstrapSentinelFile, bootstrapExtensionRetries, bootstrapExtensionSleep)

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -391,6 +391,10 @@ func (s *ManagedControlPlaneScope) FailureDomains() []string {
 	return []string{}
 }
 
+func (s *ManagedControlPlaneScope) ManagedClusterAnnotations() map[string]string {
+	return s.ControlPlane.Annotations
+}
+
 // ManagedClusterSpec returns the managed cluster spec.
 func (s *ManagedControlPlaneScope) ManagedClusterSpec() (azure.ManagedClusterSpec, error) {
 	decodedSSHPublicKey, err := base64.StdEncoding.DecodeString(s.ControlPlane.Spec.SSHPublicKey)
@@ -555,6 +559,10 @@ func (s *ManagedControlPlaneScope) GetAllAgentPoolSpecs(ctx context.Context) ([]
 	}
 
 	return ammps, nil
+}
+
+func (s *ManagedControlPlaneScope) AgentPoolAnnotations() map[string]string {
+	return s.InfraMachinePool.Annotations
 }
 
 // AgentPoolSpec returns an azure.AgentPoolSpec for currently reconciled AzureManagedMachinePool.

--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -55,7 +55,7 @@ func TestReconcile(t *testing.T) {
 			expectedError:            "",
 			expect: func(m *mock_agentpools.MockClientMockRecorder, provisioningstate string) {
 				pv := provisioningstate
-				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agentpool", gomock.Any()).Return(nil)
+				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agentpool", gomock.Any(), gomock.Any()).Return(nil)
 				m.Get(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agentpool").Return(containerservice.AgentPool{ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 					ProvisioningState: &pv,
 				}}, nil)
@@ -144,7 +144,7 @@ func TestReconcile(t *testing.T) {
 			},
 			expectedError: "",
 			expect: func(m *mock_agentpools.MockClientMockRecorder) {
-				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agentpool", gomock.Any()).Return(nil)
+				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agentpool", gomock.Any(), gomock.Any()).Return(nil)
 				m.Get(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agentpool").Return(containerservice.AgentPool{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not Found"))
 			},
 		},
@@ -182,7 +182,7 @@ func TestReconcile(t *testing.T) {
 			expectedError: "",
 			expect: func(m *mock_agentpools.MockClientMockRecorder) {
 				m.Get(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agent-pool").Return(containerservice.AgentPool{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
-				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agent-pool", gomock.AssignableToTypeOf(containerservice.AgentPool{})).Return(nil)
+				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agent-pool", gomock.AssignableToTypeOf(containerservice.AgentPool{}), gomock.Any()).Return(nil)
 			},
 		},
 		{
@@ -201,7 +201,7 @@ func TestReconcile(t *testing.T) {
 			expectedError: "failed to create or update agent pool: #: Internal Server Error: StatusCode=500",
 			expect: func(m *mock_agentpools.MockClientMockRecorder) {
 				m.Get(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agent-pool").Return(containerservice.AgentPool{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
-				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agent-pool", gomock.AssignableToTypeOf(containerservice.AgentPool{})).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
+				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agent-pool", gomock.AssignableToTypeOf(containerservice.AgentPool{}), gomock.Any()).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 			},
 		},
 		{
@@ -228,7 +228,7 @@ func TestReconcile(t *testing.T) {
 						ProvisioningState:   to.StringPtr("Failed"),
 					},
 				}, nil)
-				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agent-pool", gomock.AssignableToTypeOf(containerservice.AgentPool{})).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
+				m.CreateOrUpdate(gomockinternal.AContext(), "my-rg", "my-cluster", "my-agent-pool", gomock.AssignableToTypeOf(containerservice.AgentPool{}), gomock.Any()).Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Server Error"))
 			},
 		},
 		{

--- a/azure/services/agentpools/mock_agentpools/agentpools_mock.go
+++ b/azure/services/agentpools/mock_agentpools/agentpools_mock.go
@@ -52,17 +52,17 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CreateOrUpdate mocks base method.
-func (m *MockClient) CreateOrUpdate(arg0 context.Context, arg1, arg2, arg3 string, arg4 containerservice.AgentPool) error {
+func (m *MockClient) CreateOrUpdate(arg0 context.Context, arg1, arg2, arg3 string, arg4 containerservice.AgentPool, arg5 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateOrUpdate indicates an expected call of CreateOrUpdate.
-func (mr *MockClientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockClient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockClient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Delete mocks base method.

--- a/azure/services/managedclusters/mock_managedclusters/client_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/client_mock.go
@@ -52,18 +52,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CreateOrUpdate mocks base method.
-func (m *MockClient) CreateOrUpdate(arg0 context.Context, arg1, arg2 string, arg3 containerservice.ManagedCluster) (containerservice.ManagedCluster, error) {
+func (m *MockClient) CreateOrUpdate(arg0 context.Context, arg1, arg2 string, arg3 containerservice.ManagedCluster, arg4 map[string]string) (containerservice.ManagedCluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(containerservice.ManagedCluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateOrUpdate indicates an expected call of CreateOrUpdate.
-func (mr *MockClientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockClient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockClient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Delete mocks base method.

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -266,6 +266,20 @@ func (mr *MockManagedClusterScopeMockRecorder) MakeEmptyKubeConfigSecret() *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeEmptyKubeConfigSecret", reflect.TypeOf((*MockManagedClusterScope)(nil).MakeEmptyKubeConfigSecret))
 }
 
+// ManagedClusterAnnotations mocks base method.
+func (m *MockManagedClusterScope) ManagedClusterAnnotations() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagedClusterAnnotations")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// ManagedClusterAnnotations indicates an expected call of ManagedClusterAnnotations.
+func (mr *MockManagedClusterScopeMockRecorder) ManagedClusterAnnotations() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagedClusterAnnotations", reflect.TypeOf((*MockManagedClusterScope)(nil).ManagedClusterAnnotations))
+}
+
 // ManagedClusterSpec mocks base method.
 func (m *MockManagedClusterScope) ManagedClusterSpec() (azure.ManagedClusterSpec, error) {
 	m.ctrl.T.Helper()

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -257,6 +257,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcluster
+  failurePolicy: Fail
+  name: validation.azuremanagedclusters.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - UPDATE
+    resources:
+    - azuremanagedclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcontrolplane
   failurePolicy: Fail
   name: validation.azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io

--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -338,6 +338,26 @@ spec:
       value: kafka
 ```
 
+### Enable AKS features with custom headers (--aks-custom-headers)
+To enable some AKS cluster / node pool features you need to pass special headers to the cluster / node pool create request. 
+For example, to [add a node pool for GPU nodes](https://docs.microsoft.com/en-us/azure/aks/gpu-cluster#add-a-node-pool-for-gpu-nodes),
+you need to pass a custom header `UseGPUDedicatedVHD=true` (with `--aks-custom-headers UseGPUDedicatedVHD=true` argument). 
+To do this with CAPZ, you need to add special annotations to AzureManagedCluster (for cluster 
+features) or AzureManagedMachinePool (for node pool features). These annotations should have a prefix `infrastructure.cluster.x-k8s.io/custom-header-` followed 
+by the name of the AKS feature. For example, to create a node pool with GPU support, you would add the following 
+annotation to AzureManagedMachinePool:
+```
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedMachinePool
+metadata:
+  ...
+  annotations:
+    "infrastructure.cluster.x-k8s.io/custom-header-UseGPUDedicatedVHD": "true"
+  ...
+spec:
+  ...
+```
+
 ### Use a public Standard Load Balancer
 
 A public Load Balancer when integrated with AKS serves two purposes:

--- a/exp/api/v1beta1/azuremanagedcluster_webhook.go
+++ b/exp/api/v1beta1/azuremanagedcluster_webhook.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"fmt"
+	"reflect"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/util/maps"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// SetupWebhookWithManager sets up and registers the webhook with the manager.
+func (r *AzureManagedCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcluster,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=azuremanagedclusters,versions=v1beta1,name=validation.azuremanagedclusters.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+var _ webhook.Validator = &AzureManagedCluster{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedCluster) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedCluster) ValidateUpdate(oldRaw runtime.Object) error {
+	old := oldRaw.(*AzureManagedCluster)
+	var allErrs field.ErrorList
+
+	// custom headers are immutable
+	oldCustomHeaders := maps.FilterByKeyPrefix(old.ObjectMeta.Annotations, azure.CustomHeaderPrefix)
+	newCustomHeaders := maps.FilterByKeyPrefix(r.ObjectMeta.Annotations, azure.CustomHeaderPrefix)
+	if !reflect.DeepEqual(oldCustomHeaders, newCustomHeaders) {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("metadata", "annotations"),
+				r.ObjectMeta.Annotations,
+				fmt.Sprintf("annotations with '%s' prefix are immutable", azure.CustomHeaderPrefix)))
+	}
+
+	if len(allErrs) != 0 {
+		return apierrors.NewInvalid(GroupVersion.WithKind("AzureManagedCluster").GroupKind(), r.Name, allErrs)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedCluster) ValidateDelete() error {
+	return nil
+}

--- a/exp/api/v1beta1/azuremanagedcluster_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedcluster_webhook_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAzureManagedCluster_ValidateUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name    string
+		oldAMC  *AzureManagedCluster
+		amc     *AzureManagedCluster
+		wantErr bool
+	}{
+		{
+			name: "custom header annotation values are immutable",
+			oldAMC: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+					},
+				},
+				Spec: AzureManagedClusterSpec{},
+			},
+			amc: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "false",
+					},
+				},
+				Spec: AzureManagedClusterSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "custom header annotations cannot be removed after resource creation",
+			oldAMC: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+					},
+				},
+				Spec: AzureManagedClusterSpec{},
+			},
+			amc: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: AzureManagedClusterSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "custom header annotations cannot be added after resource creation",
+			oldAMC: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+					},
+				},
+				Spec: AzureManagedClusterSpec{},
+			},
+			amc: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature":    "true",
+						"infrastructure.cluster.x-k8s.io/custom-header-AnotherFeature": "true",
+					},
+				},
+				Spec: AzureManagedClusterSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-custom header annotations are mutable",
+			oldAMC: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"annotation-a": "true",
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+					},
+				},
+				Spec: AzureManagedClusterSpec{},
+			},
+			amc: &AzureManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+						"annotation-b": "true",
+					},
+				},
+				Spec: AzureManagedClusterSpec{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.amc.ValidateUpdate(tc.oldAMC)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}

--- a/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -255,6 +255,87 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "custom header annotation values are immutable",
+			old: &AzureManagedMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+					},
+				},
+				Spec: AzureManagedMachinePoolSpec{},
+			},
+			new: &AzureManagedMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "false",
+					},
+				},
+				Spec: AzureManagedMachinePoolSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "cannot remove custom header annotation after resource creation",
+			old: &AzureManagedMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+					},
+				},
+				Spec: AzureManagedMachinePoolSpec{},
+			},
+			new: &AzureManagedMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: AzureManagedMachinePoolSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "cannot add new custom header annotations after resource creation",
+			old: &AzureManagedMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+					},
+				},
+				Spec: AzureManagedMachinePoolSpec{},
+			},
+			new: &AzureManagedMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature":    "true",
+						"infrastructure.cluster.x-k8s.io/custom-header-AnotherFeature": "true",
+					},
+				},
+				Spec: AzureManagedMachinePoolSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-custom headers annotations are mutable",
+			old: &AzureManagedMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"annotation-a": "true",
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+					},
+				},
+				Spec: AzureManagedMachinePoolSpec{},
+			},
+			new: &AzureManagedMachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"infrastructure.cluster.x-k8s.io/custom-header-SomeFeature": "true",
+						"annotation-b": "true",
+					},
+				},
+				Spec: AzureManagedMachinePoolSpec{},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Unchanged OSDiskType in an agentpool should not result in an error",
 			new: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{

--- a/main.go
+++ b/main.go
@@ -505,6 +505,13 @@ func registerWebhooks(mgr manager.Manager) {
 	}
 
 	if feature.Gates.Enabled(feature.AKS) {
+		if err := (&infrav1beta1exp.AzureManagedCluster{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedCluster")
+			os.Exit(1)
+		}
+	}
+
+	if feature.Gates.Enabled(feature.AKS) {
 		if err := (&infrav1beta1exp.AzureManagedControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedControlPlane")
 			os.Exit(1)

--- a/util/maps/maps.go
+++ b/util/maps/maps.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maps
+
+import (
+	"strings"
+)
+
+// FilterByKeyPrefix returns a sub-map of the input that only contains keys starting with 'prefix'.
+func FilterByKeyPrefix(input map[string]string, prefix string) map[string]string {
+	var result = map[string]string{}
+	for key, value := range input {
+		if strings.HasPrefix(key, prefix) {
+			remainingKey := strings.TrimPrefix(key, prefix)
+			if len(remainingKey) > 0 {
+				result[remainingKey] = value
+			}
+		}
+	}
+	return result
+}

--- a/util/maps/maps_test.go
+++ b/util/maps/maps_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maps
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestFilterByKeyPrefix(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Input    map[string]string
+		Prefix   string
+		Expected map[string]string
+	}{
+		{
+			Name: "TestMixed",
+			Input: map[string]string{
+				"prefix-key1": "value1",
+				"prefix-key2": "value2",
+				"PrEfIx-key3": "value3",
+				"prefix-":     "value4",
+				"":            "value5",
+				"foobar":      "value6",
+				"prefix-key4": "",
+			},
+			Prefix: "prefix-",
+			Expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key4": "",
+			},
+		},
+		{
+			Name:     "WithEmptyInput",
+			Input:    map[string]string{},
+			Prefix:   "prefix-",
+			Expected: map[string]string{},
+		},
+		{
+			Name:     "WithNilInput",
+			Input:    nil,
+			Prefix:   "prefix-",
+			Expected: map[string]string{},
+		},
+		{
+			Name: "WithEmptyPrefix",
+			Input: map[string]string{
+				"prefix-key1": "value1",
+			},
+			Prefix: "",
+			Expected: map[string]string{
+				"prefix-key1": "value1",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			g.Expect(FilterByKeyPrefix(c.Input, c.Prefix)).To(gomega.Equal(c.Expected))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
To use some AKS features one needs to pass custom headers when creating/updating a resource. One example is when you want to use a [GPU node pool](https://docs.microsoft.com/en-us/azure/aks/gpu-cluster), you need to register `GPUDedicatedVHDPreview` feature and pass a custom header to node pool creation request:
```
az aks nodepool add \
   ...
   --aks-custom-headers UseGPUDedicatedVHD=true \
   ...
```
This PR adds a mechanism where you can pass custom headers to cluster and node pool create/update requests by using annotations prefixed with `custom-headers.azure.dev/`. E.g. to create mentioned GPU node pool one would set `"custom-headers.azure.dev/UseGPUDedicatedVHD": true` annotation on `AzureManagedMachinePool`.

**Which issue(s) this PR fixes**:
fixes #1981, fixes #1979

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support passing custom headers to cluster and node pool create/update requests to enable additional features
```
